### PR TITLE
[AC-4748] - BLOCKS AC-4670 - Add Django-accelerator, Work Around ImageField issues

### DIFF
--- a/web/impact/impact/tests/test_api_routes.py
+++ b/web/impact/impact/tests/test_api_routes.py
@@ -290,7 +290,6 @@ class TestApiRoute(TestCase):
             "public_inquiry_email": "test@test.com",
             "video_elevator_pitch_url": "http://example.com",
             "user": startup.user.id,
-            "high_resolution_logo": "test",
             "created_datetime": None,
             "last_updated_datetime": None,
             "community": "red",
@@ -304,7 +303,7 @@ class TestApiRoute(TestCase):
             "location_postcode": "test",
             "location_regional": "test",
             "landing_page": "test"
-        })
+        })  # field "high_resolution_logo" was removed, to be solved in AC-4750
         extra = {"content_type": "application/json"}
         put_kwargs = get_kwargs.copy()
         put_kwargs["data"] = data
@@ -348,7 +347,7 @@ class TestApiRoute(TestCase):
         )
         change_startup_permission, _ = Permission.objects.get_or_create(
             content_type=startup_content_type,
-            codename='change_startup',)
+            codename='change_startup', )
         perm_user = self.make_user(
             'perm_user@test.com')
         perm_user.user_permissions.add(startup_permission)

--- a/web/impact/impact/tests/test_v0_utils.py
+++ b/web/impact/impact/tests/test_v0_utils.py
@@ -1,0 +1,24 @@
+# MIT License
+# Copyright (c) 2017 MassChallenge, Inc.
+
+from test_plus.test import TestCase
+from impact.v0.views.utils import (
+    logo_url,
+    pad_slash,
+)
+from impact.tests.factories import StartupFactory
+
+REMOTE_URL = "http://cloud.test.com/logo.jpg"
+
+URL_WITHOUT_TRAILING_SLASH = "http://cloud.test.com"
+
+
+class TestUtils(TestCase):
+    def test_logo_url_returns_url_as_is_if_remote_url(self):
+        startup = StartupFactory(high_resolution_logo=REMOTE_URL)
+
+        assert REMOTE_URL == logo_url(startup)
+
+    def test_pad_slash_pads_slash_correctly(self):
+        assert URL_WITHOUT_TRAILING_SLASH + "/" == pad_slash(
+            URL_WITHOUT_TRAILING_SLASH)

--- a/web/impact/impact/v0/views/utils.py
+++ b/web/impact/impact/v0/views/utils.py
@@ -29,7 +29,7 @@ def encrypt_image_token(token, password=None):
         iv = os.urandom(IMAGE_TOKEN_BLOCK_SIZE)
         key = hashlib.sha256(password).hexdigest()[:32]
         cipher = AES.new(key, AES.MODE_CBC, iv)
-        raw = _pad(token + ":" + str(time()))
+        raw = _pad(str(token) + ":" + str(time()))
         return base64.urlsafe_b64encode((iv + cipher.encrypt(raw)))
     return b""
 
@@ -46,9 +46,9 @@ def logo_url(startup):
     if not startup.high_resolution_logo:
         return ""
     schema = "^(http|https)://"
-    if re.match(schema, startup.high_resolution_logo, re.IGNORECASE):
+    if re.match(schema, str(startup.high_resolution_logo), re.IGNORECASE):
         return startup.high_resolution_logo
-    return BaseMediaInfo.url(startup.high_resolution_logo)
+    return BaseMediaInfo.url(str(startup.high_resolution_logo))
 
 
 def status_description(status):

--- a/web/impact/requirements/base.txt
+++ b/web/impact/requirements/base.txt
@@ -31,6 +31,7 @@ django-registration
 django-filter # Filtering support
 django-oauth-toolkit
 django-cors-middleware==1.3.1
+git+https://github.com/masschallenge/django-accelerator.git@10ffd6f42749257a9c1b9a752ee97e3645224de8#egg=django-accelerator
 
 # django-configurations from Git master (needed for Django 1.8 support)
 git+https://github.com/jezdez/django-configurations


### PR DESCRIPTION
**Changes introduced:**

- add django-accelerator to requirements (as prep for AC-4670)
- fix or workaround all issues created by Startup.high_resolution_logo being parsed as an ImageField.

**Test:**
- tests are running, coverage is 100%.
- this [Postman Collection](https://www.getpostman.com/collections/e20616ae9b0b627db313) works correctly (instructions for setup are now available in `QUICK_START.md` in #21 (and soon in development)). 
- See notes below as of what to expect functionally and re code changes.

**Notes:**
- This is issue blocks AC-4670, and is a work around. This introduces a functional degradation - we now can't do Startup Patch with "high_resolution_logo" input (which is optional). This is approved by @mc-nathan, and is marked for sorting out in a follow on ticket [AC-4750](https://masschallenge.atlassian.net/browse/AC-4750).