### PR TITLE
[AC-4335] Retool the API deploy process to work with a single public repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,10 +26,10 @@ before_script:
 - git fetch
 - git checkout $BRANCH
 - echo "" >> .prod.env
-- export stuff="STUFF1 STUFF2 STUFF3"
-- for key in $stuff; do echo "$key" >> stuff; echo "" >> stuff.txt; done
+- stuff="STUFF1 STUFF2 STUFF3"
+- for key in $stuff; do echo "$key" >> stuff.txt; echo "" >> stuff.txt; done
 - cat stuff.txt
-- export keys="DJANGO_SECRET_KEY IMPACT_API_V0_SECURITY_KEY IMPACT_API_V0_IMAGE_PASSWORD"
+- keys="DJANGO_SECRET_KEY IMPACT_API_V0_SECURITY_KEY IMPACT_API_V0_IMAGE_PASSWORD"
 - for key in $keys; do echo "$key=${!key}" >> .prod.env; echo "" >> .prod.env; done
 - echo "DATABASE_URL=mysql://${DATABASE_USER}:${DATABASE_PASSWORD}@${DATABASE_HOST}/${DATABASE_NAME}" >> .prod.env
 - echo "" >> .prod.env

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,14 +22,12 @@ before_install:
 
 before_script:
 - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
+- git remote set-branches origin $BRANCH
+- git fetch
 - git checkout $BRANCH
 - echo "" >> .prod.env
 - keys="DJANGO_SECRET_KEY IMPACT_API_V0_SECURITY_KEY IMPACT_API_V0_IMAGE_PASSWORD"
-- for key in $keys
-- do
--     echo "$key=${!key}" >> .prod.env
--     echo "" >> .prod.env
-- done
+- for key in $keys; do echo "$key=${!key}" >> .prod.env; echo "" >> .prod.env; done
 - echo "DATABASE_URL=mysql://${DATABASE_USER}:${DATABASE_PASSWORD}@${DATABASE_HOST}/${DATABASE_NAME}" >> .prod.env
 - echo "" >> .prod.env
 - docker-compose build --no-cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,41 @@
+sudo: required
+language: python
+services:
+  - docker
+env:
+    DOCKER_COMPOSE_VERSION: 1.10.1
+before_install:
+- sudo apt-add-repository 'deb http://archive.ubuntu.com/ubuntu trusty-backports universe'
+- sudo apt-get update -qq
+- docker-compose --version
+- sudo apt-get update
+- sudo apt-get install -o Dpkg::Options::="--force-confold" --force-yes -y docker-ce
+- sudo rm /usr/local/bin/docker-compose
+- curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
+- chmod +x docker-compose
+- sudo mv docker-compose /usr/local/bin
+- docker-compose --version
+before_script:
+- export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
+- git checkout $BRANCH
+- echo "" >> .prod.env
+- echo "DJANGO_SECRET_KEY=${DJANGO_SECRET_KEY}" >> .prod.env
+- echo "" >> .prod.env
+- echo "DATABASE_URL=mysql://${DATABASE_USER}:${DATABASE_PASSWORD}@${DATABASE_HOST}/${DATABASE_NAME}" >> .prod.env
+- echo "" >> .prod.env
+- echo "IMPACT_API_V0_SECURITY_KEY=${IMPACT_API_V0_SECURITY_KEY}" >> .prod.env
+- echo "" >> .prod.env
+- echo "IMPACT_API_V0_IMAGE_PASSWORD=${IMPACT_API_V0_IMAGE_PASSWORD}" >> .prod.env
+- echo "" >> .prod.env
+- docker-compose build --no-cache
+- docker-compose up -d 
+script:
+- make test
+after_success:
+- if [ "$DEPLOY_ENVIRONMENT" == "" ]; then export DEPLOY_ENVIRONMENT=$(if [ "$BRANCH" == "master" ]; then echo "production"; else echo "staging"; fi); fi;
+- sudo curl -o /usr/local/bin/ecs-cli https://s3.amazonaws.com/amazon-ecs-cli/ecs-cli-linux-amd64-latest;
+- sudo chmod +x /usr/local/bin/ecs-cli;
+- pip install awscli;
+- export PATH=$PATH:$HOME/.local/bin;
+- eval $(aws ecr get-login --region us-east-1);
+- make release AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY ENVIRONMENT=$DEPLOY_ENVIRONMENT DOCKER_REGISTRY=$DOCKER_REGISTRY RELEASE_TAG=$BRANCH

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,6 @@ before_script:
 - git fetch
 - git checkout $BRANCH
 - echo "" >> .prod.env
