### PR TITLE
[AC-4646] add docker run flag that removes process when done

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ superuser:
 code-check: DIFFBRANCH?=$(shell if [ "${BRANCH}" == "" ]; \
    then echo "development"; else echo "${BRANCH}"; fi;)
 code-check:
-	-@docker run -v ${PWD}:/code -e BRANCH=$(DIFFBRANCH) \
+	-@docker run --rm -v ${PWD}:/code -e BRANCH=$(DIFFBRANCH) \
 		masschallenge/fpdiff /bin/bash | grep -v "^\.\/\.venv" | \
 		grep -v "site-packages"
 


### PR DESCRIPTION
**Test:**

* On development:
  * `make code-check`
  * `docker ps -a`
  * See that a freshly exited container appears in the list.
* On AC-4646
  * `make code-check`
  * `docker ps -a`
  * See that nothing is added.