### PR TITLE
[AC-4795] Failure when loading Jim Miller's history

### DIFF
--- a/web/impact/impact/v1/events/base_user_role_grant_event.py
+++ b/web/impact/impact/v1/events/base_user_role_grant_event.py
@@ -45,8 +45,10 @@ class BaseUserRoleGrantEvent(object):
         if result:
             return (result, result)
         program = self.program_role_grant.program_role.program
-        earliest = max(program.cycle.application_final_deadline_date,
-                       self.program_role_grant.person.date_joined)
+        earliest = self.program_role_grant.person.date_joined
+        deadline = program.cycle.application_final_deadline_date
+        if deadline and deadline > earliest:
+            earliest = deadline
         latest = utc.localize(datetime.now())
         prg_with_created_at = next_instance(self.program_role_grant,
                                             Q(created_at__isnull=False))


### PR DESCRIPTION
To test:
- Load the clean database and [grant a superuser account v1_clients permission](https://github.com/masschallenge/impact-api/blob/development/README.md#granting-permissions)
- Login as that user and go to http://localhost:8000/api/v1/user/182/history
- On development you'll get 500/stack trace
- On the branch it provides a reasonable response
