### PR TITLE
Ac 4788: Move django-accelerator to the 2017.09.06a release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ target_help = \
 
 
 dbload_error_msg = GZ_FILE must be set. \
-  E.g. 'make dbload GZ_FILE=../accelerate/test_data/initial_schema.sql.gz'
+  E.g. 'make dbload GZ_FILE=../accelerate/db_cache/initial_schema.sql.gz'
 
 grant_permissions_error_msg = PERMISSION_USER and PERMISSION_CLASSES must be \
   set.  E.g., 'make grant-permissions PERMISSION_USER=test@example.org PERMISSION_CLASSES=v0_clients'

--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -68,7 +68,7 @@ you have an up-to-date accelerate source code directory next to
 the impact-api directory, the following should work:
 
 ```
-make dbload GZ_FILE=../accelerate/test_data/initial_schema.sql.gz
+make dbload GZ_FILE=../accelerate/db_cache/initial_schema.sql.gz
 ```
 
 6. Create a new superuser account:

--- a/web/impact/requirements/base.txt
+++ b/web/impact/requirements/base.txt
@@ -32,7 +32,7 @@ django-registration
 django-filter # Filtering support
 django-oauth-toolkit
 django-cors-middleware==1.3.1
-git+https://github.com/masschallenge/django-accelerator.git@master#egg=django-accelerator
+git+https://github.com/masschallenge/django-accelerator.git@2017.09.06a#egg=django-accelerator
 
 # django-configurations from Git master (needed for Django 1.8 support)
 git+https://github.com/jezdez/django-configurations


### PR DESCRIPTION
```
make clean
make build
make dbload GZ_FILE=../accelerate/db_cache/initial_schema.sql.gz
```
will report "Applying accelerator.0004_update_organization_url_slug" on the branch.  On development it will not run that migration.

Also the help text for reloading the database has /db_cache/ rather than /test_data/ on the branch vs. development.
