### PR TITLE
adding fix for production staticfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,7 +182,6 @@ crashlytics-build.properties
 fabric.properties
 
 # impact-api
-web/impact/static-compiled/*
 local_settings.py
 mysql/data/
 web/impact/.coverage

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
       - ./web/impact/media:/media:ro
-      - ./web/impact/static:/static:ro
+      - ./web/impact/static-compiled:/static:ro
     links:
       - web
     environment:

--- a/nginx.Dockerfile
+++ b/nginx.Dockerfile
@@ -1,4 +1,4 @@
 FROM nginx
 COPY nginx/nginx.conf /etc/nginx/nginx.conf
-COPY web/impact/static /static
+ADD web/impact/static-compiled /static
 CMD nginx -g 'daemon off;'

--- a/nginx.Dockerfile
+++ b/nginx.Dockerfile
@@ -1,4 +1,4 @@
 FROM nginx
 COPY nginx/nginx.conf /etc/nginx/nginx.conf
-ADD web/impact/static-compiled /static
+COPY web/impact/static /static
 CMD nginx -g 'daemon off;'

--- a/web/impact/static-compiled/.gitignore
+++ b/web/impact/static-compiled/.gitignore
@@ -1,0 +1,7 @@
+admin/
+css/
+debug_toolbar/
+img/
+js/
+rest_framework/
+rest_framework_swagger/


### PR DESCRIPTION
This requires some hackiness to test locally due to issues in using elb to host the production site and how redirects work in nginx.

to test the case where it does not work:

- checkout the latest development branch.

-  first remove this line from nginx/nginx.conf:

```
if ($http_x_forwarded_proto != 'https') {
                rewrite ^ https://$server_name$request_uri?;
} 
```

- then rebuild just the nginx container via ```docker-compose build nginx``` 

- run `make build; make dev`

- In a separate window, run make dbload```make dbload GZ_FILE=<path to initial_schema.sql.gz>```

- go directly to http://localhost:80/ (note its port 80)

- login as demoadmin@masschallenge.org/password

- open up the chrome web inspector and go to the resources tab and note that a lot of resources fail to load.

<img width="1382" alt="screen shot 2017-06-22 at 3 18 48 pm" src="https://user-images.githubusercontent.com/196425/27451903-ae2a99bc-575e-11e7-8a0c-249b901f6561.png">


to test the fix:
- repeat the above process on this branch and verify that static resources load properly.
