### PR TITLE
AC-4501: Add v1 API to support RESTful user calls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ targets = \
   comp-message \
   coverage \
   coverage-html \
+  dbdump \
   dbload \
   dbshell \
   deploy \
@@ -38,6 +39,7 @@ target_help = \
   "comp-message - Compiles .po files and makes them available to Django." \
   "coverage - Run coverage and generate text report." \
   "coverage-html - Run coverage and generate HTML report." \
+  "dbdump - Create a gzipped database dump as dump.sql.gz in local directory." \
   "dbload - Load gzipped database file. GZ_FILE must be defined." \
   "dbshell - Access to running MySQL." \
   "dev - Start all containers needed to run a webserver." \
@@ -154,6 +156,10 @@ lint:
 
 messages:
 	@docker-compose exec web python manage.py makemessages -a
+
+dbdump:
+	@docker-compose run --rm web /usr/bin/mysqldump -h mysql -u root -proot mc_dev | gzip > dump.sql.gz
+	@echo Created dump.sql.gz
 
 dbload:
 ifndef GZ_FILE

--- a/web/impact/impact/management/commands/grant_permissions.py
+++ b/web/impact/impact/management/commands/grant_permissions.py
@@ -7,7 +7,6 @@ from django.contrib.auth.models import Permission, Group
 from django.contrib.contenttypes.models import ContentType
 from django.core.management.base import BaseCommand
 from django.contrib.auth import get_user_model
-from django.conf import settings
 
 
 class Command(BaseCommand):

--- a/web/impact/impact/management/commands/grant_permissions.py
+++ b/web/impact/impact/management/commands/grant_permissions.py
@@ -1,22 +1,6 @@
+# -*- coding: utf-8 -*-
 # MIT License
 # Copyright (c) 2017 MassChallenge, Inc.
-
-
-# -*- coding: utf-8 -*-
-
-"""Add permissions for proxy model.
-
-This is needed because of the bug https://code.djangoproject.com/ticket/11154
-in Django (as of 1.6, it's not fixed).
-
-When a permission is created for a proxy model, it actually creates if for it's
-base model app_label (eg: for "article" instead of "about", for the About proxy
-model).
-
-What we need, however, is that the permission be created for the proxy model
-itself, in order to have the proper entries displayed in the admin.
-
-"""
 
 from __future__ import unicode_literals, absolute_import, division
 from django.contrib.auth.models import Permission, Group
@@ -30,32 +14,42 @@ class Command(BaseCommand):
     help = "Grant permissions for api objects."
 
     def add_arguments(self, parser):
-        parser.add_argument('user_email', nargs='?', type=str)
-        parser.add_argument('permission_names', nargs='?', type=str)
+        parser.add_argument("user_email", nargs="?", type=str)
+        parser.add_argument("permission_names", nargs="?", type=str)
 
     def handle(self, *args, **options):
-        permission_names = options.get('permission_names', "").split(',')
-        user_email = options.get('user_email')
+        permission_names = options.get("permission_names", "").split(",")
+        user_email = options.get("user_email")
         User = get_user_model()
         user = User.objects.get(email=user_email)
         for permission_name in permission_names:
-            if permission_name == "v0_api":
-                self.grant_v0_perms(user)
+            perm, model = permission_name.split("_")
+            content_type = ContentType.objects.filter(model=model).first()
+            if content_type:
+                grant_model_permission(permission_name, content_type, user)
             else:
-                perm, model = permission_name.split('_')
-                content_type = ContentType.objects.get(model=model)
-                permission, _ = Permission.objects.get_or_create(
-                    codename=permission_name,
-                    content_type=content_type)
-                user.user_permissions.add(permission)
-                print(
-                    "granting permission %s to %s" % (
-                        permission_name, user.email))
+                grant_group_permission(permission_name, user)
         user.save()
 
-    def grant_v0_perms(self, user):
-        group, created = Group.objects.get_or_create(
-            name=settings.V0_API_GROUP)
-        user.groups.add(group)
-        print(
-            "granting permission to the v0 api to %s" % user.email)
+
+def grant_model_permission(permission_name, content_type, user):
+    permission, _ = Permission.objects.get_or_create(
+        codename=permission_name,
+        content_type=content_type)
+    user.user_permissions.add(permission)
+    print("granting model permission {name} to {email}".format(
+            name=permission_name,
+            email=user.email))
+
+
+def grant_group_permission(group_name, user):
+    group = Group.objects.filter(name=group_name).first()
+    if not group:
+        response = input("Create group name {}? ".format(group_name))
+        if response.lower() not in ["y", "yes"]:
+            print("Ignoring requested permissions: {}".format(group_name))
+            return
+        group = Group.objects.create(name=group_name)
+    user.groups.add(group)
+    print("granting {email} add to group {group}".format(email=user.email,
+                                                         group=group_name))

--- a/web/impact/impact/models/reference.py
+++ b/web/impact/impact/models/reference.py
@@ -30,7 +30,7 @@ class Reference(MCModel):
     question_1_rating = models.IntegerField(null=True)
     question_2_rating = models.IntegerField(null=True)
     comments = models.TextField(blank=True)
-    user = models.ForeignKey(User, null=True)
+    requesting_user = models.ForeignKey(User, null=True)
 
     class Meta(MCModel.Meta):
         db_table = "mc_reference"

--- a/web/impact/impact/permissions.py
+++ b/web/impact/impact/permissions.py
@@ -94,18 +94,14 @@ class DynamicModelPermissions(BasePermission):
         try:
             boolean_value = literal_eval(text_value.title())
         except:  # pragma: no cover
-            # Regarding coverage, it's not clear that we need this code
-            # any more.  See has_object_permissions.
-            # not a bool? unequivocably reject permission
+            # Regarding coverage, see AC-4573
             raise PermissionDenied  # pragma: no cover
         return boolean_value
 
     def has_object_permission(self, request, view, obj):
         model_name = view.kwargs.get('model', "").lower()
         app_label = 'mc'
-        # This needs to be revised but is outside the scope of AC-4501.
-        # Field level permissions are no longer expected to be handled
-        # through the low level API.
+        # This needs to be revised.  See AC-4573
         for permission in self.get_field_level_perms(app_label, model_name):
             action, perm_model, field, boolean_str = (
                 self.decompose_perm(permission.codename))

--- a/web/impact/impact/permissions.py
+++ b/web/impact/impact/permissions.py
@@ -24,6 +24,15 @@ class V0APIPermissions(BasePermission):
             name=settings.V0_API_GROUP).exists()
 
 
