### PR TITLE
[AC-4631-api] Provide GET calls for organization list view and detail view

### DIFF
--- a/web/impact/impact/api_data/api_data.py
+++ b/web/impact/impact/api_data/api_data.py
@@ -58,7 +58,8 @@ class APIData(object):
             if isinstance(key, int) or key.isdigit():
                 result = Startup.objects.filter(id=key).first()
             elif isinstance(key, str):
-                result = Startup.objects.filter(url_slug=key).first()
+                result = Startup.objects.filter(
+                    organization__url_slug=key).first()
         if result:
             return result
         else:

--- a/web/impact/impact/models/__init__.py
+++ b/web/impact/impact/models/__init__.py
@@ -56,6 +56,7 @@ from .functional_expertise import FunctionalExpertise
 from .industry import Industry
 from .member_profile import MemberProfile
 from .named_group import NamedGroup
+from .organization import Organization
 from .partner import Partner
 from .partner_team_member import PartnerTeamMember
 from .program_manager import ProgramManager

--- a/web/impact/impact/models/organization.py
+++ b/web/impact/impact/models/organization.py
@@ -2,7 +2,6 @@
 # Copyright (c) 2017 MassChallenge, Inc.
 
 from django.db import models
-from django.template.defaultfilters import slugify
 from django.core.validators import (
     RegexValidator,
     validate_slug

--- a/web/impact/impact/models/organization.py
+++ b/web/impact/impact/models/organization.py
@@ -17,8 +17,7 @@ class Organization(MCModel):
     description = models.TextField(
         max_length=1000,
         blank=True,
-        help_text='This is the generic description of the Partner, shared '
-        'across all Programs.')
+        help_text='This is the generic description of the Organization.')
     website_url = models.URLField(max_length=100, blank=True)
     twitter_handle = models.CharField(
         max_length=40,

--- a/web/impact/impact/models/organization.py
+++ b/web/impact/impact/models/organization.py
@@ -1,0 +1,47 @@
+# MIT License
+# Copyright (c) 2017 MassChallenge, Inc.
+
+
+from django.db import models
+from django.core.validators import (
+    RegexValidator,
+    validate_slug
+)
+
+from impact.models.mc_model import MCModel
+from impact.models.utils import is_managed
+
+
+class Organization(MCModel):
+    name = models.CharField(max_length=100, unique=True)
+    description = models.TextField(
+        max_length=1000,
+        blank=True,
+        help_text='This is the generic description of the Partner, shared '
+        'across all Programs.')
+    website_url = models.URLField(max_length=100, blank=True)
+    twitter_handle = models.CharField(
+        max_length=40,
+        blank=True,
+        help_text='Omit the "@". We\'ll add it.')
+    public_inquiry_email = models.EmailField(verbose_name="Email address",
+                                             max_length=100,
+                                             blank=True)
+    url_slug = models.CharField(
+        max_length=64,
+        blank=True,
+        default="",  # This actually gets replaced by a real slug.
+        unique=True,
+        validators=[RegexValidator(".*\D.*",
+                                   "Slug must contain a non-numeral."),
+                    validate_slug, ]
+    )
+
+    class Meta(MCModel.Meta):
+        db_table = 'mc_organization'
+        managed = is_managed(db_table)
+        verbose_name_plural = 'Organizations'
+        ordering = ['name', ]
+
+    def __str__(self):
+        return self.name

--- a/web/impact/impact/models/organization.py
+++ b/web/impact/impact/models/organization.py
@@ -68,4 +68,3 @@ def organization_save_patch(self, *args, **kwargs):
 
 
 Organization.save_base = organization_save_patch
-    

--- a/web/impact/impact/models/organization.py
+++ b/web/impact/impact/models/organization.py
@@ -45,26 +45,3 @@ class Organization(MCModel):
 
     def __str__(self):
         return self.name
-
-    @classmethod
-    def slug_from_instance(cls, instance):
-        slug = slugify(instance.name)
-        if slug == "":
-            slug = "organization"
-        slug = slug[:61]
-        slugbase = slug
-        i = 0
-        while (cls.objects.filter(url_slug=slug).exists() and
-               (i < 100 or slugbase == "organization")):
-            i += 1
-            slug = slugbase + "-" + str(i)
-        return slug
-
-
-def organization_save_patch(self, *args, **kwargs):
-    if self.url_slug == "":
-        self.url_slug = Organization.slug_from_instance(self)
-    super(Organization, self).save_base(*args, **kwargs)
-
-
-Organization.save_base = organization_save_patch

--- a/web/impact/impact/models/partner.py
+++ b/web/impact/impact/models/partner.py
@@ -15,11 +15,13 @@ except ImportError:
     HAS_SORL = False
 
 from impact.models.mc_model import MCModel
+from impact.models.organization import Organization
 from impact.models.utils import is_managed
 
 
 class Partner(MCModel):
     name = models.CharField(max_length=100, unique=True)
+    organization = models.ForeignKey(Organization, blank=True, null=True)    
     description = models.TextField(
         max_length=1000,
         blank=True,

--- a/web/impact/impact/models/partner.py
+++ b/web/impact/impact/models/partner.py
@@ -1,12 +1,7 @@
 # MIT License
 # Copyright (c) 2017 MassChallenge, Inc.
 
-
 from django.db import models
-from django.core.validators import (
-    RegexValidator,
-    validate_slug
-)
 
 try:
     from sorl.thumbnail import ImageField
@@ -21,7 +16,7 @@ from impact.models.utils import is_managed
 
 class Partner(MCModel):
     name = models.CharField(max_length=100, unique=True)
-    organization = models.ForeignKey(Organization, blank=True, null=True)    
+    organization = models.ForeignKey(Organization, blank=True, null=True)
     description = models.TextField(
         max_length=1000,
         blank=True,

--- a/web/impact/impact/models/partner.py
+++ b/web/impact/impact/models/partner.py
@@ -33,7 +33,7 @@ class Partner(MCModel):
             verbose_name="Partner Logo",
             blank=True)
     else:
-        partner_logo = models.CharField(max_length=100)
+        partner_logo = models.CharField(max_length=100, blank=True)
 
     website_url = models.URLField(max_length=100, blank=True)
     twitter_handle = models.CharField(
@@ -43,15 +43,6 @@ class Partner(MCModel):
     public_inquiry_email = models.EmailField(verbose_name="Email address",
                                              max_length=100,
                                              blank=True)
-    url_slug = models.CharField(
-        max_length=64,
-        blank=True,
-        default="",  # This actually gets replaced by a real slug.
-        unique=True,
-        validators=[RegexValidator(".*\D.*",
-                                   "Slug must contain a non-numeral."),
-                    validate_slug, ]
-    )
 
     class Meta(MCModel.Meta):
         db_table = 'mc_partner'

--- a/web/impact/impact/models/startup.py
+++ b/web/impact/impact/models/startup.py
@@ -6,10 +6,7 @@ from embed_video.fields import EmbedVideoField
 
 from simpleuser.models import User
 from django.db import models
-from django.core.validators import (
-    RegexValidator,
-    validate_slug
-)
+from django.core.validators import RegexValidator
 
 try:
     from sorl.thumbnail import ImageField
@@ -40,7 +37,7 @@ STARTUP_COMMUNITIES = (
 
 class Startup(MCModel):
     name = models.CharField(max_length=255)
-    organization = models.ForeignKey(Organization, blank=True, null=True)    
+    organization = models.ForeignKey(Organization, blank=True, null=True)
     user = models.ForeignKey(User)
     is_visible = models.BooleanField(
         default=True,

--- a/web/impact/impact/models/startup.py
+++ b/web/impact/impact/models/startup.py
@@ -18,6 +18,7 @@ except ImportError:
     HAS_SORL = False
 
 from impact.models.mc_model import MCModel
+from impact.models.organization import Organization
 from impact.models.industry import Industry
 from impact.models.recommendation_tag import RecommendationTag
 from impact.models.currency import Currency
@@ -39,6 +40,7 @@ STARTUP_COMMUNITIES = (
 
 class Startup(MCModel):
     name = models.CharField(max_length=255)
+    organization = models.ForeignKey(Organization, blank=True, null=True)    
     user = models.ForeignKey(User)
     is_visible = models.BooleanField(
         default=True,

--- a/web/impact/impact/models/startup.py
+++ b/web/impact/impact/models/startup.py
@@ -111,15 +111,6 @@ class Startup(MCModel):
         choices=STARTUP_COMMUNITIES,
         blank=True,
     )
-    url_slug = models.CharField(
-        max_length=64,
-        blank=True,
-        default="",  # This actually gets replaced by a real slug.
-        unique=True,
-        validators=[RegexValidator(".*\D.*",
-                                   "Slug must contain a non-numeral."),
-                    validate_slug, ]
-    )
 
     # profile color fields are deprecated - do not delete until we know
     # what the marketing site is doing with startup display

--- a/web/impact/impact/tests/contexts/organization_context.py
+++ b/web/impact/impact/tests/contexts/organization_context.py
@@ -1,2 +1,0 @@
-class OrganizationContext(object):
-    self.

--- a/web/impact/impact/tests/contexts/organization_context.py
+++ b/web/impact/impact/tests/contexts/organization_context.py
@@ -1,0 +1,2 @@
+class OrganizationContext(object):
+    self.

--- a/web/impact/impact/tests/factories/__init__.py
+++ b/web/impact/impact/tests/factories/__init__.py
@@ -40,6 +40,7 @@ from .named_group_factory import NamedGroupFactory
 from .newsletter_factory import NewsletterFactory
 from .newsletter_receipt_factory import NewsletterReceiptFactory
 from .observer_factory import ObserverFactory
+from .organization_factory import OrganizationFactory
 from .panel_factory import PanelFactory
 from .panel_location_factory import PanelLocationFactory
 from .panel_time_factory import PanelTimeFactory

--- a/web/impact/impact/tests/factories/organization_factory.py
+++ b/web/impact/impact/tests/factories/organization_factory.py
@@ -1,0 +1,20 @@
+from factory import (
+    DjangoModelFactory,
+    Sequence,
+)
+from impact.models import Organization
+
+
+class OrganizationFactory(DjangoModelFactory):
+
+    class Meta:
+        model = Organization
+
+    name = Sequence(lambda n: "Test Organization {0}".format(n))
+    description = Sequence(
+        lambda n: "Description of Organization {0}".format(n))
+    website_url = Sequence(lambda n: "www.organization{0}.com".format(n))
+    twitter_handle = Sequence(lambda n: "organization{0}".format(n))
+    public_inquiry_email = Sequence(
+        lambda n: "contact@organization{0}.com".format(n))
+    url_slug = Sequence(lambda n: "slug{0}".format(n))

--- a/web/impact/impact/tests/factories/partner_factory.py
+++ b/web/impact/impact/tests/factories/partner_factory.py
@@ -4,9 +4,10 @@
 from factory import (
     DjangoModelFactory,
     Sequence,
+    SubFactory,
 )
 from impact.models import Partner
-
+from .organization_factory import OrganizationFactory
 
 class PartnerFactory(DjangoModelFactory):
 
@@ -14,10 +15,11 @@ class PartnerFactory(DjangoModelFactory):
         model = Partner
 
     name = Sequence(lambda n: "Test Partner {0}".format(n))
+
     description = Sequence(lambda n: "Description of Partner {0}".format(n))
-    partner_logo = None
+    organization = SubFactory(OrganizationFactory)
+    partner_logo = Sequence(lambda n: "logo {0}".format(n))
     website_url = Sequence(lambda n: "www.partner{0}.com".format(n))
     twitter_handle = Sequence(lambda n: "partner{0}".format(n))
     public_inquiry_email = Sequence(
         lambda n: "contact@partner{0}.com".format(n))
-    url_slug = ""

--- a/web/impact/impact/tests/factories/partner_factory.py
+++ b/web/impact/impact/tests/factories/partner_factory.py
@@ -9,6 +9,7 @@ from factory import (
 from impact.models import Partner
 from .organization_factory import OrganizationFactory
 
+
 class PartnerFactory(DjangoModelFactory):
 
     class Meta:

--- a/web/impact/impact/tests/factories/startup_factory.py
+++ b/web/impact/impact/tests/factories/startup_factory.py
@@ -14,7 +14,6 @@ from impact.models import (
     DEFAULT_PROFILE_BACKGROUND_COLOR,
     DEFAULT_PROFILE_TEXT_COLOR,
     STARTUP_COMMUNITIES,
-    Organization,
     Startup,
 )
 
@@ -23,12 +22,13 @@ from .industry_factory import IndustryFactory
 from .user_factory import UserFactory
 from .organization_factory import OrganizationFactory
 
+
 class StartupFactory(DjangoModelFactory):
     class Meta:
         model = Startup
 
     name = Sequence(lambda n: "Test Startup {0} Inc.".format(n))
-    organization = SubFactory(OrganizationFactory)    
+    organization = SubFactory(OrganizationFactory)
     user = SubFactory(UserFactory)
     is_visible = True
     primary_industry = SubFactory(IndustryFactory)
@@ -54,7 +54,7 @@ class StartupFactory(DjangoModelFactory):
     location_postcode = "02210"
     date_founded = "01/2010"
     landing_page = None
-    
+
     @post_generation
     def additional_industry_categories(self, create, extracted, **kwargs):
         if not create:

--- a/web/impact/impact/tests/factories/startup_factory.py
+++ b/web/impact/impact/tests/factories/startup_factory.py
@@ -14,19 +14,21 @@ from impact.models import (
     DEFAULT_PROFILE_BACKGROUND_COLOR,
     DEFAULT_PROFILE_TEXT_COLOR,
     STARTUP_COMMUNITIES,
+    Organization,
     Startup,
 )
 
 from .currency_factory import CurrencyFactory
 from .industry_factory import IndustryFactory
 from .user_factory import UserFactory
-
+from .organization_factory import OrganizationFactory
 
 class StartupFactory(DjangoModelFactory):
     class Meta:
         model = Startup
 
     name = Sequence(lambda n: "Test Startup {0} Inc.".format(n))
+    organization = SubFactory(OrganizationFactory)    
     user = SubFactory(UserFactory)
     is_visible = True
     primary_industry = SubFactory(IndustryFactory)
@@ -43,7 +45,6 @@ class StartupFactory(DjangoModelFactory):
     created_datetime = utc.localize(datetime(2015, 1, 1))
     last_updated_datetime = utc.localize(datetime(2015, 7, 1))
     community = STARTUP_COMMUNITIES[0][0]
-    url_slug = Sequence(lambda n: "startup{0}".format(n))
     profile_background_color = DEFAULT_PROFILE_BACKGROUND_COLOR
     profile_text_color = DEFAULT_PROFILE_TEXT_COLOR
     currency = SubFactory(CurrencyFactory)
@@ -53,7 +54,7 @@ class StartupFactory(DjangoModelFactory):
     location_postcode = "02210"
     date_founded = "01/2010"
     landing_page = None
-
+    
     @post_generation
     def additional_industry_categories(self, create, extracted, **kwargs):
         if not create:

--- a/web/impact/impact/tests/test_api_routes.py
+++ b/web/impact/impact/tests/test_api_routes.py
@@ -40,9 +40,9 @@ class TestApiRoute(TestCase):
                 'programrole']).delete()
 
     def test_api_object_list(self):
-        StartupFactory(is_visible=1, url_slug="test1")
-        StartupFactory(is_visible=1, url_slug="test2")
-        StartupFactory(is_visible=1, url_slug="test3")
+        StartupFactory(is_visible=1, organization__url_slug="test1")
+        StartupFactory(is_visible=1, organization__url_slug="test2")
+        StartupFactory(is_visible=1, organization__url_slug="test3")
         Permission.objects.get_or_create(
             content_type=ContentType.objects.get(
                 app_label='mc',

--- a/web/impact/impact/tests/test_organization.py
+++ b/web/impact/impact/tests/test_organization.py
@@ -1,8 +1,8 @@
 from impact.tests.api_test_case import APITestCase
 from impact.tests.factories import OrganizationFactory
 
-class TestOrganization(APITestCase):
 
+class TestOrganization(APITestCase):
     def test_str(self):
         organization = OrganizationFactory()
         assert str(organization) == organization.name

--- a/web/impact/impact/tests/test_organization.py
+++ b/web/impact/impact/tests/test_organization.py
@@ -1,0 +1,8 @@
+from impact.tests.api_test_case import APITestCase
+from impact.tests.factories import OrganizationFactory
+
+class TestOrganization(APITestCase):
+
+    def test_str(self):
+        organization = OrganizationFactory()
+        assert str(organization) == organization.name

--- a/web/impact/impact/tests/test_organization_detail_view.py
+++ b/web/impact/impact/tests/test_organization_detail_view.py
@@ -13,7 +13,6 @@ from impact.tests.api_test_case import APITestCase
 
 
 class TestOrganizationDetailView(APITestCase):
-
     def test_get_startup(self):
         startup = StartupFactory()
         with self.login(username=self.basic_user().username):
@@ -42,7 +41,7 @@ class TestOrganizationDetailView(APITestCase):
 
     def test_get_org_is_both_partner_and_startup(self):
         partner = PartnerFactory()
-        
+
         with self.login(username=self.basic_user().username):
             url = reverse("organization_detail",
                           args=[partner.organization.id])
@@ -53,7 +52,7 @@ class TestOrganizationDetailView(APITestCase):
                     partner.public_inquiry_email)
             assert response.data["is_startup"] is False
             assert response.data["is_partner"] is True
-            
+
     def test_organization_has_no_startup_nor_partner(self):
         organization = OrganizationFactory()
         with self.login(username=self.basic_user().username):

--- a/web/impact/impact/tests/test_organization_detail_view.py
+++ b/web/impact/impact/tests/test_organization_detail_view.py
@@ -4,6 +4,7 @@
 from django.urls import reverse
 
 from impact.tests.factories import (
+    OrganizationFactory,
     PartnerFactory,
     StartupFactory,
 )
@@ -21,6 +22,8 @@ class TestOrganizationDetailView(APITestCase):
             response = self.client.get(url)
             assert response.data["name"] == startup.organization.name
             assert response.data["url_slug"] == startup.organization.url_slug
+            assert (response.data["public_inquiry_email"] ==
+                    startup.public_inquiry_email)
             assert response.data["is_startup"] is True
             assert response.data["is_partner"] is False
 
@@ -32,5 +35,33 @@ class TestOrganizationDetailView(APITestCase):
             response = self.client.get(url)
             assert response.data["name"] == partner.organization.name
             assert response.data["url_slug"] == partner.organization.url_slug
+            assert (response.data["public_inquiry_email"] ==
+                    partner.public_inquiry_email)
             assert response.data["is_startup"] is False
             assert response.data["is_partner"] is True
+
+    def test_get_org_is_both_partner_and_startup(self):
+        partner = PartnerFactory()
+        
+        with self.login(username=self.basic_user().username):
+            url = reverse("organization_detail",
+                          args=[partner.organization.id])
+            response = self.client.get(url)
+            assert response.data["name"] == partner.organization.name
+            assert response.data["url_slug"] == partner.organization.url_slug
+            assert (response.data["public_inquiry_email"] ==
+                    partner.public_inquiry_email)
+            assert response.data["is_startup"] is False
+            assert response.data["is_partner"] is True
+            
+    def test_organization_has_no_startup_nor_partner(self):
+        organization = OrganizationFactory()
+        with self.login(username=self.basic_user().username):
+            url = reverse("organization_detail",
+                          args=[organization.id])
+            response = self.client.get(url)
+            assert response.data["name"] == organization.name
+            assert response.data["url_slug"] == organization.url_slug
+            assert response.data["public_inquiry_email"] == ""
+            assert response.data["is_startup"] is False
+            assert response.data["is_partner"] is False

--- a/web/impact/impact/tests/test_organization_detail_view.py
+++ b/web/impact/impact/tests/test_organization_detail_view.py
@@ -1,0 +1,36 @@
+# MIT License
+# Copyright (c) 2017 MassChallenge, Inc.
+
+from django.urls import reverse
+
+from impact.tests.factories import (
+    OrganizationFactory,
+    PartnerFactory,
+    StartupFactory,
+)
+    
+from impact.tests.api_test_case import APITestCase
+
+
+class TestOrganizationDetailView(APITestCase):
+
+    def test_get_startup(self):
+        startup = StartupFactory()
+        with self.login(username=self.basic_user().username):
+            url = reverse("organization_detail", args=[startup.organization.id])
+            response = self.client.get(url)
+            assert response.data["name"] == startup.organization.name
+            assert response.data["url_slug"] == startup.organization.url_slug
+            assert response.data["is_startup"] == True
+            assert response.data["is_partner"] == False
+
+    def test_get_partner(self):
+        partner = PartnerFactory()
+        with self.login(username=self.basic_user().username):
+            url = reverse("organization_detail", args=[partner.organization.id])
+            response = self.client.get(url)
+            assert response.data["name"] == partner.organization.name
+            assert response.data["url_slug"] == partner.organization.url_slug
+            assert response.data["is_startup"] == False
+            assert response.data["is_partner"] == True            
+            

--- a/web/impact/impact/tests/test_organization_detail_view.py
+++ b/web/impact/impact/tests/test_organization_detail_view.py
@@ -4,11 +4,10 @@
 from django.urls import reverse
 
 from impact.tests.factories import (
-    OrganizationFactory,
     PartnerFactory,
     StartupFactory,
 )
-    
+
 from impact.tests.api_test_case import APITestCase
 
 
@@ -17,20 +16,21 @@ class TestOrganizationDetailView(APITestCase):
     def test_get_startup(self):
         startup = StartupFactory()
         with self.login(username=self.basic_user().username):
-            url = reverse("organization_detail", args=[startup.organization.id])
+            url = reverse("organization_detail",
+                          args=[startup.organization.id])
             response = self.client.get(url)
             assert response.data["name"] == startup.organization.name
             assert response.data["url_slug"] == startup.organization.url_slug
-            assert response.data["is_startup"] == True
-            assert response.data["is_partner"] == False
+            assert response.data["is_startup"] is True
+            assert response.data["is_partner"] is False
 
     def test_get_partner(self):
         partner = PartnerFactory()
         with self.login(username=self.basic_user().username):
-            url = reverse("organization_detail", args=[partner.organization.id])
+            url = reverse("organization_detail",
+                          args=[partner.organization.id])
             response = self.client.get(url)
             assert response.data["name"] == partner.organization.name
             assert response.data["url_slug"] == partner.organization.url_slug
-            assert response.data["is_startup"] == False
-            assert response.data["is_partner"] == True            
-            
+            assert response.data["is_startup"] is False
+            assert response.data["is_partner"] is True

--- a/web/impact/impact/tests/test_organization_list_view.py
+++ b/web/impact/impact/tests/test_organization_list_view.py
@@ -4,13 +4,13 @@
 from django.urls import reverse
 
 from impact.tests.factories import (
-    OrganizationFactory,
     PartnerFactory,
     StartupFactory,
 )
-    
+
 from impact.tests.api_test_case import APITestCase
 from impact.v1.views.organization_list_view import serialize_org
+
 
 class TestOrganizationDetailView(APITestCase):
 
@@ -21,7 +21,8 @@ class TestOrganizationDetailView(APITestCase):
             url = reverse("organization")
             response = self.client.get(url)
             assert response.data['count'] == count
-            assert all([serialize_org(startup.organization) in response.data['results']
+            assert all([serialize_org(startup.organization)
+                        in response.data['results']
                         for startup in startups])
 
     def test_get_partner(self):
@@ -31,6 +32,6 @@ class TestOrganizationDetailView(APITestCase):
             url = reverse("organization")
             response = self.client.get(url)
             assert response.data['count'] == count
-            assert all([serialize_org(partner.organization) in response.data['results']
+            assert all([serialize_org(partner.organization)
+                        in response.data['results']
                         for partner in partners])
-            

--- a/web/impact/impact/tests/test_organization_list_view.py
+++ b/web/impact/impact/tests/test_organization_list_view.py
@@ -1,0 +1,36 @@
+# MIT License
+# Copyright (c) 2017 MassChallenge, Inc.
+
+from django.urls import reverse
+
+from impact.tests.factories import (
+    OrganizationFactory,
+    PartnerFactory,
+    StartupFactory,
+)
+    
+from impact.tests.api_test_case import APITestCase
+from impact.v1.views.organization_list_view import serialize_org
+
+class TestOrganizationDetailView(APITestCase):
+
+    def test_get_startup(self):
+        count = 5
+        startups = StartupFactory.create_batch(count)
+        with self.login(username=self.basic_user().username):
+            url = reverse("organization")
+            response = self.client.get(url)
+            assert response.data['count'] == count
+            assert all([serialize_org(startup.organization) in response.data['results']
+                        for startup in startups])
+
+    def test_get_partner(self):
+        count = 5
+        partners = PartnerFactory.create_batch(5)
+        with self.login(username=self.basic_user().username):
+            url = reverse("organization")
+            response = self.client.get(url)
+            assert response.data['count'] == count
+            assert all([serialize_org(partner.organization) in response.data['results']
+                        for partner in partners])
+            

--- a/web/impact/impact/tests/test_partner.py
+++ b/web/impact/impact/tests/test_partner.py
@@ -1,8 +1,8 @@
 from impact.tests.api_test_case import APITestCase
 from impact.tests.factories import PartnerFactory
 
-class TestPartner(APITestCase):
 
+class TestPartner(APITestCase):
     def test_str(self):
         partner = PartnerFactory()
         assert str(partner) == partner.name

--- a/web/impact/impact/tests/test_partner.py
+++ b/web/impact/impact/tests/test_partner.py
@@ -1,0 +1,8 @@
+from impact.tests.api_test_case import APITestCase
+from impact.tests.factories import PartnerFactory
+
+class TestPartner(APITestCase):
+
+    def test_str(self):
+        partner = PartnerFactory()
+        assert str(partner) == partner.name

--- a/web/impact/impact/tests/test_startup.py
+++ b/web/impact/impact/tests/test_startup.py
@@ -1,8 +1,8 @@
 from impact.tests.api_test_case import APITestCase
 from impact.tests.factories import StartupFactory
 
-class TestStartup(APITestCase):
 
+class TestStartup(APITestCase):
     def test_str(self):
         startup = StartupFactory()
         assert str(startup) == startup.name

--- a/web/impact/impact/tests/test_startup.py
+++ b/web/impact/impact/tests/test_startup.py
@@ -1,0 +1,8 @@
+from impact.tests.api_test_case import APITestCase
+from impact.tests.factories import StartupFactory
+
+class TestStartup(APITestCase):
+
+    def test_str(self):
+        startup = StartupFactory()
+        assert str(startup) == startup.name

--- a/web/impact/impact/tests/test_startup_detail_view.py
+++ b/web/impact/impact/tests/test_startup_detail_view.py
@@ -94,9 +94,10 @@ class TestStartupDetailView(APITestCase):
         program = ProgramFactory()
         with self.login(username=self.basic_user().username):
             url = reverse("startup_detail")
-            response = self.client.post(url,
-                                        {"ProgramKey": program.id,
-                                         "StartupKey": startup.url_slug})
+            response = self.client.post(
+                url,
+                {"ProgramKey": program.id,
+                 "StartupKey": startup.organization.url_slug})
             assert startup.name == response.data["name"]
 
     def test_public_member_post(self):

--- a/web/impact/impact/urls.py
+++ b/web/impact/impact/urls.py
@@ -22,6 +22,8 @@ from impact.v0.views import (
 from impact.v1.views import (
     UserDetailView,
     UserListView,
+    OrganizationDetailView,
+    OrganizationListView,
 )
 from rest_framework import routers
 
@@ -29,6 +31,7 @@ impact_router = routers.DefaultRouter()
 simpleuser_router = routers.DefaultRouter()
 
 simpleuser_router.register('User', GeneralViewSet, base_name='User')
+impact_router.register('Organization', GeneralViewSet, base_name='Organization')
 impact_router.register('Application', GeneralViewSet, base_name='Application')
 impact_router.register('ApplicationAnswer', GeneralViewSet,
                        base_name='ApplicationAnswer')
@@ -254,6 +257,13 @@ v1_urlpatterns = [
     url(r"^user/$",
         UserListView.as_view(),
         name="user"),
+    url(r"^organization_detail/(?P<pk>[0-9]+)/$",
+        OrganizationDetailView.as_view(),
+        name="organization_detail"),
+    url(r"^organization/$",
+        OrganizationListView.as_view(),
+        name="organization"),
+    
 ]
 
 urls = [

--- a/web/impact/impact/urls.py
+++ b/web/impact/impact/urls.py
@@ -257,7 +257,7 @@ v1_urlpatterns = [
     url(r"^user/$",
         UserListView.as_view(),
         name="user"),
-    url(r"^organization_detail/(?P<pk>[0-9]+)/$",
+    url(r"^organization/(?P<pk>[0-9]+)/$",
         OrganizationDetailView.as_view(),
         name="organization_detail"),
     url(r"^organization/$",

--- a/web/impact/impact/urls.py
+++ b/web/impact/impact/urls.py
@@ -31,7 +31,9 @@ impact_router = routers.DefaultRouter()
 simpleuser_router = routers.DefaultRouter()
 
 simpleuser_router.register('User', GeneralViewSet, base_name='User')
-impact_router.register('Organization', GeneralViewSet, base_name='Organization')
+impact_router.register('Organization',
+                       GeneralViewSet,
+                       base_name='Organization')
 impact_router.register('Application', GeneralViewSet, base_name='Application')
 impact_router.register('ApplicationAnswer', GeneralViewSet,
                        base_name='ApplicationAnswer')
@@ -263,7 +265,7 @@ v1_urlpatterns = [
     url(r"^organization/$",
         OrganizationListView.as_view(),
         name="organization"),
-    
+
 ]
 
 urls = [

--- a/web/impact/impact/v0/views/job_posting_detail_view.py
+++ b/web/impact/impact/v0/views/job_posting_detail_view.py
@@ -38,7 +38,7 @@ class JobPostingDetailView(APIView):
             image_token = ""
         url = ""
         if job.startup.is_visible:
-            url = base_program_url(program) + job.startup.url_slug
+            url = base_program_url(program) + job.startup.organization.url_slug
         job_data = {"startup_name": job.startup.name,
                     "startup_profile_url": url,
                     "startup_logo_image_token": image_token,

--- a/web/impact/impact/v0/views/job_posting_list_view.py
+++ b/web/impact/impact/v0/views/job_posting_list_view.py
@@ -83,7 +83,7 @@ class JobPostingListView(APIView):
                 image_token = ""
             url = ""
             if job.startup.is_visible:
-                url = base_url + job.startup.url_slug
+                url = base_url + job.startup.organization.url_slug
             joblist.append({"startup_name": job.startup.name,
                             "startup_profile_url": url,
                             "startup_logo_image_token": image_token,

--- a/web/impact/impact/v0/views/startup_list_view.py
+++ b/web/impact/impact/v0/views/startup_list_view.py
@@ -178,7 +178,7 @@ def _startup_description(startup, statuses, base_url):
             "is_visible": True,
             "name": startup.name,
             "id": startup.id,
-            "profile_url": base_url + startup.url_slug,
+            "profile_url": base_url + startup.organization.url_slug,
             "image_token": encrypt_image_token(startup.high_resolution_logo),
             "logo_url": logo_url(startup),
             "statuses": [status_description(status) for status in statuses],

--- a/web/impact/impact/v1/views/__init__.py
+++ b/web/impact/impact/v1/views/__init__.py
@@ -1,2 +1,4 @@
 from impact.v1.views.user_detail_view import UserDetailView
 from impact.v1.views.user_list_view import UserListView
+from impact.v1.views.organization_detail_view import OrganizationDetailView
+from impact.v1.views.organization_list_view import OrganizationListView

--- a/web/impact/impact/v1/views/organization_detail_view.py
+++ b/web/impact/impact/v1/views/organization_detail_view.py
@@ -1,0 +1,42 @@
+from django.contrib.auth import get_user_model
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from impact.permissions import (
+    V1APIPermissions,
+)
+from impact.models import Organization
+from impact.utils import (
+    ALL_USER_RELATED_KEYS,
+    INVALID_GENDER_ERROR,
+    PROFILE_KEYS,
+    USER_KEYS,
+    KEY_TRANSLATIONS,
+    find_gender,
+    get_profile,
+    user_gender,
+)
+
+INVALID_KEYS_ERROR = ("Received invalid key(s): {invalid_keys}. "
+                      "Valid keys are: {valid_keys}.")
+
+
+
+
+class OrganizationDetailView(APIView):
+    model = Organization
+    permission_classes = (
+        V1APIPermissions,
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def get(self, request, pk):
+
+        instance = self.model.objects.get(pk=pk)        
+        fields = ["name", "url_slug",]
+        result = {
+            field: getattr(instance, field) for field in fields}
+        return Response(result)
+

--- a/web/impact/impact/v1/views/organization_detail_view.py
+++ b/web/impact/impact/v1/views/organization_detail_view.py
@@ -1,3 +1,6 @@
+# MIT License
+# Copyright (c) 2017 MassChallenge, Inc.
+
 from django.contrib.auth import get_user_model
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -5,26 +8,39 @@ from rest_framework.views import APIView
 from impact.permissions import (
     V1APIPermissions,
 )
-from impact.models import Organization
-from impact.utils import (
-    ALL_USER_RELATED_KEYS,
-    INVALID_GENDER_ERROR,
-    PROFILE_KEYS,
-    USER_KEYS,
-    KEY_TRANSLATIONS,
-    find_gender,
-    get_profile,
-    user_gender,
+from impact.models import (
+    Organization,
+    Partner,
+    Startup,
 )
 
 INVALID_KEYS_ERROR = ("Received invalid key(s): {invalid_keys}. "
                       "Valid keys are: {valid_keys}.")
 
+def organization_is_startup(organization):
+    return _organization_is(organization, Startup)
 
+def organization_is_partner(organization):
+    return _organization_is(organization, Partner)
+
+def public_inquiry_email(organization):
+    for klass in (Partner, Startup):
+        qs = klass.objects.filter(organization=organization)
+        if qs.exists():
+            return qs.first().public_inquiry_email
+    return ""
+
+def _organization_is(organization, klass):
+    return klass.objects.filter(organization=organization).exists()
 
 
 class OrganizationDetailView(APIView):
     model = Organization
+    model_fields = ["name", "url_slug"]
+    derived_field_functions = {"public_inquiry_email": public_inquiry_email,
+                               "is_startup": organization_is_startup,
+                               "is_partner": organization_is_partner}
+
     permission_classes = (
         V1APIPermissions,
     )
@@ -33,10 +49,15 @@ class OrganizationDetailView(APIView):
         super().__init__(*args, **kwargs)
 
     def get(self, request, pk):
-
-        instance = self.model.objects.get(pk=pk)        
-        fields = ["name", "url_slug",]
-        result = {
-            field: getattr(instance, field) for field in fields}
+        self.instance = self.model.objects.get(pk=pk)
+        result = self.get_model_fields()
+        result.update(self.derived_fields())
         return Response(result)
 
+    def get_model_fields(self):
+        return {field: getattr(self.instance, field)
+                for field in self.model_fields}
+    
+    def derived_fields(self):
+        return {key: func(self.instance)
+                for (key, func) in self.derived_field_functions.items()}

--- a/web/impact/impact/v1/views/organization_detail_view.py
+++ b/web/impact/impact/v1/views/organization_detail_view.py
@@ -1,7 +1,6 @@
 # MIT License
 # Copyright (c) 2017 MassChallenge, Inc.
 
-from django.contrib.auth import get_user_model
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -17,11 +16,14 @@ from impact.models import (
 INVALID_KEYS_ERROR = ("Received invalid key(s): {invalid_keys}. "
                       "Valid keys are: {valid_keys}.")
 
+
 def organization_is_startup(organization):
     return _organization_is(organization, Startup)
 
+
 def organization_is_partner(organization):
     return _organization_is(organization, Partner)
+
 
 def public_inquiry_email(organization):
     for klass in (Partner, Startup):
@@ -29,6 +31,7 @@ def public_inquiry_email(organization):
         if qs.exists():
             return qs.first().public_inquiry_email
     return ""
+
 
 def _organization_is(organization, klass):
     return klass.objects.filter(organization=organization).exists()
@@ -57,7 +60,7 @@ class OrganizationDetailView(APIView):
     def get_model_fields(self):
         return {field: getattr(self.instance, field)
                 for field in self.model_fields}
-    
+
     def derived_fields(self):
         return {key: func(self.instance)
                 for (key, func) in self.derived_field_functions.items()}

--- a/web/impact/impact/v1/views/organization_list_view.py
+++ b/web/impact/impact/v1/views/organization_list_view.py
@@ -40,11 +40,11 @@ class OrganizationListView(APIView):
         return Response({"foo": "bar"})                        
 
 def _results(limit, offset):
-    return [_serialize_org(org)
+    return [serialize_org(org)
             for org in Organization.objects.all()[offset:offset+limit]]
                         
 
-def _serialize_org(org):
+def serialize_org(org):
     return {"id": org.id,
             "name": org.name,
             "url_slug": org.url_slug,

--- a/web/impact/impact/v1/views/organization_list_view.py
+++ b/web/impact/impact/v1/views/organization_list_view.py
@@ -1,7 +1,6 @@
 # MIT License
 # Copyright (c) 2017 MassChallenge, Inc.
 
-from django.contrib.auth import get_user_model
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -14,6 +13,7 @@ from .organization_detail_view import (
     organization_is_partner,
     public_inquiry_email,
 )
+
 
 class OrganizationListView(APIView):
     permission_classes = (
@@ -37,12 +37,13 @@ class OrganizationListView(APIView):
         return Response(result)
 
     def post(self, request):
-        return Response({"foo": "bar"})                        
+        return Response({"foo": "bar"})
+
 
 def _results(limit, offset):
     return [serialize_org(org)
             for org in Organization.objects.all()[offset:offset+limit]]
-                        
+
 
 def serialize_org(org):
     return {"id": org.id,
@@ -51,7 +52,8 @@ def serialize_org(org):
             "public_inquiry_email": public_inquiry_email(org),
             "is_startup": organization_is_startup(org),
             "is_partner": organization_is_partner(org)}
-                        
+
+
 def _url(base_url, limit, offset):
     if offset >= 0:
         return base_url + "?limit={limit}&offset={offset}".format(

--- a/web/impact/impact/v1/views/organization_list_view.py
+++ b/web/impact/impact/v1/views/organization_list_view.py
@@ -1,0 +1,59 @@
+from django.contrib.auth import get_user_model
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from impact.permissions import (
+    V1APIPermissions,
+)
+from impact.models import Organization
+from impact.utils import (
+    find_gender,
+    user_gender,
+    ALL_USER_RELATED_KEYS,
+    INVALID_GENDER_ERROR,
+    KEY_TRANSLATIONS,
+    PROFILE_KEYS,
+    REQUIRED_PROFILE_KEYS,
+    REQUIRED_USER_KEYS,
+    USER_KEYS,
+)
+
+
+class OrganizationListView(APIView):
+    permission_classes = (
+        V1APIPermissions,
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.errors = []
+
+    def get(self, request):
+        limit = int(request.GET.get('limit', 10))
+        offset = int(request.GET.get('offset', 0))
+        base_url = request.build_absolute_uri().split("?")[0]
+        result = {
+            "count": Organization.objects.count(),
+            "next": _url(base_url, limit, offset + limit),
+            "previous": _url(base_url, limit, offset - limit),
+            "results": _results(limit, offset),
+            }
+        return Response(result)
+
+    def post(self, request):
+        return Response({"foo": "bar"})                        
+
+def _results(limit, offset):
+    return [_serialize_org(org)
+            for org in Organization.objects.all()[offset:offset+limit]]
+                        
+
+def _serialize_org(org):
+    return {"id": org.id,
+            "name": org.name}
+                        
+def _url(base_url, limit, offset):
+    if offset >= 0:
+        return base_url + "?limit={limit}&offset={offset}".format(
+            limit=limit, offset=offset)
+    return None

--- a/web/impact/impact/v1/views/organization_list_view.py
+++ b/web/impact/impact/v1/views/organization_list_view.py
@@ -36,9 +36,6 @@ class OrganizationListView(APIView):
             }
         return Response(result)
 
-    def post(self, request):
-        return Response({"foo": "bar"})
-
 
 def _results(limit, offset):
     return [serialize_org(org)

--- a/web/impact/impact/v1/views/organization_list_view.py
+++ b/web/impact/impact/v1/views/organization_list_view.py
@@ -1,3 +1,6 @@
+# MIT License
+# Copyright (c) 2017 MassChallenge, Inc.
+
 from django.contrib.auth import get_user_model
 from rest_framework.response import Response
 from rest_framework.views import APIView

--- a/web/impact/impact/v1/views/organization_list_view.py
+++ b/web/impact/impact/v1/views/organization_list_view.py
@@ -9,18 +9,11 @@ from impact.permissions import (
     V1APIPermissions,
 )
 from impact.models import Organization
-from impact.utils import (
-    find_gender,
-    user_gender,
-    ALL_USER_RELATED_KEYS,
-    INVALID_GENDER_ERROR,
-    KEY_TRANSLATIONS,
-    PROFILE_KEYS,
-    REQUIRED_PROFILE_KEYS,
-    REQUIRED_USER_KEYS,
-    USER_KEYS,
+from .organization_detail_view import (
+    organization_is_startup,
+    organization_is_partner,
+    public_inquiry_email,
 )
-
 
 class OrganizationListView(APIView):
     permission_classes = (
@@ -53,7 +46,11 @@ def _results(limit, offset):
 
 def _serialize_org(org):
     return {"id": org.id,
-            "name": org.name}
+            "name": org.name,
+            "url_slug": org.url_slug,
+            "public_inquiry_email": public_inquiry_email(org),
+            "is_startup": organization_is_startup(org),
+            "is_partner": organization_is_partner(org)}
                         
 def _url(base_url, limit, offset):
     if offset >= 0:


### PR DESCRIPTION
To test: provision an API user, as per the (hah!) documentation

Hit this route to see list view: http://localhost:8000/api/v1/organization/

Use any of the PKs returned to see the detail view. (detail view currently doesn't offer anything more than the list view)

http://localhost:8000/api/v1/organization/ORGANIZATION_ID_HERE