### PR TITLE
[AC-4629] - set Proxy API calls to Test-3's Host

### DIFF
--- a/web/impact/impact/settings.py
+++ b/web/impact/impact/settings.py
@@ -156,7 +156,9 @@ class Base(Configuration):
     CORS_ORIGIN_ALLOW_ALL = True
     # settings.py
     REST_PROXY = {
-        'HOST': bytes(os.environ.get('ACCELERATE_SITE_URL'), 'utf-8'),
+        'HOST': bytes(
+            os.environ.get('ACCELERATE_SITE_URL',
+                           'https://accelerate.masschallenge.org'), 'utf-8'),
         'AUTH': {
             'user': None,
             'password': None,

--- a/web/impact/impact/settings.py
+++ b/web/impact/impact/settings.py
@@ -9,7 +9,6 @@ from unipath import Path
 
 
 class Base(Configuration):
-
     LANGUAGE_CODE = 'en-us'
 
     TIME_ZONE = 'America/New_York'
@@ -157,7 +156,7 @@ class Base(Configuration):
     CORS_ORIGIN_ALLOW_ALL = True
     # settings.py
     REST_PROXY = {
-        'HOST': 'https://accelerate-test-3-sf-elb-1843213725.us-east-1.elb.amazonaws.com',
+        'HOST': bytes(os.environ.get('ACCELERATE_SITE_URL'), 'utf-8'),
         'AUTH': {
             'user': None,
             'password': None,
@@ -188,7 +187,6 @@ class Base(Configuration):
 
 
 class Dev(Base):
-
     DEBUG = True
 
     Base.TEMPLATES[0]['OPTIONS']['debug'] = True
@@ -202,8 +200,8 @@ class Dev(Base):
     ]
 
     MIDDLEWARE_CLASSES = [
-        'debug_toolbar.middleware.DebugToolbarMiddleware',
-    ] + Base.MIDDLEWARE_CLASSES
+                             'debug_toolbar.middleware.DebugToolbarMiddleware',
+                         ] + Base.MIDDLEWARE_CLASSES
 
     INSTALLED_APPS = Base.INSTALLED_APPS + [
         'debug_toolbar',
@@ -215,7 +213,6 @@ class Dev(Base):
 
 
 class Test(Base):
-
     MIGRATION_MODULES = {'django.contrib.auth': None, 'impact': None}
     DATABASES = {
         'default': {
@@ -233,7 +230,6 @@ class Test(Base):
 
 
 class Prod(Base):
-
     ALLOWED_HOSTS = Base.ALLOWED_HOSTS + [
         os.environ.get('DJANGO_ALLOWED_HOST', '*'),
     ]

--- a/web/impact/impact/settings.py
+++ b/web/impact/impact/settings.py
@@ -157,7 +157,7 @@ class Base(Configuration):
     CORS_ORIGIN_ALLOW_ALL = True
     # settings.py
     REST_PROXY = {
-        'HOST': 'https://accelerate.masschallenge.org',
+        'HOST': 'https://accelerate-test-3-sf-elb-1843213725.us-east-1.elb.amazonaws.com',
         'AUTH': {
             'user': None,
             'password': None,


### PR DESCRIPTION
The current settings redirect Proxy API calls to production, instead of test.
This change solves this.