+class V1APIPermissions(BasePermission):
+
+    authenticated_users_only = True
+
+    def has_permission(self, request, view):
+        return request.user.groups.filter(
+            name=settings.V1_API_GROUP).exists()
+
+
 class DynamicModelPermissions(BasePermission):
     perms_map = {
         'GET': ['%(app)s.view_%(model_name)s'],

--- a/web/impact/impact/permissions.py
+++ b/web/impact/impact/permissions.py
@@ -47,11 +47,6 @@ class DynamicModelPermissions(BasePermission):
     authenticated_users_only = True
 
     def has_permission(self, request, view):
-        # Workaround to ensure DjangoModelPermissions are not applied
-        # to the root view when using DefaultRouter.
-        if getattr(view, '_ignore_model_permissions', False):
-            return True
-
         model_name = view.kwargs.get('model', "").lower()
         app_label = 'mc'
         kwargs = {'app': app_label, 'model_name': model_name}

--- a/web/impact/impact/permissions.py
+++ b/web/impact/impact/permissions.py
@@ -93,14 +93,19 @@ class DynamicModelPermissions(BasePermission):
     def convert_string_to_bool(self, text_value):
         try:
             boolean_value = literal_eval(text_value.title())
-        except:
+        except:  # pragma: no cover
+            # Regarding coverage, it's not clear that we need this code
+            # any more.  See has_object_permissions.
             # not a bool? unequivocably reject permission
-            raise PermissionDenied
+            raise PermissionDenied  # pragma: no cover
         return boolean_value
 
     def has_object_permission(self, request, view, obj):
         model_name = view.kwargs.get('model', "").lower()
         app_label = 'mc'
+        # This needs to be revised but is outside the scope of AC-4501.
+        # Field level permissions are no longer expected to be handled
+        # through the low level API.
         for permission in self.get_field_level_perms(app_label, model_name):
             action, perm_model, field, boolean_str = (
                 self.decompose_perm(permission.codename))
@@ -111,7 +116,7 @@ class DynamicModelPermissions(BasePermission):
                         '{}.{}'.format(app_label, permission.codename))
                     if getattr(obj, field, None) is boolean_value:
                         if not get_user(request).has_perm(permission_code):
-                            return False
+                            return False  # pragma: no cover
                     # some other value is in place,
                     # so we don't require permissions
         return True

--- a/web/impact/impact/settings.py
+++ b/web/impact/impact/settings.py
@@ -138,8 +138,14 @@ class Base(Configuration):
     V0_SITE_NAME = bytes(os.environ.get(
         'IMPACT_API_V0_SITE_NAME', 'masschallenge.org'), 'utf-8')
 
+    # This seems too complicated.  Why would we want to
+    # override the name of an API group using environment
+    # variables?  Shouldn't this name just be a constant?
     V0_API_GROUP = bytes(os.environ.get(
         'IMPACT_API_V0_API_GROUP', 'v0_clients'), 'utf-8')
+
+    V1_API_GROUP = bytes(os.environ.get(
+        'IMPACT_API_V1_API_GROUP', 'v1_clients'), 'utf-8')
 
     OAUTH2_PROVIDER = {
         # this is the list of available scopes

--- a/web/impact/impact/settings.py
+++ b/web/impact/impact/settings.py
@@ -138,12 +138,10 @@ class Base(Configuration):
     V0_SITE_NAME = bytes(os.environ.get(
         'IMPACT_API_V0_SITE_NAME', 'masschallenge.org'), 'utf-8')
 
-    # This seems too complicated.  Why would we want to
-    # override the name of an API group using environment
-    # variables?  Shouldn't this name just be a constant?
     V0_API_GROUP = bytes(os.environ.get(
         'IMPACT_API_V0_API_GROUP', 'v0_clients'), 'utf-8')
 
+    # This and the above should get generalized.  See AC-4574.
     V1_API_GROUP = bytes(os.environ.get(
         'IMPACT_API_V1_API_GROUP', 'v1_clients'), 'utf-8')
 

--- a/web/impact/impact/tests/api_test_case.py
+++ b/web/impact/impact/tests/api_test_case.py
@@ -11,9 +11,10 @@ from django.conf import settings
 from impact.tests.factories import UserFactory
 
 OAuth_App = get_application_model()
+API_GROUPS = [settings.V0_API_GROUP, settings.V1_API_GROUP]
 
 
-class APIV0TestCase(TestCase):
+class APITestCase(TestCase):
     SOME_SITE_NAME = "somesite.com"
 
     client_class = APIClient
@@ -21,20 +22,17 @@ class APIV0TestCase(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        Group.objects.get_or_create(
-            name=settings.V0_API_GROUP)
+        [Group.objects.get_or_create(name=name) for name in API_GROUPS]
 
     @classmethod
     def tearDownClass(cls):
-        Group.objects.get(
-            name=settings.V0_API_GROUP).delete()
+        [Group.objects.get(name=name).delete() for name in API_GROUPS]
 
     def basic_user(self):
         user = self.make_user('basic_user@test.com',
                               perms=["mc.view_startup"])
-        v0_group = Group.objects.get(
-            name=settings.V0_API_GROUP)
-        user.groups.add(v0_group)
+        [user.groups.add(group)
+         for group in Group.objects.filter(name__in=API_GROUPS)]
         user.set_password('password')
         user.save()
         return user

--- a/web/impact/impact/tests/factories/reference_factory.py
+++ b/web/impact/impact/tests/factories/reference_factory.py
@@ -37,4 +37,4 @@ class ReferenceFactory(DjangoModelFactory):
     question_1_rating = Iterator([1, 2, 3, 4])
     question_2_rating = Iterator([1, 2, 3, 4, 5])
     comments = "This is the best startup ever."
-    user = SubFactory(EntrepreneurFactory)
+    requesting_user = SubFactory(EntrepreneurFactory)

--- a/web/impact/impact/tests/test_api_routes.py
+++ b/web/impact/impact/tests/test_api_routes.py
@@ -41,26 +41,6 @@ class TestApiRoute(TestCase):
                 'startupteammember',
                 'programrole']).delete()
 
-    @unittest.skip(
-        "this test will need to be revived"
-        "once we have the ability"
-        "to control permissions in the"
-        "api root view (/api/impact/)")
-    def test_model_root_get(self):
-        basic_user = self.make_user('basic_user@test.com')
-        with self.login(basic_user):
-            response = self.get("api-root")
-            self.response_200(response)
-            response_dict = json.loads(response.content)
-            self.assertNotIn("PanelTime", response_dict.keys())
-
-        perm_user = self.make_user('perm_user@test.com', perms=["django.*"])
-        with self.login(perm_user):
-            response = self.get("api-root")
-            self.response_200(response)
-            response_dict = json.loads(response.content)
-            self.assertIn("PanelTime", response_dict.keys())
-
     def test_api_object_list(self):
         StartupFactory(is_visible=1, url_slug="test1")
         StartupFactory(is_visible=1, url_slug="test2")
