### PR TITLE
[AC-4335] Retool the API deploy process to work with a single public repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,41 @@
+sudo: required
+language: python
+services:
+  - docker
+env:
+    DOCKER_COMPOSE_VERSION: 1.10.1
+before_install:
+- sudo apt-add-repository 'deb http://archive.ubuntu.com/ubuntu trusty-backports universe'
+- sudo apt-get update -qq
+- docker-compose --version
+- sudo apt-get update
+- sudo apt-get install -o Dpkg::Options::="--force-confold" --force-yes -y docker-ce
+- sudo rm /usr/local/bin/docker-compose
+- curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
+- chmod +x docker-compose
+- sudo mv docker-compose /usr/local/bin
+- docker-compose --version
+before_script:
+- export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
+- git checkout $BRANCH
+- echo "" >> .prod.env
+- echo "DJANGO_SECRET_KEY=${DJANGO_SECRET_KEY}" >> .prod.env
+- echo "" >> .prod.env
+- echo "DATABASE_URL=mysql://${DATABASE_USER}:${DATABASE_PASSWORD}@${DATABASE_HOST}/${DATABASE_NAME}" >> .prod.env
+- echo "" >> .prod.env
+- echo "IMPACT_API_V0_SECURITY_KEY=${IMPACT_API_V0_SECURITY_KEY}" >> .prod.env
+- echo "" >> .prod.env
+- echo "IMPACT_API_V0_IMAGE_PASSWORD=${IMPACT_API_V0_IMAGE_PASSWORD}" >> .prod.env
+- echo "" >> .prod.env
+- docker-compose build --no-cache
+- docker-compose up -d 
+script:
+- make test
+after_success:
+- if [ "$DEPLOY_ENVIRONMENT" == "" ]; then export DEPLOY_ENVIRONMENT=$(if [ "$BRANCH" == "master" ]; then echo "production"; else echo "staging"; fi); fi;
+- sudo curl -o /usr/local/bin/ecs-cli https://s3.amazonaws.com/amazon-ecs-cli/ecs-cli-linux-amd64-latest;
+- sudo chmod +x /usr/local/bin/ecs-cli;
+- pip install awscli;
+- export PATH=$PATH:$HOME/.local/bin;
+- eval $(aws ecr get-login --region us-east-1);
+- make release AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY ENVIRONMENT=$DEPLOY_ENVIRONMENT DOCKER_REGISTRY=$DOCKER_REGISTRY RELEASE_TAG=$BRANCH

--- a/test.txt
+++ b/test.txt
@@ -1,0 +1,1 @@
+This is a test file for deploy purposes.


### PR DESCRIPTION
Ultimate goal: You should be able to trigger a deploy and it works without errors.

**Set Up**
In your text editor: 
- Open up impact-api/.travis.yml.
- Open impact-api/test.txt.
- Make a change to this file, commit it, and push it.

In a browser window:
- Go to https://travis-ci.org/masschallenge/
- Make sure that impact-api is one of the available directories.
- Click on `impact-api`.

**Checking the Output**
- Click `Restart build` in the main frame on the lefthand side.  The build will take about 5 minutes to run.
  -  Find the Job Log at the bottom of the page.
  - Check that the environment variables all load with `[secure]` after them.
  - Then verify that the commands in the yml file are present in the Job Log.
  - The tests should run and pass.
  - The build should succeed.

In another browser window:
- Login to AWS.
- Go to EC2 Container Service > Repositories > impact-api.
- Sort the repositories by `Pushed at` and look for a new repository that has:
  -  your release date
  - the branch name tagged