### PR TITLE
[AC-4677-api] Change field definitions to mirror mc models

### DIFF
--- a/web/impact/impact/models/program_role.py
+++ b/web/impact/impact/models/program_role.py
@@ -7,12 +7,15 @@ from impact.models.mc_model import MCModel
 from impact.models.program import Program
 from impact.models.user_role import UserRole
 from impact.models.user_label import UserLabel
-from impact.models.utils import is_managed
+from impact.models.utils import (
+    is_managed,
+    LABEL_LENGTH,
+)
 
 
 class ProgramRole(MCModel):
     program = models.ForeignKey(Program)
-    name = models.CharField(max_length=255, unique=True, db_index=True)
+    name = models.CharField(max_length=LABEL_LENGTH, unique=True, db_index=True)
     user_role = models.ForeignKey(UserRole, null=True, blank=True)
     landing_page = models.CharField(max_length=255, null=True, blank=True)
     newsletter_recipient = models.BooleanField(default=False)

--- a/web/impact/impact/models/program_role.py
+++ b/web/impact/impact/models/program_role.py
@@ -12,7 +12,7 @@ from impact.models.utils import is_managed
 
 class ProgramRole(MCModel):
     program = models.ForeignKey(Program)
-    name = models.CharField(max_length=30, unique=True, db_index=True)
+    name = models.CharField(max_length=255, unique=True, db_index=True)
     user_role = models.ForeignKey(UserRole, null=True, blank=True)
     landing_page = models.CharField(max_length=255, null=True, blank=True)
     newsletter_recipient = models.BooleanField(default=False)

--- a/web/impact/impact/models/utils.py
+++ b/web/impact/impact/models/utils.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2017 MassChallenge, Inc.
 
 
-LABEL_LENGTH = 256
+LABEL_LENGTH = 255
 
 
 def is_managed(db_table):


### PR DESCRIPTION
ProgramRole.name, NamedGroup.name, UserLabel.label, and StartupLabel.label should all have same length

To review: check model changes, verify that migrations (both here and accelerate side) are correct

Note that as of Aug 14 none of the affected fields has a length > 50.