@@ -394,21 +374,3 @@ class TestApiRoute(TestCase):
             response_dict = json.loads(response.content)
             self.assertIn("is_visible", response_dict.keys())
             self.assertEqual(response_dict["is_visible"], True)
-
-    @unittest.skip(
-        "this test will need to be revived"
-    )
-    def test_schema(self):
-
-        User = get_user_model()
-        user = User.objects.create_superuser("admin@test.com", "password")
-        perm = PermissionFactory.create(codename='change_user')
-        user.user_permissions.add(perm)
-        with self.login(username="admin@test.com"):
-            view_kwargs = {}
-            response = self.get("schema", **view_kwargs)
-            self.response_200(response)
-            response_dict = json.loads(response.content)
-            self.assertEqual(
-                set(["info", "paths", "swagger", "securityDefinitions"]),
-                set(response_dict.keys()))

--- a/web/impact/impact/tests/test_api_routes.py
+++ b/web/impact/impact/tests/test_api_routes.py
@@ -2,9 +2,7 @@
 # Copyright (c) 2017 MassChallenge, Inc.
 
 import json
-import unittest
 from impact.models import ProgramRole
-from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
 from rest_framework.test import APIClient

--- a/web/impact/impact/tests/test_image_proxy_view.py
+++ b/web/impact/impact/tests/test_image_proxy_view.py
@@ -6,12 +6,12 @@ from django.http import HttpResponse
 from django.conf import settings
 
 from django.contrib.auth.models import Group
-from impact.tests.api_v0_test_case import APIV0TestCase
+from impact.tests.api_test_case import APITestCase
 from impact.tests.utils import match_errors
 from impact.v0.views import ImageProxyView
 
 
-class TestImageProxyView(APIV0TestCase):
+class TestImageProxyView(APITestCase):
     def test_proxy_images_view(self):
         basic_user = self.make_user(
             'basic_user@test.com', perms=["mc.view_startup"])

--- a/web/impact/impact/tests/test_job_posting_detail_view.py
+++ b/web/impact/impact/tests/test_job_posting_detail_view.py
@@ -2,14 +2,14 @@
 # Copyright (c) 2017 MassChallenge, Inc.
 
 from django.urls import reverse
-from impact.tests.api_v0_test_case import APIV0TestCase
+from impact.tests.api_test_case import APITestCase
 from impact.tests.factories import (
     JobPostingFactory,
     StartupStatusFactory,
 )
 
 
-class TestJobPostingDetailView(APIV0TestCase):
+class TestJobPostingDetailView(APITestCase):
 
     def test_request_with_no_jobkey(self):
         with self.login(username=self.basic_user().username):

