### PR TITLE
[AC-4435] Add Headers To Address XSS Vulnerability

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -45,6 +45,13 @@ http {
         server_name api.masschallenge.org
           *.elb.amazonaws.com;
 
+        ##
+        # XSS Protection
+        ##
+        add_header X-Content-Type-Options nosniff;
+        add_header X-XSS-Protection "1; mode=block";
+        add_header Content-Security-Policy "default-src https: data: 'unsafe-inline' 'unsafe-eval'" always;
+
         location /static/ {
             sendfile off;
             alias /static/;


### PR DESCRIPTION
**Setup**
If you do not already have OWASP ZAP installed, download it [here](https://www.owasp.org/index.php/OWASP_Zed_Attack_Proxy_Project).  You will likely need to [upgrade](https://www.java.com/en/download/mac_download.jsp) to Java 8.

**Without added security**
On development:

- Follow the testing instructions from PR [AC-4512](https://github.com/masschallenge/impact-api/pull/1) up to the `make dbload` command.
  - You can ignore the login and Chrome Developer Tools instructions.
- Launch OWASP ZAP. (You can select any persistence option you want.)
- Enter `http://localhost:80` in the "URL to attack" location bar.
- Attack!
  - It should take about 8-10 minutes to run.
- Check the alerts.
  - You can check the alerts in the bottom left corner, or you can create a report from the menu bar.
- You should see the "X-Content-Type-Options Header Missing" warning.
- You should also see that "Web Browser XSS Protection Not Enabled" is present on the following URLs (GETs):
  - http:/localhost/
  - http:/localhost/accounts/login/
  - http:/localhost:80/
 
- You can ignore these URLs:
  - http://localhost/robots.txt
  - http://localhost/sitemap.xml
  - http:/localhost/accounts/login/ (POST) 

**With added security**
On branch AC-4435:

- Follow the testing instructions from PR [AC-4512](https://github.com/masschallenge/impact-api/pull/1) up to the `make dbload` command.
  - You can ignore the login and Chrome Developer Tools instructions.
- Launch OWASP ZAP. (You can select any persistence option you want.)
- Enter `http://localhost:80` in the "URL to attack" location bar.
- Attack!
  - It should take about 8-10 minutes to run.
- Check the alerts.
  - You can check the alerts in the bottom left corner, or you can create a report from the menu bar.
- The "X-Content-Type-Options Header Missing" warning is gone.
- The "Web Browser XSS Protection Not Enabled" is still present, but only on the following URLs:
  - http://localhost/robots.txt
  - http://localhost/sitemap.xml
  - http:/localhost/accounts/login/ (POST) 