### PR TITLE
AC-4604: compiled static assets on production api not getting generated correctly

### DIFF
--- a/web/impact/templates/base.html
+++ b/web/impact/templates/base.html
@@ -9,7 +9,7 @@
   {% endblock %}
   <title>{% block title %}{% if name %}{{ name }} – {% endif %}Impact{% endblock %}</title>
   {% block style %}
-    <link rel="stylesheet" type="text/css" href="{% static "css/build/style.min.css" %}"/>
+    <link rel="stylesheet" type="text/css" href="{% static "css/dev/style.css" %}"/>
     {% block bootstrap_theme %}
       <link rel="stylesheet" type="text/css" href="{% static "rest_framework/css/bootstrap.min.css" %}"/>
       <link rel="stylesheet" type="text/css" href="{% static "rest_framework/css/bootstrap-tweaks.css" %}"/>

--- a/web/impact/templates/rest_framework/api.html
+++ b/web/impact/templates/rest_framework/api.html
@@ -4,11 +4,11 @@
 {% block bootstrap_theme %}
   <link
     rel="stylesheet"
-    href="http://bootswatch.com/flatly/bootstrap.min.css"
+    href="//bootswatch.com/flatly/bootstrap.min.css"
     type="text/css" />
     <link
       rel="stylesheet"
-      href="{% static 'css/build/style.min.css' %}"
+      href="{% static 'css/dev/style.css' %}"
       type="text/css" />
     {% endblock %}
     {% block navbar %}


### PR DESCRIPTION
To test this, run make dev locally and open up a developer console and verify that there no 404's for static files. Part of the difficulty here is that this is something that previously worked locally so nothing will visibly change locally but not on production staticfiles will properly load (please note that this was an issue that was manually patched on production to confirm it works so you will not see this on the current prod)