--- a/web/impact/impact/tests/test_job_posting_list_view.py
+++ b/web/impact/impact/tests/test_job_posting_list_view.py
@@ -9,7 +9,7 @@ from datetime import (
 import json
 from django.urls import reverse
 
-from impact.tests.api_v0_test_case import APIV0TestCase
+from impact.tests.api_test_case import APITestCase
 from impact.models import (
     JobPosting,
     Site,
@@ -26,7 +26,7 @@ from impact.tests.factories import (
 )
 
 
-class TestJobPostingListView(APIV0TestCase):
+class TestJobPostingListView(APITestCase):
 
     def setUp(self):
         # Many objects must be created to scaffold this thing

--- a/web/impact/impact/tests/test_mentors_proxy_view.py
+++ b/web/impact/impact/tests/test_mentors_proxy_view.py
@@ -7,12 +7,12 @@ from django.http import HttpResponse
 from django.conf import settings
 
 from django.contrib.auth.models import Group
-from impact.tests.api_v0_test_case import APIV0TestCase
+from impact.tests.api_test_case import APITestCase
 from impact.tests.utils import match_errors
 from impact.v0.views import MentorsProxyView
 
 
-class TestMentorsProxyView(APIV0TestCase):
+class TestMentorsProxyView(APITestCase):
     SOME_SECURITY_KEY = "Some Secret Security Key"
 
     def test_proxy_mentors_view(self):

--- a/web/impact/impact/tests/test_reference.py
+++ b/web/impact/impact/tests/test_reference.py
@@ -1,0 +1,14 @@
+# MIT License
+# Copyright (c) 2017 MassChallenge, Inc.
+
+from test_plus.test import TestCase
+from impact.tests.factories import ReferenceFactory
+
+
+class TestReference(TestCase):
+
+    def test_submitted_str(self):
+        assert "request" not in str(ReferenceFactory())
+
+    def test_unsubmitted_str(self):
+        assert "request" in str(ReferenceFactory(submitted=None))

--- a/web/impact/impact/tests/test_startup_detail_view.py
+++ b/web/impact/impact/tests/test_startup_detail_view.py
@@ -11,7 +11,7 @@ from impact.tests.factories import (
 )
 from impact.tests.contexts import UserContext
 from impact.tests.utils import match_errors
-from impact.tests.api_v0_test_case import APIV0TestCase
+from impact.tests.api_test_case import APITestCase
 from impact.v0.views.startup_detail_view import EMPTY_DETAIL_RESULT
 from impact.v0.views.utils import BADGE_DISPLAYS
 
@@ -22,7 +22,7 @@ BAD_YOUTUBE_EXAMPLE = "https://www.youtube.com/x/y/z"
 UNKNOWN_VIDEO_EXAMPLE = "http://blahblahblah.com/149212783"
 
 
-class TestStartupDetailView(APIV0TestCase):
+class TestStartupDetailView(APITestCase):
 
     def test_basic_post(self):
         context = UserContext()

--- a/web/impact/impact/tests/test_startup_list_view.py
+++ b/web/impact/impact/tests/test_startup_list_view.py
@@ -4,7 +4,7 @@
 from django.urls import reverse
 
 from impact.v0.api_data.startup_list_data import StartupListData as Data
-from impact.tests.api_v0_test_case import APIV0TestCase
+from impact.tests.api_test_case import APITestCase
 from impact.tests.factories import (
     IndustryFactory,
     ProgramFactory,
@@ -47,7 +47,7 @@ STARTUP_LOGO = "logo.jpg"
 REMOTE_LOGO = "http://cloud.test.com/logo.jpg"
 
 
-class TestStartupListView(APIV0TestCase):
+class TestStartupListView(APITestCase):
     def test_program_key_post(self):
         program = ProgramFactory()
         with self.login(username=self.basic_user().username):

--- a/web/impact/impact/tests/test_user.py
+++ b/web/impact/impact/tests/test_user.py
@@ -1,0 +1,15 @@
+# MIT License
+# Copyright (c) 2017 MassChallenge, Inc.
+
+from test_plus.test import TestCase
+from django.contrib.auth import get_user_model
+
+
+User = get_user_model()
+
+
+class TestUser(TestCase):
+
+    def test_create_user_without_email(self):
+        with self.assertRaises(ValueError):
+            User.objects.create_user()

--- a/web/impact/impact/tests/test_user_detail_view.py
+++ b/web/impact/impact/tests/test_user_detail_view.py
@@ -29,7 +29,7 @@ class TestUserDetailView(APITestCase):
                 "is_active": is_active,
                 "first_name": first_name,
                 }
-            response = self.client.patch(url, data)
+            self.client.patch(url, data)
             user.refresh_from_db()
             assert user.is_active == is_active
             assert user.full_name == first_name

--- a/web/impact/impact/tests/test_user_detail_view.py
+++ b/web/impact/impact/tests/test_user_detail_view.py
@@ -1,0 +1,35 @@
+# MIT License
+# Copyright (c) 2017 MassChallenge, Inc.
+
+from django.urls import reverse
+
+from impact.tests.contexts import UserContext
+from impact.tests.api_test_case import APITestCase
+
+
+class TestUserDetailView(APITestCase):
+
+    def test_get(self):
+        context = UserContext()
+        user = context.user
+        with self.login(username=self.basic_user().username):
+            url = reverse("user_detail", args=[user.id])
+            response = self.client.get(url)
+            assert user.full_name == response.data["first_name"]
+            assert user.short_name == response.data["last_name"]
+
+    def test_patch(self):
+        context = UserContext()
+        user = context.user
+        with self.login(username=self.basic_user().username):
+            url = reverse("user_detail", args=[user.id])
+            is_active = not user.is_active
+            first_name = "David"
+            data = {
+                "is_active": is_active,
+                "first_name": first_name,
+                }
+            response = self.client.patch(url, data)
+            user.refresh_from_db()
+            assert user.is_active == is_active
+            assert user.full_name == first_name

--- a/web/impact/impact/tests/test_user_detail_view.py
+++ b/web/impact/impact/tests/test_user_detail_view.py
@@ -28,8 +28,29 @@ class TestUserDetailView(APITestCase):
             data = {
                 "is_active": is_active,
                 "first_name": first_name,
+                "gender": "Male",
                 }
             self.client.patch(url, data)
             user.refresh_from_db()
             assert user.is_active == is_active
             assert user.full_name == first_name
+
+    def test_patch_invalid_key(self):
+        context = UserContext()
+        user = context.user
+        with self.login(username=self.basic_user().username):
+            url = reverse("user_detail", args=[user.id])
+            bad_key = "bad key"
+            response = self.client.patch(url, {bad_key: True})
+            assert response.status_code == 403
+            assert bad_key in response.data
+
+    def test_patch_invalid_gender(self):
+        context = UserContext()
+        user = context.user
+        with self.login(username=self.basic_user().username):
+            url = reverse("user_detail", args=[user.id])
+            bad_gender = "bad gender"
+            response = self.client.patch(url, {"gender": bad_gender})
+            assert response.status_code == 403
+            assert bad_gender in response.data

--- a/web/impact/impact/tests/test_user_list_view.py
+++ b/web/impact/impact/tests/test_user_list_view.py
@@ -43,6 +43,14 @@ class TestUserListView(APITestCase):
             response = self.client.post(url, {})
             assert response.status_code == 403
 
+    def test_post_bad_key(self):
+        with self.login(username=self.basic_user().username):
+            url = reverse("user")
+            bad_key = "bad key"
+            response = self.client.post(url, {bad_key: True})
+            assert response.status_code == 403
+            assert any([bad_key in error for error in response.data])
+
     def test_post_existing(self):
         user = UserContext().user
         data = EXAMPLE_USER.copy()

--- a/web/impact/impact/tests/test_user_list_view.py
+++ b/web/impact/impact/tests/test_user_list_view.py
@@ -1,0 +1,53 @@
+# MIT License
+# Copyright (c) 2017 MassChallenge, Inc.
+
+from django.urls import reverse
+
+from impact.tests.contexts import UserContext
+from impact.tests.api_test_case import APITestCase
+from django.contrib.auth import get_user_model
+
+
+EXAMPLE_USER = {
+    "first_name": "First",
+    "last_name": "Last",
+    "email": "test@example.com",
+    "gender": "o",
+}
+User = get_user_model()
+
+
+class TestUserListView(APITestCase):
+
+    def test_get(self):
+        user1 = UserContext().user
+        user2 = UserContext().user
+        with self.login(username=self.basic_user().username):
+            url = reverse("user")
+            response = self.client.get(url)
+            emails = [result["email"] for result in response.data["results"]]
+            assert user1.email in emails
+            assert user2.email in emails
+
+    def test_post(self):
+        with self.login(username=self.basic_user().username):
+            url = reverse("user")
+            response = self.client.post(url, EXAMPLE_USER)
+            id = response.data["id"]
+            user = User.objects.get(id=id)
+            assert user.email == EXAMPLE_USER["email"]
+
+    def test_post_required_missing(self):
+        with self.login(username=self.basic_user().username):
+            url = reverse("user")
+            response = self.client.post(url, {})
+            assert response.status_code == 403
+
+    def test_post_existing(self):
+        user = UserContext().user
+        data = EXAMPLE_USER.copy()
+        data["email"] = user.email
+        with self.login(username=self.basic_user().username):
+            url = reverse("user")
+            response = self.client.post(url, data)
+            assert response.status_code == 403

--- a/web/impact/impact/tests/test_user_list_view.py
+++ b/web/impact/impact/tests/test_user_list_view.py
@@ -2,10 +2,11 @@
 # Copyright (c) 2017 MassChallenge, Inc.
 
 from django.urls import reverse
+from django.contrib.auth import get_user_model
 
 from impact.tests.contexts import UserContext
 from impact.tests.api_test_case import APITestCase
-from django.contrib.auth import get_user_model
+from impact.v1.views.user_list_view import EMAIL_EXISTS_ERROR
 
 
 EXAMPLE_USER = {
@@ -37,7 +38,7 @@ class TestUserListView(APITestCase):
             user = User.objects.get(id=id)
             assert user.email == EXAMPLE_USER["email"]
 
-    def test_post_required_missing(self):
+    def test_post_without_required_field(self):
         with self.login(username=self.basic_user().username):
             url = reverse("user")
             response = self.client.post(url, {})
@@ -51,7 +52,7 @@ class TestUserListView(APITestCase):
             assert response.status_code == 403
             assert any([bad_key in error for error in response.data])
 
-    def test_post_existing(self):
+    def test_post_with_existing_email(self):
         user = UserContext().user
         data = EXAMPLE_USER.copy()
         data["email"] = user.email
@@ -59,3 +60,4 @@ class TestUserListView(APITestCase):
             url = reverse("user")
             response = self.client.post(url, data)
             assert response.status_code == 403
+            assert EMAIL_EXISTS_ERROR.format(user.email) in response.data

--- a/web/impact/impact/urls.py
+++ b/web/impact/impact/urls.py
@@ -19,6 +19,10 @@ from impact.v0.views import (
     StartupListView,
     StartupDetailView,
 )
+from impact.v1.views import (
+    UserDetailView,
+    UserListView,
+)
 from rest_framework import routers
 
 impact_router = routers.DefaultRouter()
@@ -243,8 +247,18 @@ v0_urlpatterns = [
         name="startup_detail"),
 ]
 
+v1_urlpatterns = [
+    url(r"^user/(?P<pk>[0-9]+)/$",
+        UserDetailView.as_view(),
+        name="user_detail"),
+    url(r"^user/$",
+        UserListView.as_view(),
+        name="user"),
+]
+
 urls = [
     url(r"^api/v0/", include(v0_urlpatterns)),
+    url(r"^api/v1/", include(v1_urlpatterns)),
     url(r'^api/(?P<app>\w+)/(?P<model>\w+)/$',
         GeneralViewSet.as_view({'get': 'list', 'post': 'create'}),
         name='object-list'),

--- a/web/impact/impact/utils.py
+++ b/web/impact/impact/utils.py
@@ -2,6 +2,35 @@
 # Copyright (c) 2017 MassChallenge, Inc.
 from impact.models import BaseProfile
 
+REQUIRED_USER_KEYS = [
+    "email",
+    "first_name",
+    "last_name",
+]
+OPTIONAL_USER_KEYS = [
+    "is_active",
+]
+USER_KEYS = REQUIRED_USER_KEYS + OPTIONAL_USER_KEYS
+REQUIRED_PROFILE_KEYS = [
+    "gender",
+]
+PROFILE_KEYS = REQUIRED_PROFILE_KEYS
+ALL_USER_RELATED_KEYS = USER_KEYS + PROFILE_KEYS
+KEY_TRANSLATIONS = {
+    "first_name": "full_name",
+    "last_name": "short_name",  # Yes, this is correct
+}
+VALID_GENDERS = ["f", "m", "o", "p"]
+INVALID_GENDER_ERROR = ("Invalid gender: '{}'. Valid values are "
+                        "'f' or 'female', 'm' or 'male', "
+                        "'o' or 'other', and 'p' or 'prefer not to state'")
+GENDER_TRANSLATIONS = {
+    "female": "f",
+    "male": "m",
+    "other": "o",
+    "prefer not to state": "p",
+}
+
 
 def compose_filter(key_pieces, value):
     return {"__".join(key_pieces): value}
@@ -23,4 +52,13 @@ def user_gender(user):
     profile = get_profile(user)
     if profile:
         return profile.gender
+    return None
+
+
+def find_gender(gender):
+    if not hasattr(gender, "lower"):
+        return None
+    gender = GENDER_TRANSLATIONS.get(gender.lower(), gender)
+    if gender in VALID_GENDERS:
+        return gender
     return None

--- a/web/impact/impact/utils.py
+++ b/web/impact/impact/utils.py
@@ -1,5 +1,6 @@
 # MIT License
 # Copyright (c) 2017 MassChallenge, Inc.
+from impact.models import BaseProfile
 
 
 def compose_filter(key_pieces, value):
@@ -7,14 +8,15 @@ def compose_filter(key_pieces, value):
 
 
 def get_profile(user):
-    if not user.baseprofile:
+    try:
+        user_type = user.baseprofile.user_type
+        if user_type == "ENTREPRENEUR":
+            return user.entrepreneurprofile
+        if user_type == "EXPERT":
+            return user.expertprofile
+        return user.memberprofile
+    except BaseProfile.DoesNotExist:
         return None
-    user_type = user.baseprofile.user_type
-    if user_type == "ENTREPRENEUR":
-        return user.entrepreneurprofile
-    if user_type == "EXPERT":
-        return user.expertprofile
-    return user.memberprofile
 
 
 def user_gender(user):

--- a/web/impact/impact/utils.py
+++ b/web/impact/impact/utils.py
@@ -7,9 +7,18 @@ def compose_filter(key_pieces, value):
 
 
 def get_profile(user):
+    if not user.baseprofile:
+        return None
     user_type = user.baseprofile.user_type
     if user_type == "ENTREPRENEUR":
         return user.entrepreneurprofile
     if user_type == "EXPERT":
         return user.expertprofile
     return user.memberprofile
+
+
+def user_gender(user):
+    profile = get_profile(user)
+    if profile:
+        return profile.gender
+    return None

--- a/web/impact/impact/v1/views/__init__.py
+++ b/web/impact/impact/v1/views/__init__.py
@@ -1,0 +1,2 @@
+from impact.v1.views.user_detail_view import UserDetailView
+from impact.v1.views.user_list_view import UserListView

--- a/web/impact/impact/v1/views/user_detail_view.py
+++ b/web/impact/impact/v1/views/user_detail_view.py
@@ -6,7 +6,6 @@ from simpleuser.models import USER_KEY_TRANSLATIONS
 from impact.permissions import (
     V1APIPermissions,
 )
-from impact.models import ProgramStartupStatus
 from impact.utils import user_gender
 
 

--- a/web/impact/impact/v1/views/user_detail_view.py
+++ b/web/impact/impact/v1/views/user_detail_view.py
@@ -2,11 +2,22 @@ from django.contrib.auth import get_user_model
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from simpleuser.models import USER_KEY_TRANSLATIONS
 from impact.permissions import (
     V1APIPermissions,
 )
-from impact.utils import user_gender
+from impact.utils import (
+    ALL_USER_RELATED_KEYS,
+    INVALID_GENDER_ERROR,
+    PROFILE_KEYS,
+    USER_KEYS,
+    KEY_TRANSLATIONS,
+    find_gender,
+    get_profile,
+    user_gender,
+)
+
+INVALID_KEYS_ERROR = ("Recevied invalid key(s): {invalid_keys}. "
+                      "Valid keys are: {valid_keys}.")
 
 
 User = get_user_model()
@@ -35,12 +46,25 @@ class UserDetailView(APIView):
     def patch(self, request, pk):
         user = User.objects.get(pk=pk)
         data = request.data
+        invalid_keys = set(data.keys()) - set(ALL_USER_RELATED_KEYS)
+        if invalid_keys:
+            return Response(
+                status=403,
+                data=INVALID_KEYS_ERROR.format(
+                    invalid_keys=list(invalid_keys),
+                    valid_keys=ALL_USER_RELATED_KEYS))
+        if "gender" in data and not find_gender(data.get("gender")):
+            return Response(
+                status=403,
+                data=INVALID_GENDER_ERROR.format(data.get("gender")))
         for key, value in data.items():
-            if hasattr(user, key):
+            if key in KEY_TRANSLATIONS:
+                setattr(user, KEY_TRANSLATIONS[key], data[key])
+            elif key in USER_KEYS:
                 setattr(user, key, data[key])
-            else:
-                alt_key = USER_KEY_TRANSLATIONS.get(key)
-                if alt_key:
-                    setattr(user, alt_key, data[key])
+            elif key in PROFILE_KEYS:
+                profile = get_profile(user)
+                setattr(profile, key, data[key])
+                profile.save()
         user.save()
         return Response(status=200)

--- a/web/impact/impact/v1/views/user_detail_view.py
+++ b/web/impact/impact/v1/views/user_detail_view.py
@@ -1,0 +1,47 @@
+from django.contrib.auth import get_user_model
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from simpleuser.models import USER_KEY_TRANSLATIONS
+from impact.permissions import (
+    V1APIPermissions,
+)
+from impact.models import ProgramStartupStatus
+from impact.utils import user_gender
+
+
+User = get_user_model()
+
+
+class UserDetailView(APIView):
+    permission_classes = (
+        V1APIPermissions,
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def get(self, request, pk):
+        user = User.objects.get(pk=pk)
+        result = {
+            "id": pk,
+            "first_name": user.full_name,
+            "last_name": user.short_name,
+            "email": user.email,
+            "is_active": user.is_active,
+            "gender": get_user_gender(user),
+            }
+        return Response(result)
+
+    def patch(self, request, pk):
+        user = User.objects.get(pk=pk)
+        data = request.data
+        for key, value in data.items():
+            if hasattr(user, key):
+                setattr(user, key, data[key])
+            else:
+                alt_key = USER_KEY_TRANSLATIONS.get(key)
+                if alt_key:
+                    setattr(user, alt_key, data[key])
+        user.save()
+        return Response(status=200)

--- a/web/impact/impact/v1/views/user_detail_view.py
+++ b/web/impact/impact/v1/views/user_detail_view.py
@@ -29,7 +29,7 @@ class UserDetailView(APIView):
             "last_name": user.short_name,
             "email": user.email,
             "is_active": user.is_active,
-            "gender": get_user_gender(user),
+            "gender": user_gender(user),
             }
         return Response(result)
 

--- a/web/impact/impact/v1/views/user_list_view.py
+++ b/web/impact/impact/v1/views/user_list_view.py
@@ -57,8 +57,8 @@ class UserListView(APIView):
 
     def _user_args(self, dict):
         results = self._copy_required_keys(dict, USER_KEYS)
-        email = results["email"]
-        if User.objects.filter(email=email).exists():
+        email = results.get("email")
+        if email and User.objects.filter(email=email).exists():
             self.errors.append(EMAIL_EXISTS_ERROR.format(email))
         return results
 

--- a/web/impact/impact/v1/views/user_list_view.py
+++ b/web/impact/impact/v1/views/user_list_view.py
@@ -2,7 +2,6 @@ from django.contrib.auth import get_user_model
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from simpleuser.models import USER_KEY_TRANSLATIONS
 from impact.permissions import (
     V1APIPermissions,
 )
@@ -10,19 +9,23 @@ from impact.models import (
     BaseProfile,
     MemberProfile,
 )
-from impact.utils import user_gender
+from impact.utils import (
+    find_gender,
+    user_gender,
+    ALL_USER_RELATED_KEYS,
+    INVALID_GENDER_ERROR,
+    KEY_TRANSLATIONS,
+    PROFILE_KEYS,
+    REQUIRED_PROFILE_KEYS,
+    REQUIRED_USER_KEYS,
+    USER_KEYS,
+)
 
 
-USER_KEYS = [
-    "email",
-    "first_name",
-    "last_name",
-]
-PROFILE_KEYS = [
-    "gender",
-]
 EMAIL_EXISTS_ERROR = "User with email {} already exists"
+INVALID_KEY_ERROR = "'{}' is not a valid key."
 KEY_ERROR = "'{}' is required"
+VALID_KEYS_NOTE = "Valid keys are: {}"
 User = get_user_model()
 
 
@@ -50,33 +53,52 @@ class UserListView(APIView):
     def post(self, request):
         user_args = self._user_args(request.POST)
         profile_args = self._profile_args(request.POST)
+        self._invalid_keys(request.POST)
         if self.errors:
+            self.errors.append(VALID_KEYS_NOTE.format(ALL_USER_RELATED_KEYS))
             return Response(status=403, data=self.errors)
         user = _construct_user(user_args, profile_args)
         return Response({"id": user.id})
 
     def _user_args(self, dict):
-        results = self._copy_required_keys(dict, USER_KEYS)
+        self._check_required_keys(dict, REQUIRED_USER_KEYS)
+        results = self._copy_translated_keys(dict, USER_KEYS)
         email = results.get("email")
         if email and User.objects.filter(email=email).exists():
             self.errors.append(EMAIL_EXISTS_ERROR.format(email))
+        if "is_active" not in results:
+            results["is_active"] = False
         return results
 
-    def _profile_args(self, dict):
-        result = self._copy_required_keys(dict, PROFILE_KEYS)
-        result["privacy_policy_accepted"] = False
-        result["newsletter_sender"] = False
+    def _check_required_keys(self, user_keys, required_keys):
+        for key in set(required_keys) - set(user_keys):
+            self.errors.append(KEY_ERROR.format(key))
+
+    def _copy_translated_keys(self, user_data, keys):
+        result = {}
+        for key in keys:
+            if key in user_data:
+                target_key = KEY_TRANSLATIONS.get(key, key)
+                result[target_key] = user_data[key]
         return result
 
-    def _copy_required_keys(self, dict, keys):
-        result = {}
-        for input_key in keys:
-            try:
-                output_key = USER_KEY_TRANSLATIONS.get(input_key, input_key)
-                result[output_key] = dict[input_key]
-            except:
-                self.errors.append(KEY_ERROR.format(input_key))
+    def _profile_args(self, user_data):
+        self._check_required_keys(user_data, REQUIRED_PROFILE_KEYS)
+        results = self._copy_translated_keys(user_data, PROFILE_KEYS)
+        results["gender"] = self._find_gender(results.get("gender"))
+        results["privacy_policy_accepted"] = False
+        results["newsletter_sender"] = False
+        return results
+
+    def _find_gender(self, user_value):
+        result = find_gender(user_value)
+        if result is None:
+            self.errors.append(INVALID_GENDER_ERROR.format(user_value))
         return result
+
+    def _invalid_keys(self, user_keys):
+        for key in set(user_keys) - set(ALL_USER_RELATED_KEYS):
+            self.errors.append(INVALID_KEY_ERROR.format(key))
 
 
 def _url(base_url, limit, offset):

--- a/web/impact/impact/v1/views/user_list_view.py
+++ b/web/impact/impact/v1/views/user_list_view.py
@@ -104,8 +104,7 @@ def _serialize_user(user):
 
 def _construct_user(user_args, profile_args):
     user = User.objects.create_user(**user_args)
-    base = BaseProfile.objects.create(user=user, user_type="MEMBER")
+    BaseProfile.objects.create(user=user, user_type="MEMBER")
     profile_args["user"] = user
     MemberProfile.objects.create(**profile_args)
     return user
-

--- a/web/impact/impact/v1/views/user_list_view.py
+++ b/web/impact/impact/v1/views/user_list_view.py
@@ -1,0 +1,111 @@
+from django.contrib.auth import get_user_model
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from simpleuser.models import USER_KEY_TRANSLATIONS
+from impact.permissions import (
+    V1APIPermissions,
+)
+from impact.models import (
+    BaseProfile,
+    MemberProfile,
+)
+from impact.utils import user_gender
+
+
+USER_KEYS = [
+    "email",
+    "first_name",
+    "last_name",
+]
+PROFILE_KEYS = [
+    "gender",
+]
+EMAIL_EXISTS_ERROR = "User with email {} already exists"
+KEY_ERROR = "'{}' is required"
+User = get_user_model()
+
+
+class UserListView(APIView):
+    permission_classes = (
+        V1APIPermissions,
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.errors = []
+
+    def get(self, request):
+        limit = int(request.GET.get('limit', 10))
+        offset = int(request.GET.get('offset', 0))
+        base_url = request.build_absolute_uri().split("?")[0]
+        result = {
+            "count": User.objects.count(),
+            "next": _url(base_url, limit, offset + limit),
+            "previous": _url(base_url, limit, offset - limit),
+            "results": _user_results(limit, offset),
+            }
+        return Response(result)
+
+    def post(self, request):
+        user_args = self._user_args(request.POST)
+        profile_args = self._profile_args(request.POST)
+        if self.errors:
+            return Response(status=403, data=self.errors)
+        user = _construct_user(user_args, profile_args)
+        return Response({"id": user.id})
+
+    def _user_args(self, dict):
+        results = self._copy_required_keys(dict, USER_KEYS)
+        email = results["email"]
+        if User.objects.filter(email=email).exists():
+            self.errors.append(EMAIL_EXISTS_ERROR.format(email))
+        return results
+
+    def _profile_args(self, dict):
+        result = self._copy_required_keys(dict, PROFILE_KEYS)
+        result["privacy_policy_accepted"] = False
+        result["newsletter_sender"] = False
+        return result
+
+    def _copy_required_keys(self, dict, keys):
+        result = {}
+        for input_key in keys:
+            try:
+                output_key = USER_KEY_TRANSLATIONS.get(input_key, input_key)
+                result[output_key] = dict[input_key]
+            except:
+                self.errors.append(KEY_ERROR.format(input_key))
+        return result
+
+
+def _url(base_url, limit, offset):
+    if offset >= 0:
+        return base_url + "?limit={limit}&offset={offset}".format(
+            limit=limit, offset=offset)
+    return None
+
+
+def _user_results(limit, offset):
+    return [_serialize_user(user)
+            for user in User.objects.all()[offset:offset+limit]]
+
+
+def _serialize_user(user):
+    return {
+        "id": user.id,
+        "email": user.email,
+        "first_name": user.full_name,
+        "last_name": user.short_name,
+        "is_active": user.is_active,
+        "gender": user_gender(user),
+        }
+
+
+def _construct_user(user_args, profile_args):
+    user = User.objects.create_user(**user_args)
+    base = BaseProfile.objects.create(user=user, user_type="MEMBER")
+    profile_args["user"] = user
+    MemberProfile.objects.create(**profile_args)
+    return user
+

--- a/web/impact/simpleuser/models.py
+++ b/web/impact/simpleuser/models.py
@@ -7,7 +7,6 @@ user model.  JamBon SW is planning to open source this code before March
 under a BSD 2-clause license. This will allow for this entire app to be
 removed by MC, if so desired.
 """
-from django.core.mail import send_mail
 from django.contrib.auth.models import (
     BaseUserManager,
     AbstractBaseUser,
@@ -82,14 +81,6 @@ class SimpleIdentityMixin(models.Model):
     class Meta:
         abstract = True
 
-    def get_full_name(self):
-        """Returns the full name of the user."""
-        return self.full_name
-
-    def get_short_name(self):
-        """Returns the short name for the user."""
-        return self.short_name
-
 
 class AbstractUser(SimpleIdentityMixin, PermissionsMixin, AbstractBaseUser):
     """
@@ -109,10 +100,6 @@ class AbstractUser(SimpleIdentityMixin, PermissionsMixin, AbstractBaseUser):
         verbose_name = _('user')
         verbose_name_plural = _('users')
         abstract = True
-
-    def email_user(self, subject, message, from_email=None, **kwargs):
-        """Sends an email to this User."""
-        send_mail(subject, message, from_email, [self.email], **kwargs)
 
 
 class User(AbstractUser):

--- a/web/impact/simpleuser/models.py
+++ b/web/impact/simpleuser/models.py
@@ -17,12 +17,6 @@ from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 
 
-USER_KEY_TRANSLATIONS = {
-    "first_name": "full_name",
-    "last_name": "short_name",  # Yes, this is correct
-    }
-
-
 class UserManager(BaseUserManager):
     use_in_migrations = True
 
@@ -35,10 +29,11 @@ class UserManager(BaseUserManager):
         if not email:
             raise ValueError('An email address must be provided.')
         email = self.normalize_email(email)
+        if "is_active" not in extra_fields:
+            extra_fields["is_active"] = True
         user = self.model(email=email,
-                          is_staff=is_staff, is_active=True,
-                          is_superuser=is_superuser, last_login=now,
-                          date_joined=now, **extra_fields)
+                          is_staff=is_staff, is_superuser=is_superuser,
+                          last_login=now, date_joined=now, **extra_fields)
         user.set_password(password)
         user.save(using=self._db)
         return user

--- a/web/impact/simpleuser/models.py
+++ b/web/impact/simpleuser/models.py
@@ -18,6 +18,12 @@ from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 
 
+USER_KEY_TRANSLATIONS = {
+    "first_name": "full_name",
+    "last_name": "short_name",  # Yes, this is correct
+    }
+
+
 class UserManager(BaseUserManager):
     use_in_migrations = True
 


### PR DESCRIPTION
To test:

1) Get the branch.

2) make dev

3) `make dbload GZ_FILE=../accelerate/test_data/initial_schema.sql.gz`