-- stuff="STUFF1 STUFF2 STUFF3"
-- for key in $stuff; do echo "$key" >> stuff.txt; echo "" >> stuff.txt; done
-- cat stuff.txt
 - keys="DJANGO_SECRET_KEY IMPACT_API_V0_SECURITY_KEY IMPACT_API_V0_IMAGE_PASSWORD"
 - for key in $keys; do echo "$key=${!key}" >> .prod.env; echo "" >> .prod.env; done
 - echo "DATABASE_URL=mysql://${DATABASE_USER}:${DATABASE_PASSWORD}@${DATABASE_HOST}/${DATABASE_NAME}" >> .prod.env

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,9 @@ before_script:
 - git fetch
 - git checkout $BRANCH
 - echo "" >> .prod.env
+- stuff="STUFF1 STUFF2 STUFF3"
+- for key in $stuff; do echo "$key" >> stuff; echo "" >> stuff.txt; done
+- cat stuff.txt
 - keys="DJANGO_SECRET_KEY IMPACT_API_V0_SECURITY_KEY IMPACT_API_V0_IMAGE_PASSWORD"
 - for key in $keys; do echo "$key=${!key}" >> .prod.env; echo "" >> .prod.env; done
 - echo "DATABASE_URL=mysql://${DATABASE_USER}:${DATABASE_PASSWORD}@${DATABASE_HOST}/${DATABASE_NAME}" >> .prod.env

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,13 +19,13 @@ before_script:
 - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
 - git checkout $BRANCH
 - echo "" >> .prod.env
-- echo "DJANGO_SECRET_KEY=${DJANGO_SECRET_KEY}" >> .prod.env
-- echo "" >> .prod.env
+- keys="DJANGO_SECRET_KEY IMPACT_API_V0_SECURITY_KEY IMPACT_API_V0_IMAGE_PASSWORD"
+- for key in $keys
+- do
+-     echo "$key=${key}" >> .prod.env
+-     echo "" >> .prod.env
+- done
 - echo "DATABASE_URL=mysql://${DATABASE_USER}:${DATABASE_PASSWORD}@${DATABASE_HOST}/${DATABASE_NAME}" >> .prod.env
-- echo "" >> .prod.env
-- echo "IMPACT_API_V0_SECURITY_KEY=${IMPACT_API_V0_SECURITY_KEY}" >> .prod.env
-- echo "" >> .prod.env
-- echo "IMPACT_API_V0_IMAGE_PASSWORD=${IMPACT_API_V0_IMAGE_PASSWORD}" >> .prod.env
 - echo "" >> .prod.env
 - docker-compose build --no-cache
 - docker-compose up -d 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_script:
 - keys="DJANGO_SECRET_KEY IMPACT_API_V0_SECURITY_KEY IMPACT_API_V0_IMAGE_PASSWORD"
 - for key in $keys
 - do
--     echo "$key=${key}" >> .prod.env
+-     echo "$key=${!key}" >> .prod.env
 -     echo "" >> .prod.env
 - done
 - echo "DATABASE_URL=mysql://${DATABASE_USER}:${DATABASE_PASSWORD}@${DATABASE_HOST}/${DATABASE_NAME}" >> .prod.env

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,5 +37,5 @@ after_success:
 - sudo chmod +x /usr/local/bin/ecs-cli;
 - pip install awscli;
 - export PATH=$PATH:$HOME/.local/bin;
