### PR TITLE
[AC-4897] "count" field in list views should reflect size of full result set

### DIFF
--- a/web/impact/impact/tests/test_organization_list_view.py
+++ b/web/impact/impact/tests/test_organization_list_view.py
@@ -18,7 +18,6 @@ import pytz
 
 
 class TestOrganizationListView(APITestCase):
-
     def test_get_startup(self):
         count = 5
         startups = StartupFactory.create_batch(count)
@@ -40,6 +39,16 @@ class TestOrganizationListView(APITestCase):
             assert all([OrganizationHelper(partner.organization).serialize()
                         in response.data['results']
                         for partner in partners])
+
+    def test_get_with_limit(self):
+        count = 5
+        StartupFactory.create_batch(count)
+        with self.login(username=self.basic_user().username):
+            limit = 2
+            url = reverse("organization") + "?limit=%s" % limit
+            response = self.client.get(url)
+            assert response.data['count'] == count
+            assert len(response.data['results']) == limit
 
     def test_updated_at_lt_datetime_filter(self):
         count = 5

--- a/web/impact/impact/tests/test_user_list_view.py
+++ b/web/impact/impact/tests/test_user_list_view.py
@@ -32,10 +32,25 @@ class TestUserListView(APITestCase):
         user2 = UserContext().user
         with self.login(username=self.basic_user().username):
             url = reverse("user")
+            user_count = User.objects.count()
             response = self.client.get(url)
+            results = response.data["results"]
+            assert user_count == min(len(results), 10)
             emails = [result["email"] for result in response.data["results"]]
             assert user1.email in emails
             assert user2.email in emails
+            assert user_count == response.data["count"]
+
+    def test_get_with_limit(self):
+        UserContext().user
+        UserContext().user
+        with self.login(username=self.basic_user().username):
+            url = reverse("user") + "?limit=1"
+            user_count = User.objects.count()
+            response = self.client.get(url)
+            results = response.data["results"]
+            assert 1 == len(results)
+            assert user_count == response.data["count"]
 
     def test_post(self):
         with self.login(username=self.basic_user().username):

--- a/web/impact/impact/v1/views/base_list_view.py
+++ b/web/impact/impact/v1/views/base_list_view.py
@@ -31,9 +31,9 @@ class BaseListView(LoggingMixin, APIView):
         limit = int(request.GET.get('limit', 10))
         offset = int(request.GET.get('offset', 0))
         base_url = request.build_absolute_uri().split("?")[0]
-        results = self._results(limit, offset)
+        count, results = self._results(limit, offset)
         result = {
-            "count": len(results),
+            "count": count,
             "next": _url(base_url, limit, offset + limit),
             "previous": _url(base_url, limit, offset - limit),
             "results": results,
@@ -46,8 +46,10 @@ class BaseListView(LoggingMixin, APIView):
         updated_at_lt = self.request.query_params.get('updated_at__lt', None)
         if updated_at_gt or updated_at_lt:
             queryset = _filter_by_date(queryset, updated_at_gt, updated_at_lt)
-        return [self.helper_class(obj).serialize()
-                for obj in queryset[offset:offset + limit]]
+        count = queryset.count()
+        return (count,
+                [self.helper_class(obj).serialize()
+                 for obj in queryset[offset:offset + limit]])
 
 
 def _filter_by_date(queryset, updated_at_gt, updated_at_lt):

--- a/web/impact/impact/v1/views/user_list_view.py
+++ b/web/impact/impact/v1/views/user_list_view.py
@@ -84,9 +84,10 @@ class UserListView(BaseListView):
                 queryset,
                 updated_at_gt,
                 updated_at_lt)
-        return [
-            UserHelper(user).serialize()
-            for user in queryset[offset:offset + limit]]
+        count = queryset.count()
+        return (count,
+                [UserHelper(user).serialize()
+                 for user in queryset[offset:offset + limit]])
 
 
 def _filter_profiles_by_date(queryset, updated_at_gt, updated_at_lt):


### PR DESCRIPTION
To test:
- resetremotedb (`make load-remote-db DB_FILE_NAME=initial_schema.sql.gz`)
- Go to http://localhost:8000/api/v1/organization/?limit=5
- On development the count field is 5, but on the branch it's 20247
- Try the same thing with http://localhost:8000/api/v1/user/?limit=5
- On development the count field is 5, but on the branch it's 46186