4) Grant v1_clients permission to a user without any existing permissions and answer 'y' when/if it asks.  E.g.,
```
$ make grant-permissions PERMISSION_USER=37891-user@example.com PERMISSION_CLASSES=v1_clients
Create group name v1_clients? y
granting 37891-user@example.com add to group v1_clients
```

5) Login to the local impact-api server as the given user.

6) Create an application for the user.  Provide name, select Client type => Public, Authorization grant type => Resource owner password-based, click 'Save'.

7) In Postman load the [collection](https://www.getpostman.com/collections/4b28d750ca0b7d27dc77):  File => Import => Import from Link

8) Set the Environment variables for the user and the client id (<eye> => Edit)

9) Send 'oauth token' API from Postman

10)   Send 'v1 user list get' (should see a list of user info in the results).

11) You can test the next and previous links by pasting the URL into the url box next to 'GET V'.  This should behave the same way that they do for more generic DRF API calls like 'startup list'.  Running 'v1 user list get' should set the Postman `variable random_user_id` which is used by the other 'v1 user get' and 'v1 user patch'.

**Yotam: As far as I can see the script that sets `random_user_id` is at "simple user list". I had to add it manually to "v1 user list get", and then it worked as described.**
**Nathan: That was true for an earlier version of the collection, but it should be updated now.  You may need to reload the collection.  Let me know if that doesn't work since that would mean there's something I don't understand about Postman.**

