### PR TITLE
[AC-4477] - Switch to using S3 clean database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,5 +186,6 @@ local_settings.py
 mysql/data/
 web/impact/.coverage
 web/impact/htmlcov/
+db_cache/
 *~
 *.orig

--- a/Makefile
+++ b/Makefile
@@ -243,3 +243,12 @@ endif
 	@docker push $(DOCKER_REGISTRY)/redis:$(IMAGE_TAG)
 	@ecs-cli compose -f docker-compose.prod.yml down
 	@ecs-cli compose -f docker-compose.prod.yml up
+
+dbdump:
+	@echo ERROR: dbdump has been replaced by db-dump
+
+dbload:
+	@echo ERROR: dbload has been replaced by load-db
+
+dbshell:
+	@echo ERROR: dbshell has been replaced by db-shell

--- a/Makefile
+++ b/Makefile
@@ -194,10 +194,10 @@ endif
 	@gzcat $(GZ_FILE) | docker-compose run --rm web ./manage.py dbshell
 	@docker-compose run --rm web ./manage.py migrate --no-input
 
-db_cache:
+${DB_CACHE_DIR}:
 	mkdir -p ${DB_CACHE_DIR}
 
-fetch-remote-db: db_cache
+fetch-remote-db: ${DB_CACHE_DIR}
 fetch-remote-db:
 ifndef DB_FILE_NAME
 	$(error $(fetch_remote_db_error_msg))


### PR DESCRIPTION
**Changes Introduced in [AC-4477](https://masschallenge.atlassian.net/browse/AC-4477):**
- add target fetchremotedb, that removes existing cache and downloads
  an up to date copy of the DB_FILE_NAME specified.
- update dbload_error_msg to expect a db to exist in ./db_cache/
- update gitignore to exclude ./db_cache/

**Test:**
- run `make load-remote-db`. You'll get a descriptive error message. Also, **./db_cache/** will be created if it doesn't exist yet.
- run `make load-remote-db DB_FILE_NAME=initial_schema.sql.gz`. This will start a download of the given file, and once the file is downloaded, that file will be loaded to the DB.
- if you run the same command again, the existing local copy will be removed first.
-in a different terminal, run `make dev`
- run `make load-db GZ_FILE=./db_cache/initial_schema.sql.gz`, should work as usual (note that it was renamed).

you can also test:
- `make dbload` shows an error message re rename. Also `make dbshell` and `make dbdump`.
- running `make fetch-remote-db` will do a download only, without loading the DB.
