### PR TITLE
[AC-4899] Fix date filters for list views

### DIFF
--- a/web/impact/impact/utils.py
+++ b/web/impact/impact/utils.py
@@ -3,6 +3,7 @@
 from datetime import datetime
 from pytz import utc
 from impact.models import BaseProfile
+from django.db import connection
 from django.db.models import Q
 from django.utils.formats import get_format
 import dateutil.parser
@@ -11,6 +12,15 @@ import dateutil.parser
 DAWN_OF_TIME = utc.localize(datetime.strptime(
         "2010-01-01T00:00:00Z",
         "%Y-%m-%dT%H:%M:%SZ"))  # format based on browsable API output
+
+UPDATE_STATEMENT = "UPDATE {table} SET updated_at = %s WHERE id = %s"
+
+
+def override_updated_at(model, value):
+    # Yes, this big of stick is needed to change the update_at field
+    with connection.cursor() as cursor:
+        sql = UPDATE_STATEMENT.format(table=model._meta.db_table)
+        cursor.execute(sql, [value, model.id])
 
 
 def parse_date(date_str):

--- a/web/impact/impact/v1/views/user_list_view.py
+++ b/web/impact/impact/v1/views/user_list_view.py
@@ -77,41 +77,34 @@ class UserListView(BaseListView):
 
     def _results(self, limit, offset):
         queryset = User.objects.all()
-        updated_at_gt = self.request.query_params.get('updated_at__gt', None)
-        updated_at_lt = self.request.query_params.get('updated_at__lt', None)
-        if updated_at_gt or updated_at_lt:
+        updated_at_after = self.request.query_params.get(
+            'updated_at.after', None)
+        updated_at_before = self.request.query_params.get(
+            'updated_at.before', None)
+        if updated_at_after or updated_at_before:
             queryset = _filter_profiles_by_date(
                 queryset,
-                updated_at_gt,
-                updated_at_lt)
+                updated_at_after,
+                updated_at_before)
         count = queryset.count()
         return (count,
                 [UserHelper(user).serialize()
                  for user in queryset[offset:offset + limit]])
 
 
-def _filter_profiles_by_date(queryset, updated_at_gt, updated_at_lt):
-    updated_at_gt = parse_date(updated_at_gt)
-    updated_at_lt = parse_date(updated_at_lt)
-    if updated_at_lt:
+def _filter_profiles_by_date(queryset, updated_at_after, updated_at_before):
+    updated_at_after = parse_date(updated_at_after)
+    updated_at_before = parse_date(updated_at_before)
+    if updated_at_after:
         queryset = queryset.filter(
-            Q(expertprofile__updated_at__isnull=False) |
-            Q(entrepreneurprofile__updated_at__isnull=False) |
-            Q(memberprofile__updated_at__isnull=False)
-        ).exclude(
-            Q(expertprofile__updated_at__gte=updated_at_lt) |
-            Q(entrepreneurprofile__updated_at__gte=updated_at_lt) |
-            Q(memberprofile__updated_at__gte=updated_at_lt)
-        )
-    if updated_at_gt:
-        queryset.filter(
-            Q(expertprofile__updated_at__isnull=False) |
-            Q(entrepreneurprofile__updated_at__isnull=False) |
-            Q(memberprofile__updated_at__isnull=False)
-        ).exclude(
-            Q(expertprofile__updated_at__lte=updated_at_gt) |
-            Q(entrepreneurprofile__updated_at__lte=updated_at_gt) |
-            Q(memberprofile__updated_at__lte=updated_at_gt)
+            Q(expertprofile__updated_at__gte=updated_at_after) |
+            Q(entrepreneurprofile__updated_at__gte=updated_at_after) |
+            Q(memberprofile__updated_at__gte=updated_at_after))
+    if updated_at_before:
+        queryset = queryset.exclude(
+            Q(expertprofile__updated_at__gt=updated_at_before) |
+            Q(entrepreneurprofile__updated_at__gt=updated_at_before) |
+            Q(memberprofile__updated_at__gt=updated_at_before)
         )
     return queryset
 


### PR DESCRIPTION
Work done:
- Switched from update_at__gt and update_at__lt to update_at.after and update_at.before.
- Ensure that the expected results are right (per ticket).

To test:
On the branch with URLs like http://localhost:8000/api/v1/user/?update_at.after=<date>, http://localhost:8000/api/v1/organization/?update_at.before=<date> until you are satisfied that they are return reasonable sets.  In most cases the updated_at.after and update_at.before sets for a given resource should be distinct unless there happens to be an element right on the date given.  Resources that for historical reasons have updated_at set to None should end up in the .before set.

Note: The industry resource does not work since it does not yet have an updated_at date.