12) You should now be able to test 'v1 user get' and 'v1 user patch'.  Note if you check off items in 'v1 user patch' it should succeed and only update the appropriate fields when you then run 'v1 user get'.

13) POST should work as well and again will set the `random_user_id` appropriately.  If you send the same args more than once you should get an error since the email is already in use.  If you are missing requirement arguments it should complain.  `is_active` is the only optional argument.

To locally test that the users created by the API work in the accelerate platform you need to first connect your local impact-api server to the MySQL instance running on your vagrant machine. Unfortunately this is pretty tricky to do at the moment, but the follow instruction should get you there:

1) Switch your local accelerate repo to the 'development' branch and run `resetdb`.

2) Edit your Vagrantfile and add the following line:
```
      mc_18.vm.network :forwarded_port, guest: 3306, host: 8306, auto_correct: true
```

after the line:
```
       mc_18.vm.network :forwarded_port, guest: 8111, host: 8181, auto_correct: true
```

Note that this is the line that starts with `mc_18.` not `mc_18_safe.`.  More precisely:
```
200a201
>       mc_18.vm.network :forwarded_port, guest: 3306, host: 8306, auto_correct: true
```

3) On your host machine run: `vagrant reload`.

4) As root on your Vagrant machine edit /etc/mysql/my.cnf and comment out the line that starts with "skip-external-locking" and the following like that starts with "bind-address".  More precisely:
```
43c43
> # skip-external-locking
---
< skip-external-locking
47c47
> # bind-address		= 127.0.0.1
---
< bind-address		= 127.0.0.1
```