-- eval $(aws ecr get-login --region us-east-1);
+- eval $(aws ecr get-login --region us-east-1 --no-include-email);
 - make release AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY ENVIRONMENT=$DEPLOY_ENVIRONMENT DOCKER_REGISTRY=$DOCKER_REGISTRY RELEASE_TAG=$BRANCH

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,13 @@
 sudo: required
+
 language: python
+
 services:
   - docker
+
 env:
     DOCKER_COMPOSE_VERSION: 1.10.1
+
 before_install:
 - sudo apt-add-repository 'deb http://archive.ubuntu.com/ubuntu trusty-backports universe'
 - sudo apt-get update -qq
@@ -15,6 +19,7 @@ before_install:
 - chmod +x docker-compose
 - sudo mv docker-compose /usr/local/bin
 - docker-compose --version
+
 before_script:
 - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
 - git checkout $BRANCH
@@ -29,8 +34,10 @@ before_script:
 - echo "" >> .prod.env
 - docker-compose build --no-cache
 - docker-compose up -d 
+
 script:
 - make test
+
 after_success:
 - if [ "$DEPLOY_ENVIRONMENT" == "" ]; then export DEPLOY_ENVIRONMENT=$(if [ "$BRANCH" == "master" ]; then echo "production"; else echo "staging"; fi); fi;
 - sudo curl -o /usr/local/bin/ecs-cli https://s3.amazonaws.com/amazon-ecs-cli/ecs-cli-linux-amd64-latest;

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,10 +26,10 @@ before_script:
 - git fetch
 - git checkout $BRANCH
 - echo "" >> .prod.env
-- stuff="STUFF1 STUFF2 STUFF3"
+- export stuff="STUFF1 STUFF2 STUFF3"
 - for key in $stuff; do echo "$key" >> stuff; echo "" >> stuff.txt; done
 - cat stuff.txt
-- keys="DJANGO_SECRET_KEY IMPACT_API_V0_SECURITY_KEY IMPACT_API_V0_IMAGE_PASSWORD"
+- export keys="DJANGO_SECRET_KEY IMPACT_API_V0_SECURITY_KEY IMPACT_API_V0_IMAGE_PASSWORD"
 - for key in $keys; do echo "$key=${!key}" >> .prod.env; echo "" >> .prod.env; done
 - echo "DATABASE_URL=mysql://${DATABASE_USER}:${DATABASE_PASSWORD}@${DATABASE_HOST}/${DATABASE_NAME}" >> .prod.env
 - echo "" >> .prod.env

--- a/test.txt
+++ b/test.txt
@@ -1,0 +1,1 @@
+This is a test file for deploy purposes.

--- a/test.txt
+++ b/test.txt
@@ -1,1 +1,2 @@
 This is a test file for deploy purposes.
+Test change.

--- a/test.txt
+++ b/test.txt
@@ -1,2 +1,0 @@
-This is a test file for deploy purposes.
-Test change.


### PR DESCRIPTION
(Copied from the [accidentally merged PR](https://github.com/masschallenge/impact-api/pull/5))

Ultimate goal: You should be able to trigger a deploy and it works without errors.

**Set Up**
In your text editor: 
- Open up impact-api/.travis.yml.
- Open impact-api/test.txt.
- Make a change to this file, commit it, and push it. **Yotam: Make sure you commit to branch AC-4335-PR**

In a browser window:
- Go to https://travis-ci.org/masschallenge/
- Make sure that impact-api is one of the available directories.
- Click on `impact-api`.

**Checking the Output**
- Click `Restart build` in the main frame on the lefthand side.  The build will take about 5 minutes to run.
  -  Find the Job Log at the bottom of the page.
  - Check that the environment variables all load with `[secure]` after them.
  - Then verify that the commands in the yml file are present in the Job Log.
  - The tests should run and pass.
  - The build should succeed.

In another browser window:
- Login to AWS.
- Go to EC2 Container Service > Repositories > impact-api.
- Sort the repositories by `Pushed at` and look for a new repository that has:
  -  your release date
  - the branch name tagged