5) Restart mysql on your Vagrant box by running:

`sudo /etc/init.d/mysql restart`

6) Start the webserver on the vagrant box with `runserver`.  You may want to make a change at this point to the database so you can test it later on.  For example, change the name of startup 10000 to "Foo, Inc.".

7) On your host machine, test that you can access the database by running:

`mysql -u masschallenge -psecret --port 8306 -h 0.0.0.0 mc_dev`

You should be able to see the change you made.  E.g.,

`select name from mc_startup where id=10000;`

8) On your host machine figure out your IP address either by following the instructions here:

http://osxdaily.com/2010/11/21/find-ip-address-mac/

or by running the shell command:

`ifconfig | grep netmask | tail -1 | sed 's/.*inet //' | sed 's/ .*//'`

9) In your impact-api repo edit .dev.env and change the DATABASE_URL to point to Vagrant database by going through the host machine's IP and using the masschallenge database account (password is 'secret').  More precisely:
```
5c5
< DATABASE_URL=mysql://root:root@mysql/mc_dev
---
> DATABASE_URL=mysql://masschallenge:secret@W.X.Y.Z:8306/mc_dev
```
where `W.X.Y.Z` is replaced by your host machine's IP address.

10) In your impact-api repo, make sure you are on the AC-4501 branch and run `make clean; make dev`.  This must be rerun to ensure that necessary migrations run on your local accelerate database.

11) In your impact-api repo, run:

`make grant-permissions PERMISSION_USER=37891-user@example.com PERMISSION_CLASSES=v1_clients`

(or the email of whatever user you want to use in Postman) and answer 'y' when it asks you if you want to create the group 'v1_clients'.

12) Login to the impact-api webserver as the user (37891-user@example.com) and create an application client.

13) In Postman, update the client id (and username/password if you haven't already).

14) In Postman, run 'POST oauth token'.  If you made a change, you should be able to see it either through Postman or with Browsable API.  For example, if you changed startup 10000, you should be able to see the change by going to 'startup list' in Postman.  If you do this, you will need to either be working with a superuser account or you will need to grant the permission `view_startup` (replace 'v1_clients' with 'view_startup' in step 11).

15) Run 'v1 user post'.  Assuming the user is successfully created, you will get back the new user's id.

16) Go to your local accelerate webpage and go through the password reset workflow for 'remerson@walden.pond'.  Specifically, goto login page, click "I forgot my password", enter 'remerson@walden.pond', check the webserver output for email with the reset link, go to that link after replacing the host name with your local server, and enter your new password.

17) Click 'LOGIN', enter 'remerson@walden.pond' and the password you just set.  You should be asked to accept our privacy policy and then you'll be taken to a member profile page. Rejoice!

**IMPORTANT**: After this testing you should disconnect the two environments by running the following:

In your accelerate repo:
% git checkout Vagrantfile
% vagrant reload

You may want to uncomment the lines in my.cnf and restart mysql, but it is not critical since it doesn't have a risk of getting checked in, the port is shutdown by the actions above, and it will all get cleaned up when you rebuild the vagrant environment.

In your impact-api repo:
% git checkout .dev.env
% make clean
