### PR TITLE
Ac 4875: GET API Calls for Black Iron

### DIFF
--- a/web/impact/impact/permissions.py
+++ b/web/impact/impact/permissions.py
@@ -33,6 +33,15 @@ class V1APIPermissions(BasePermission):
             name=settings.V1_API_GROUP).exists()
 
 
+class V1ConfidentialAPIPermissions(BasePermission):
+
+    authenticated_users_only = True
+
+    def has_permission(self, request, view):
+        return request.user.groups.filter(
+            name=settings.V1_CONFIDENTIAL_API_GROUP).exists()
+
+
 class DynamicModelPermissions(BasePermission):
     perms_map = {
         'GET': ['%(app)s.view_%(model_name)s'],

--- a/web/impact/impact/settings.py
+++ b/web/impact/impact/settings.py
@@ -147,6 +147,8 @@ class Base(Configuration):
     V1_API_GROUP = bytes(os.environ.get(
         'IMPACT_API_V1_API_GROUP', 'v1_clients'), 'utf-8')
 
+    V1_CONFIDENTIAL_API_GROUP = 'v1_confidential', 'utf-8'
+
     OAUTH2_PROVIDER = {
         # this is the list of available scopes
         'SCOPES': {

--- a/web/impact/impact/tests/api_test_case.py
+++ b/web/impact/impact/tests/api_test_case.py
@@ -3,11 +3,12 @@
 
 import simplejson as json
 from oauth2_provider.models import get_application_model
-
 from rest_framework.test import APIClient
 from test_plus.test import TestCase
-from django.contrib.auth.models import Group
+
 from django.conf import settings
+from django.contrib.auth.models import Group
+
 from impact.tests.factories import UserFactory
 
 OAuth_App = get_application_model()

--- a/web/impact/impact/tests/test_program_family_detail_view.py
+++ b/web/impact/impact/tests/test_program_family_detail_view.py
@@ -1,0 +1,18 @@
+# MIT License
+# Copyright (c) 2017 MassChallenge, Inc.
+
+from django.urls import reverse
+
+from impact.tests.factories import ProgramFamilyFactory
+from impact.tests.api_test_case import APITestCase
+
+
+class TestProgramFamilyDetailView(APITestCase):
+    def test_get(self):
+        program_family = ProgramFamilyFactory()
+        with self.login(username=self.basic_user().username):
+            url = reverse("program_family_detail", args=[program_family.id])
+            response = self.client.get(url)
+            assert response.data["name"] == program_family.name
+            assert (response.data["short_description"] ==
+                    program_family.short_description)

--- a/web/impact/impact/tests/test_program_family_list_view.py
+++ b/web/impact/impact/tests/test_program_family_list_view.py
@@ -1,0 +1,20 @@
+# MIT License
+# Copyright (c) 2017 MassChallenge, Inc.
+
+from django.urls import reverse
+from impact.tests.factories import ProgramFamilyFactory
+from impact.tests.api_test_case import APITestCase
+from impact.v1.helpers import ProgramFamilyHelper
+
+
+class TestProgramFamilyListView(APITestCase):
+    def test_get(self):
+        count = 5
+        program_families = ProgramFamilyFactory.create_batch(count)
+        with self.login(username=self.basic_user().username):
+            url = reverse("program_family")
+            response = self.client.get(url)
+            assert response.data["count"] == count
+            assert all([ProgramFamilyHelper(program_family).serialize()
+                        in response.data["results"]
+                        for program_family in program_families])

--- a/web/impact/impact/tests/test_schema_endpoints.py
+++ b/web/impact/impact/tests/test_schema_endpoints.py
@@ -3,12 +3,10 @@
 
 from django.urls import reverse
 from impact.tests.api_test_case import APITestCase
-from impact.v1.metadata import (
-    ORGANIZATION_ACTIONS,
-    USER_ORGANIZATION_ACTIONS,
-    ORGANIZATION_USER_ACTIONS,
-    USER_ACTIONS
-)
+from impact.v1.views.organization_detail_view import OrganizationDetailView
+from impact.v1.views.organization_users_view import OrganizationUsersView
+from impact.v1.views.user_organizations_view import UserOrganizationsView
+from impact.v1.views.user_detail_view import UserDetailView
 from impact.tests.factories import (
     StartupFactory
 )
@@ -26,7 +24,7 @@ class TestSchemaEndpoints(APITestCase):
             response = self.client.options(url)
         response_json = json.loads(response.content)
         self.assertTrue(
-            ORGANIZATION_ACTIONS[
+            OrganizationDetailView.METADATA_ACTIONS[
                 'GET'].keys() == response_json['actions']['GET'].keys()
         )
 
@@ -39,7 +37,7 @@ class TestSchemaEndpoints(APITestCase):
             response = self.client.options(url)
         response_json = json.loads(response.content)
         self.assertTrue(
-            ORGANIZATION_USER_ACTIONS[
+            OrganizationUsersView.METADATA_ACTIONS[
                 'GET'].keys() == response_json['actions']['GET'].keys()
         )
 
@@ -52,7 +50,7 @@ class TestSchemaEndpoints(APITestCase):
             response = self.client.options(url)
         response_json = json.loads(response.content)
         self.assertTrue(
-            USER_ORGANIZATION_ACTIONS[
+            UserOrganizationsView.METADATA_ACTIONS[
                 'GET'].keys() == response_json['actions']['GET'].keys()
         )
 
@@ -65,6 +63,6 @@ class TestSchemaEndpoints(APITestCase):
             response = self.client.options(url)
         response_json = json.loads(response.content)
         self.assertTrue(
-            USER_ACTIONS[
+            UserDetailView.METADATA_ACTIONS[
                 'GET'].keys() == response_json['actions']['GET'].keys()
         )

--- a/web/impact/impact/tests/test_user_confidential_view.py
+++ b/web/impact/impact/tests/test_user_confidential_view.py
@@ -1,0 +1,40 @@
+# MIT License
+# Copyright (c) 2017 MassChallenge, Inc.
+
+from django.conf import settings
+from django.contrib.auth.models import Group
+from django.urls import reverse
+
+from impact.tests.factories import ExpertFactory
+from impact.tests.api_test_case import APITestCase
+
+TEST_EXPERT_GROUP = "11"
+TEST_INTERNAL_NOTES = "Amazing!"
+
+
+class TestUserConfidentialView(APITestCase):
+    def privileged_user(self):
+        user = self.basic_user()
+        name = settings.V1_CONFIDENTIAL_API_GROUP
+        group, _ = Group.objects.get_or_create(name=name)
+        user.groups.add(group)
+        return user
+
+    def test_basic_user_cannot_access(self):
+        user = ExpertFactory()
+        with self.login(username=self.basic_user().username):
+            url = reverse("user_confidential", args=[user.id])
+            response = self.client.get(url)
+            self.assertEqual(403, response.status_code)
+
+    def test_privileged_user_can_access(self):
+        user = ExpertFactory(profile__expert_group=TEST_EXPERT_GROUP,
+                             profile__internal_notes=TEST_INTERNAL_NOTES)
+        with self.login(username=self.privileged_user().username):
+            url = reverse("user_confidential", args=[user.id])
+            response = self.client.get(url)
+            self.assertEqual(200, response.status_code)
+            self.assertEqual(TEST_EXPERT_GROUP,
+                             response.data["expert_group"])
+            self.assertEqual(TEST_INTERNAL_NOTES,
+                             response.data["internal_notes"])

--- a/web/impact/impact/tests/test_user_history_view.py
+++ b/web/impact/impact/tests/test_user_history_view.py
@@ -178,7 +178,7 @@ class TestUserHistoryView(APITestCase):
                                                   id=jr.id),
                              events[0]["description"])
             self.assertEqual(jr.id, events[0]["judging_round_id"])
-            self.assertEqual(str(jr), events[0]["judging_round_name"])
+            self.assertEqual(jr.short_name(), events[0]["judging_round_name"])
 
     def test_user_became_confirmed_judge_with_cycle_based_judging_round(self):
         prg = ProgramRoleGrantFactory(

--- a/web/impact/impact/tests/test_user_history_view.py
+++ b/web/impact/impact/tests/test_user_history_view.py
@@ -175,6 +175,8 @@ class TestUserHistoryView(APITestCase):
             self.assertEqual(format_string.format(name=jr.short_name(),
                                                   id=jr.id),
                              events[0]["description"])
+            self.assertEqual(jr.id, events[0]["judging_round_id"])
+            self.assertEqual(str(jr), events[0]["judging_round_name"])
 
     def test_user_became_confirmed_judge_with_cycle_based_judging_round(self):
         prg = ProgramRoleGrantFactory(

--- a/web/impact/impact/urls.py
+++ b/web/impact/impact/urls.py
@@ -28,6 +28,7 @@ from impact.v1.views import (
     OrganizationUsersView,
     ProgramFamilyDetailView,
     ProgramFamilyListView,
+    UserConfidentialView,
     UserDetailView,
     UserHistoryView,
     UserListView,
@@ -102,6 +103,9 @@ v1_urlpatterns = [
         ProgramFamilyListView.as_view(),
         name="program_family"),
 
+    url(r"^user/(?P<pk>[0-9]+)/confidential/$",
+        UserConfidentialView.as_view(),
+        name="user_confidential"),
     url(r"^user/(?P<pk>[0-9]+)/$",
         UserDetailView.as_view(),
         name="user_detail"),

--- a/web/impact/impact/urls.py
+++ b/web/impact/impact/urls.py
@@ -26,6 +26,8 @@ from impact.v1.views import (
     OrganizationHistoryView,
     OrganizationListView,
     OrganizationUsersView,
+    ProgramFamilyDetailView,
+    ProgramFamilyListView,
     UserDetailView,
     UserHistoryView,
     UserListView,
@@ -92,6 +94,13 @@ v1_urlpatterns = [
     url(r"^organization/(?P<pk>[0-9]+)/users/$",
         OrganizationUsersView.as_view(),
         name="organization_users"),
+
+    url(r"^program_family/(?P<pk>[0-9]+)/$",
+        ProgramFamilyDetailView.as_view(),
+        name="program_family_detail"),
+    url(r"^program_family/$",
+        ProgramFamilyListView.as_view(),
+        name="program_family"),
 
     url(r"^user/(?P<pk>[0-9]+)/$",
         UserDetailView.as_view(),

--- a/web/impact/impact/v1/events/__init__.py
+++ b/web/impact/impact/v1/events/__init__.py
@@ -20,3 +20,6 @@ from impact.v1.events.user_became_finalist_event import (
 )
 from impact.v1.events.user_created_event import UserCreatedEvent
 from impact.v1.events.user_joined_startup_event import UserJoinedStartupEvent
+from impact.v1.events.user_received_newsletter_event import (
+    UserReceivedNewsletterEvent,
+)

--- a/web/impact/impact/v1/events/user_became_confirmed_judge_event.py
+++ b/web/impact/impact/v1/events/user_became_confirmed_judge_event.py
@@ -32,6 +32,6 @@ class UserBecameConfirmedJudgeEvent(BaseUserRoleGrantEvent):
         if self.judging_round:
             result.update({
                     "judging_round_id": self.judging_round.id,
-                    "judging_round_name": str(self.judging_round),
+                    "judging_round_name": self.judging_round.short_name(),
                     })
         return result

--- a/web/impact/impact/v1/events/user_became_confirmed_judge_event.py
+++ b/web/impact/impact/v1/events/user_became_confirmed_judge_event.py
@@ -10,15 +10,28 @@ class UserBecameConfirmedJudgeEvent(BaseUserRoleGrantEvent):
     EVENT_TYPE = "became confirmed judge"
     USER_ROLE = UserRole.JUDGE
 
-    def description(self):
-        program_role = self.program_role_grant.program_role
-        label = program_role.user_label
+    def __init__(self, program_role_grant):
+        super(UserBecameConfirmedJudgeEvent, self).__init__(program_role_grant)
+        self.judging_round = None
+        label = program_role_grant.program_role.user_label
         if label:
-            judging_round = label.rounds_confirmed_for.first()
-            if judging_round:
-                return self.JUDGING_ROUND_FORMAT.format(
-                    name=judging_round.short_name(),
-                    id=judging_round.id)
+            self.judging_round = label.rounds_confirmed_for.first()
+
+    def description(self):
+        if self.judging_round:
+            return self.JUDGING_ROUND_FORMAT.format(
+                name=self.judging_round.short_name(),
+                id=self.judging_round.id)
+        program_role = self.program_role_grant.program_role
         return self.PROGRAM_ROLE_FORMAT.format(
             name=program_role.name,
             id=program_role.id)
+
+    def serialize(self):
+        result = super(UserBecameConfirmedJudgeEvent, self).serialize()
+        if self.judging_round:
+            result.update({
+                    "judging_round_id": self.judging_round.id,
+                    "judging_round_name": str(self.judging_round),
+                    })
+        return result

--- a/web/impact/impact/v1/events/user_received_newsletter_event.py
+++ b/web/impact/impact/v1/events/user_received_newsletter_event.py
@@ -1,0 +1,31 @@
+from django.contrib.auth import get_user_model
+
+User = get_user_model()
+
+
+class UserReceivedNewsletterEvent(object):
+    EVENT_TYPE = "user received newsletter"
+    RECEIVED_NEWSLETTER_FORMAT = "Received {name} newsletter"
+
+    def __init__(self, receipt):
+        self.receipt = receipt
+
+    @classmethod
+    def events(cls, user):
+        result = []
+        for receipt in user.newsletterreceipt_set.all():
+            result.append(cls(receipt))
+        return result
+
+    def serialize(self):
+        return {
+            "datetime": self._datetime(),
+            "event_type": self.EVENT_TYPE,
+            "description": self.RECEIVED_NEWSLETTER_FORMAT.format(
+                name=self.receipt.newsletter.name),
+            "newsletter_name": self.receipt.newsletter.name,
+            "newsletter_from_address": self.receipt.newsletter.from_addr,
+            }
+
+    def _datetime(self):
+        return self.receipt.created_at or self.receipt.newsletter.date_mailed

--- a/web/impact/impact/v1/helpers/__init__.py
+++ b/web/impact/impact/v1/helpers/__init__.py
@@ -5,6 +5,7 @@ from impact.v1.helpers.profile_helper import (
     ProfileHelper,
     find_gender,
 )
+from impact.v1.helpers.program_family_helper import ProgramFamilyHelper
 from impact.v1.helpers.user_helper import (
     UserHelper,
 )

--- a/web/impact/impact/v1/helpers/industry_helper.py
+++ b/web/impact/impact/v1/helpers/industry_helper.py
@@ -1,10 +1,21 @@
 from impact.models import Industry
 from impact.v1.helpers.model_helper import ModelHelper
+from impact.v1.metadata import (
+    OPTIONAL_ID_TYPE,
+    OPTIONAL_STRING_TYPE,
+    PK_TYPE,
+)
 
 
 class IndustryHelper(ModelHelper):
     MODEL = Industry
 
+    DETAIL_METADATA = {
+        "id": PK_TYPE,
+        "name": OPTIONAL_STRING_TYPE,
+        "full_name": OPTIONAL_STRING_TYPE,
+        "parent_id": OPTIONAL_ID_TYPE,
+        }
     REQUIRED_KEYS = ["name"]
     OPTIONAL_KEYS = ["parent_id"]
     INPUT_KEYS = REQUIRED_KEYS + OPTIONAL_KEYS

--- a/web/impact/impact/v1/helpers/model_helper.py
+++ b/web/impact/impact/v1/helpers/model_helper.py
@@ -2,9 +2,10 @@ class ModelHelper(object):
     def __init__(self, subject):
         self.subject = subject
 
-    def serialize(self):
+    def serialize(self, fields=None):
+        fields = fields or self.OUTPUT_KEYS
         result = {}
-        for field in self.OUTPUT_KEYS:
+        for field in fields:
             value = self.field_value(field)
             if value is not None:
                 result[field] = value

--- a/web/impact/impact/v1/helpers/organization_helper.py
+++ b/web/impact/impact/v1/helpers/organization_helper.py
@@ -1,10 +1,41 @@
 from impact.models import Organization
 from impact.v1.helpers.model_helper import ModelHelper
+from impact.v1.metadata import (
+    OPTIONAL_STRING_TYPE,
+    OPTIONAL_BOOLEAN_TYPE,
+    OPTIONAL_DATE_TYPE,
+    OPTIONAL_LIST_TYPE,
+    OPTIONAL_ID_TYPE,
+    PK_TYPE,
+)
 
 
 class OrganizationHelper(ModelHelper):
     MODEL = Organization
 
+    DETAIL_METADATA = {
+        "id": PK_TYPE,
+        "name": OPTIONAL_STRING_TYPE,
+        "url_slug": OPTIONAL_STRING_TYPE,
+        "additional_industry_ids": OPTIONAL_LIST_TYPE,
+        "date_founded": OPTIONAL_DATE_TYPE,
+        "facebook_url": OPTIONAL_STRING_TYPE,
+        "full_elevator_pitch": OPTIONAL_STRING_TYPE,
+        "primary_industry_id": OPTIONAL_ID_TYPE,
+        "public_inquiry_email": OPTIONAL_STRING_TYPE,
+        "linked_in_url": OPTIONAL_STRING_TYPE,
+        "location_city": OPTIONAL_STRING_TYPE,
+        "location_national": OPTIONAL_STRING_TYPE,
+        "location_postcode": OPTIONAL_STRING_TYPE,
+        "location_regional": OPTIONAL_STRING_TYPE,
+        "short_pitch": OPTIONAL_STRING_TYPE,
+        "twitter_handle": OPTIONAL_STRING_TYPE,
+        "video_elevator_pitch_url": OPTIONAL_STRING_TYPE,
+        "website_url": OPTIONAL_STRING_TYPE,
+        "is_startup": OPTIONAL_BOOLEAN_TYPE,
+        "is_partner": OPTIONAL_BOOLEAN_TYPE,
+        "updated_at": OPTIONAL_DATE_TYPE,
+    }
     REQUIRED_KEYS = [
         "name",
         "url_slug",

--- a/web/impact/impact/v1/helpers/program_family_helper.py
+++ b/web/impact/impact/v1/helpers/program_family_helper.py
@@ -1,7 +1,6 @@
 from impact.models import ProgramFamily
 from impact.v1.helpers.model_helper import ModelHelper
 from impact.v1.metadata import (
-    OPTIONAL_ID_TYPE,
     OPTIONAL_STRING_TYPE,
     PK_TYPE,
 )

--- a/web/impact/impact/v1/helpers/program_family_helper.py
+++ b/web/impact/impact/v1/helpers/program_family_helper.py
@@ -1,0 +1,33 @@
+from impact.models import ProgramFamily
+from impact.v1.helpers.model_helper import ModelHelper
+from impact.v1.metadata import (
+    OPTIONAL_ID_TYPE,
+    OPTIONAL_STRING_TYPE,
+    PK_TYPE,
+)
+
+
+class ProgramFamilyHelper(ModelHelper):
+    MODEL = ProgramFamily
+
+    DETAIL_METADATA = {
+        "id": PK_TYPE,
+        "name": OPTIONAL_STRING_TYPE,
+        "email_domain": OPTIONAL_STRING_TYPE,
+        "phone_number": OPTIONAL_STRING_TYPE,
+        "short_description": OPTIONAL_STRING_TYPE,
+        "url_slug": OPTIONAL_STRING_TYPE,
+        }
+
+    REQUIRED_KEYS = ["name"]
+    OPTIONAL_KEYS = ["email_domain",
+                     "phone_number",
+                     "short_description",
+                     "url_slug"]
+    INPUT_KEYS = REQUIRED_KEYS + OPTIONAL_KEYS
+    READ_ONLY_KEYS = ["id"]
+    OUTPUT_KEYS = READ_ONLY_KEYS + INPUT_KEYS
+
+    @property
+    def full_name(self):
+        return str(self.subject)

--- a/web/impact/impact/v1/helpers/program_family_helper.py
+++ b/web/impact/impact/v1/helpers/program_family_helper.py
@@ -26,7 +26,3 @@ class ProgramFamilyHelper(ModelHelper):
     INPUT_KEYS = REQUIRED_KEYS + OPTIONAL_KEYS
     READ_ONLY_KEYS = ["id"]
     OUTPUT_KEYS = READ_ONLY_KEYS + INPUT_KEYS
-
-    @property
-    def full_name(self):
-        return str(self.subject)

--- a/web/impact/impact/v1/helpers/user_helper.py
+++ b/web/impact/impact/v1/helpers/user_helper.py
@@ -9,6 +9,8 @@ from impact.v1.metadata import (
     OPTIONAL_DATE_TYPE,
     OPTIONAL_LIST_TYPE,
     OPTIONAL_ID_TYPE,
+    PK_TYPE,
+    READ_ONLY_STRING_TYPE,
 )
 
 
@@ -36,9 +38,9 @@ USER_GET_OPTIONS = USER_POST_OPTIONS.copy()
 USER_GET_OPTIONS.update(
     {
         "id": PK_TYPE,
-        "updated_at": READ_ONLY_STRING,
-        "last_login": READ_ONLY_STRING,
-        "date_joined": READ_ONLY_STRING,
+        "updated_at": READ_ONLY_STRING_TYPE,
+        "last_login": READ_ONLY_STRING_TYPE,
+        "date_joined": READ_ONLY_STRING_TYPE,
     })
 
 

--- a/web/impact/impact/v1/helpers/user_helper.py
+++ b/web/impact/impact/v1/helpers/user_helper.py
@@ -35,24 +35,10 @@ USER_POST_OPTIONS.update(dict([
 USER_GET_OPTIONS = USER_POST_OPTIONS.copy()
 USER_GET_OPTIONS.update(
     {
-        "id": {
-            "type": "integer",
-            "required": False,
-            "read_only": True,
-            "label": "ID"
-        },
-        "updated_at": {
-            "type": "string",
-            "read_only": True
-        },
-        "last_login": {
-            "type": "string",
-            "read_only": True
-        },
-        "date_joined": {
-            "type": "string",
-            "read_only": True
-        },
+        "id": PK_TYPE,
+        "updated_at": READ_ONLY_STRING,
+        "last_login": READ_ONLY_STRING,
+        "date_joined": READ_ONLY_STRING,
     })
 
 

--- a/web/impact/impact/v1/helpers/user_helper.py
+++ b/web/impact/impact/v1/helpers/user_helper.py
@@ -3,10 +3,65 @@ from django.conf import settings
 from impact.utils import get_profile
 from impact.v1.helpers.model_helper import ModelHelper
 from impact.v1.helpers.profile_helper import ProfileHelper
+from impact.v1.metadata import (
+    OPTIONAL_STRING_TYPE,
+    OPTIONAL_BOOLEAN_TYPE,
+    OPTIONAL_DATE_TYPE,
+    OPTIONAL_LIST_TYPE,
+    OPTIONAL_ID_TYPE,
+)
+
+
+USER_POST_OPTIONS = {
+    "first_name": OPTIONAL_STRING_TYPE,
+    "last_name": OPTIONAL_STRING_TYPE,
+    "email": OPTIONAL_STRING_TYPE,
+    "is_active": OPTIONAL_BOOLEAN_TYPE,
+    "gender": OPTIONAL_STRING_TYPE,
+    "phone": OPTIONAL_STRING_TYPE,
+    "additional_industry_ids": OPTIONAL_LIST_TYPE,
+    "expert_category": OPTIONAL_STRING_TYPE,
+    "mentoring_specialties": OPTIONAL_LIST_TYPE,
+    "primary_industry_id": OPTIONAL_ID_TYPE,
+    "updated_at": OPTIONAL_DATE_TYPE,
+}
+USER_POST_OPTIONS.update(dict([
+            (key, OPTIONAL_BOOLEAN_TYPE)
+            for key in ProfileHelper.OPTIONAL_BOOLEAN_KEYS]))
+USER_POST_OPTIONS.update(dict([
+            (key, OPTIONAL_STRING_TYPE)
+            for key in ProfileHelper.OPTIONAL_STRING_KEYS]))
+
+USER_GET_OPTIONS = USER_POST_OPTIONS.copy()
+USER_GET_OPTIONS.update(
+    {
+        "id": {
+            "type": "integer",
+            "required": False,
+            "read_only": True,
+            "label": "ID"
+        },
+        "updated_at": {
+            "type": "string",
+            "read_only": True
+        },
+        "last_login": {
+            "type": "string",
+            "read_only": True
+        },
+        "date_joined": {
+            "type": "string",
+            "read_only": True
+        },
+    })
 
 
 class UserHelper(ModelHelper):
     MODEL = settings.AUTH_USER_MODEL
+
+    DETAIL_GET_METADATA = USER_GET_OPTIONS
+    DETAIL_PATCH_METADATA = USER_POST_OPTIONS
+    LIST_POST_METADATA = USER_POST_OPTIONS
 
     REQUIRED_KEYS = [
         "email",

--- a/web/impact/impact/v1/metadata.py
+++ b/web/impact/impact/v1/metadata.py
@@ -1,5 +1,4 @@
 from rest_framework.metadata import SimpleMetadata
-from impact.v1.helpers import ProfileHelper
 
 
 OPTIONAL_STRING_TYPE = {"type": "string"}
@@ -7,153 +6,19 @@ OPTIONAL_BOOLEAN_TYPE = {"type": "boolean"}
 OPTIONAL_DATE_TYPE = OPTIONAL_STRING_TYPE
 OPTIONAL_LIST_TYPE = {"type": "field"}
 OPTIONAL_ID_TYPE = {"type": "integer"}
+PK_TYPE = {
+    "type": "integer",
+    "required": False,
+    "read_only": True,
+    "label": "ID"
+}
+
 READ_ONLY_LIST_TYPE = {"type": "field", "read_only": True}
 
 
-INDUSTRY_DETAIL_ACTIONS = {
-    "GET": {
-        "id": {
-            "type": "integer",
-            "required": False,
-            "read_only": True,
-            "label": "ID"
-        },
-        "name": OPTIONAL_STRING_TYPE,
-        "full_name": OPTIONAL_STRING_TYPE,
-        "parent_id": OPTIONAL_ID_TYPE,
-    }
-}
-INDUSTRY_ACTIONS = INDUSTRY_DETAIL_ACTIONS
-
-ORGANIZATION_DETAIL_ACTIONS = {
-    "GET": {
-        "id": {
-            "type": "integer",
-            "required": False,
-            "read_only": True,
-            "label": "ID"
-        },
-        "name": OPTIONAL_STRING_TYPE,
-        "url_slug": OPTIONAL_STRING_TYPE,
-        "additional_industry_ids": OPTIONAL_LIST_TYPE,
-        "date_founded": OPTIONAL_DATE_TYPE,
-        "facebook_url": OPTIONAL_STRING_TYPE,
-        "full_elevator_pitch": OPTIONAL_STRING_TYPE,
-        "primary_industry_id": OPTIONAL_ID_TYPE,
-        "public_inquiry_email": OPTIONAL_STRING_TYPE,
-        "linked_in_url": OPTIONAL_STRING_TYPE,
-        "location_city": OPTIONAL_STRING_TYPE,
-        "location_national": OPTIONAL_STRING_TYPE,
-        "location_postcode": OPTIONAL_STRING_TYPE,
-        "location_regional": OPTIONAL_STRING_TYPE,
-        "short_pitch": OPTIONAL_STRING_TYPE,
-        "twitter_handle": OPTIONAL_STRING_TYPE,
-        "video_elevator_pitch_url": OPTIONAL_STRING_TYPE,
-        "website_url": OPTIONAL_STRING_TYPE,
-        "is_startup": OPTIONAL_BOOLEAN_TYPE,
-        "is_partner": OPTIONAL_BOOLEAN_TYPE,
-        "updated_at": OPTIONAL_DATE_TYPE
-    }
-}
-
-ORGANIZATION_ACTIONS = ORGANIZATION_DETAIL_ACTIONS
-
-ORGANIZATION_HISTORY_ACTIONS = {
-    "GET": {"history": READ_ONLY_LIST_TYPE}
-}
-
-USER_HISTORY_ACTIONS = {
-    "GET": {"history": READ_ONLY_LIST_TYPE}
-}
-
-USER_ORGANIZATION_ACTIONS = {
-    "GET": {"organizations": READ_ONLY_LIST_TYPE}
-}
-
-ORGANIZATION_USER_ACTIONS = {
-    "GET": {"users": READ_ONLY_LIST_TYPE}
-}
-
-
-USER_POST_OPTIONS = {
-    "first_name": OPTIONAL_STRING_TYPE,
-    "last_name": OPTIONAL_STRING_TYPE,
-    "email": OPTIONAL_STRING_TYPE,
-    "is_active": OPTIONAL_BOOLEAN_TYPE,
-    "gender": OPTIONAL_STRING_TYPE,
-    "phone": OPTIONAL_STRING_TYPE,
-    "additional_industry_ids": OPTIONAL_LIST_TYPE,
-    "expert_category": OPTIONAL_STRING_TYPE,
-    "mentoring_specialties": OPTIONAL_LIST_TYPE,
-    "primary_industry_id": OPTIONAL_ID_TYPE,
-    "updated_at": OPTIONAL_DATE_TYPE,
-}
-USER_POST_OPTIONS.update(dict([
-            (key, OPTIONAL_BOOLEAN_TYPE)
-            for key in ProfileHelper.OPTIONAL_BOOLEAN_KEYS]))
-USER_POST_OPTIONS.update(dict([
-            (key, OPTIONAL_STRING_TYPE)
-            for key in ProfileHelper.OPTIONAL_STRING_KEYS]))
-
-USER_GET_OPTIONS = USER_POST_OPTIONS.copy()
-USER_GET_OPTIONS.update(
-    {
-        "id": {
-            "type": "integer",
-            "required": False,
-            "read_only": True,
-            "label": "ID"
-        },
-        "updated_at": {
-            "type": "string",
-            "read_only": True
-        },
-        "last_login": {
-            "type": "string",
-            "read_only": True
-        },
-        "date_joined": {
-            "type": "string",
-            "read_only": True
-        },
-    })
-
-
-USER_ACTIONS = {
-    "GET": USER_GET_OPTIONS,
-    "POST": USER_POST_OPTIONS,
-}
-
-
-USER_DETAIL_ACTIONS = {
-    "GET": USER_GET_OPTIONS,
-    "PATCH": USER_POST_OPTIONS,
-}
-
-
-METADATA_MAP = {
-    "Industry Detail": INDUSTRY_DETAIL_ACTIONS,
-    "Industry List": INDUSTRY_ACTIONS,
-    "Organization Detail": ORGANIZATION_DETAIL_ACTIONS,
-    "Organization History": ORGANIZATION_HISTORY_ACTIONS,
-    "Organization List": ORGANIZATION_ACTIONS,
-    "Organization Users": ORGANIZATION_USER_ACTIONS,
-    "User Detail": USER_DETAIL_ACTIONS,
-    "User List": USER_ACTIONS,
-    "User Organizations": USER_ORGANIZATION_ACTIONS,
-    "User History": USER_HISTORY_ACTIONS,
-}
-
-
 class ImpactMetadata(SimpleMetadata):
-    """
-    Don't include field and other information for `OPTIONS` requests.
-    Just return the name and description.
-    """
-
     def determine_metadata(self, request, view):
-        view_name = view.get_view_name()
         metadata = super().determine_metadata(request, view)
-        metadata["actions"] = METADATA_MAP.get(view_name)
+        metadata["actions"] = view.METADATA_ACTIONS
 
         return metadata

--- a/web/impact/impact/v1/metadata.py
+++ b/web/impact/impact/v1/metadata.py
@@ -1,11 +1,11 @@
 from rest_framework.metadata import SimpleMetadata
 
 
-OPTIONAL_STRING_TYPE = {"type": "string"}
 OPTIONAL_BOOLEAN_TYPE = {"type": "boolean"}
-OPTIONAL_DATE_TYPE = OPTIONAL_STRING_TYPE
-OPTIONAL_LIST_TYPE = {"type": "field"}
 OPTIONAL_ID_TYPE = {"type": "integer"}
+OPTIONAL_LIST_TYPE = {"type": "field"}
+OPTIONAL_STRING_TYPE = {"type": "string"}
+OPTIONAL_DATE_TYPE = OPTIONAL_STRING_TYPE
 PK_TYPE = {
     "type": "integer",
     "required": False,
@@ -14,6 +14,7 @@ PK_TYPE = {
 }
 
 READ_ONLY_LIST_TYPE = {"type": "field", "read_only": True}
+READ_ONLY_STRING_TYPE = {"type": "string", "read_only": True}
 
 
 class ImpactMetadata(SimpleMetadata):

--- a/web/impact/impact/v1/views/__init__.py
+++ b/web/impact/impact/v1/views/__init__.py
@@ -9,6 +9,7 @@ from impact.v1.views.organization_users_view import OrganizationUsersView
 from impact.v1.views.program_family_detail_view import ProgramFamilyDetailView
 from impact.v1.views.program_family_list_view import ProgramFamilyListView
 
+from impact.v1.views.user_confidential_view import UserConfidentialView
 from impact.v1.views.user_detail_view import UserDetailView
 from impact.v1.views.user_history_view import UserHistoryView
 from impact.v1.views.user_list_view import UserListView

--- a/web/impact/impact/v1/views/__init__.py
+++ b/web/impact/impact/v1/views/__init__.py
@@ -6,6 +6,9 @@ from impact.v1.views.organization_history_view import OrganizationHistoryView
 from impact.v1.views.organization_list_view import OrganizationListView
 from impact.v1.views.organization_users_view import OrganizationUsersView
 
+from impact.v1.views.program_family_detail_view import ProgramFamilyDetailView
+from impact.v1.views.program_family_list_view import ProgramFamilyListView
+
 from impact.v1.views.user_detail_view import UserDetailView
 from impact.v1.views.user_history_view import UserHistoryView
 from impact.v1.views.user_list_view import UserListView

--- a/web/impact/impact/v1/views/base_history_view.py
+++ b/web/impact/impact/v1/views/base_history_view.py
@@ -7,7 +7,10 @@ from rest_framework.views import APIView
 from impact.permissions import (
     V1APIPermissions,
 )
-from impact.v1.metadata import ImpactMetadata
+from impact.v1.metadata import (
+    ImpactMetadata,
+    READ_ONLY_LIST_TYPE,
+)
 
 
 class BaseHistoryView(APIView):
@@ -16,6 +19,8 @@ class BaseHistoryView(APIView):
     permission_classes = (
         V1APIPermissions,
     )
+
+    METADATA_ACTIONS = {"GET": {"history": READ_ONLY_LIST_TYPE}}
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/web/impact/impact/v1/views/base_history_view.py
+++ b/web/impact/impact/v1/views/base_history_view.py
@@ -22,8 +22,8 @@ class BaseHistoryView(APIView):
 
     METADATA_ACTIONS = {"GET": {"history": READ_ONLY_LIST_TYPE}}
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+#    def __init__(self, *args, **kwargs):
+#        super().__init__(*args, **kwargs)
 
     def get(self, request, pk):
         self.instance = self.model.objects.get(pk=pk)

--- a/web/impact/impact/v1/views/base_history_view.py
+++ b/web/impact/impact/v1/views/base_history_view.py
@@ -22,9 +22,6 @@ class BaseHistoryView(APIView):
 
     METADATA_ACTIONS = {"GET": {"history": READ_ONLY_LIST_TYPE}}
 
-#    def __init__(self, *args, **kwargs):
-#        super().__init__(*args, **kwargs)
-
     def get(self, request, pk):
         self.instance = self.model.objects.get(pk=pk)
         events = []
@@ -32,6 +29,8 @@ class BaseHistoryView(APIView):
             events = events + event_class.events(self.instance)
         result = {
             "results": sorted([event.serialize() for event in events],
-                              key=lambda e: e["datetime"])
+                              key=lambda e: (e["datetime"],
+                                             e.get("latest_datetime",
+                                                   e["datetime"])))
         }
         return Response(result)

--- a/web/impact/impact/v1/views/industry_detail_view.py
+++ b/web/impact/impact/v1/views/industry_detail_view.py
@@ -21,6 +21,10 @@ class IndustryDetailView(LoggingMixin, APIView):
         V1APIPermissions,
     )
 
+    METADATA_ACTIONS = {
+        "GET": IndustryHelper.DETAIL_METADATA
+        }
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 

--- a/web/impact/impact/v1/views/industry_list_view.py
+++ b/web/impact/impact/v1/views/industry_list_view.py
@@ -3,7 +3,9 @@
 
 from impact.v1.views.list_view import ListView
 from impact.v1.helpers import IndustryHelper
+from impact.v1.views.industry_detail_view import IndustryDetailView
 
 
 class IndustryListView(ListView):
     helper_class = IndustryHelper
+    METADATA_ACTIONS = IndustryDetailView.METADATA_ACTIONS

--- a/web/impact/impact/v1/views/organization_detail_view.py
+++ b/web/impact/impact/v1/views/organization_detail_view.py
@@ -20,6 +20,9 @@ class OrganizationDetailView(LoggingMixin, APIView):
     permission_classes = (
         V1APIPermissions,
     )
+    METADATA_ACTIONS = {
+        "GET": OrganizationHelper.DETAIL_METADATA
+        }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/web/impact/impact/v1/views/organization_list_view.py
+++ b/web/impact/impact/v1/views/organization_list_view.py
@@ -3,7 +3,9 @@
 
 from impact.v1.views.list_view import ListView
 from impact.v1.helpers import OrganizationHelper
+from impact.v1.views.organization_detail_view import OrganizationDetailView
 
 
 class OrganizationListView(ListView):
     helper_class = OrganizationHelper
+    METADATA_ACTIONS = OrganizationDetailView.METADATA_ACTIONS

--- a/web/impact/impact/v1/views/organization_users_view.py
+++ b/web/impact/impact/v1/views/organization_users_view.py
@@ -11,7 +11,10 @@ from impact.models import (
     PartnerTeamMember,
     StartupTeamMember,
 )
-from impact.v1.metadata import ImpactMetadata
+from impact.v1.metadata import (
+    ImpactMetadata,
+    READ_ONLY_LIST_TYPE,
+)
 from impact.v1.views.utils import (
     map_data,
     coalesce_dictionaries,
@@ -24,6 +27,10 @@ class OrganizationUsersView(LoggingMixin, APIView):
     )
     metadata_class = ImpactMetadata
     model = Organization
+
+    METADATA_ACTIONS = {
+        "GET": {"users": READ_ONLY_LIST_TYPE},
+        }
 
     def get(self, request, pk):
         self.instance = self.model.objects.get(pk=pk)

--- a/web/impact/impact/v1/views/program_family_detail_view.py
+++ b/web/impact/impact/v1/views/program_family_detail_view.py
@@ -8,13 +8,13 @@ from rest_framework_tracking.mixins import LoggingMixin
 from impact.permissions import (
     V1APIPermissions,
 )
-from impact.models import Industry
-from impact.v1.helpers import IndustryHelper
+from impact.models import ProgramFamily
+from impact.v1.helpers import ProgramFamilyHelper
 from impact.v1.metadata import ImpactMetadata
 
 
-class IndustryDetailView(LoggingMixin, APIView):
-    model = Industry
+class ProgramFamilyDetailView(LoggingMixin, APIView):
+    model = ProgramFamily
     metadata_class = ImpactMetadata
 
     permission_classes = (
@@ -22,7 +22,7 @@ class IndustryDetailView(LoggingMixin, APIView):
     )
 
     METADATA_ACTIONS = {
-        "GET": IndustryHelper.DETAIL_METADATA
+        "GET": ProgramFamilyHelper.DETAIL_METADATA
     }
 
     def __init__(self, *args, **kwargs):
@@ -30,4 +30,4 @@ class IndustryDetailView(LoggingMixin, APIView):
 
     def get(self, request, pk):
         self.instance = self.model.objects.get(pk=pk)
-        return Response(IndustryHelper(self.instance).serialize())
+        return Response(ProgramFamilyHelper(self.instance).serialize())

--- a/web/impact/impact/v1/views/program_family_list_view.py
+++ b/web/impact/impact/v1/views/program_family_list_view.py
@@ -1,0 +1,11 @@
+# MIT License
+# Copyright (c) 2017 MassChallenge, Inc.
+
+from impact.v1.views.list_view import ListView
+from impact.v1.helpers import ProgramFamilyHelper
+from impact.v1.views.program_family_detail_view import ProgramFamilyDetailView
+
+
+class ProgramFamilyListView(ListView):
+    helper_class = ProgramFamilyHelper
+    METADATA_ACTIONS = ProgramFamilyDetailView.METADATA_ACTIONS

--- a/web/impact/impact/v1/views/program_list_view.py
+++ b/web/impact/impact/v1/views/program_list_view.py
@@ -1,9 +1,0 @@
-# MIT License
-# Copyright (c) 2017 MassChallenge, Inc.
-
-from impact.v1.views.list_view import ListView
-from impact.v1.helpers import IndustryHelper
-
-
-class IndustryListView(ListView):
-    helper_class = IndustryHelper

--- a/web/impact/impact/v1/views/program_list_view.py
+++ b/web/impact/impact/v1/views/program_list_view.py
@@ -1,0 +1,9 @@
+# MIT License
+# Copyright (c) 2017 MassChallenge, Inc.
+
+from impact.v1.views.list_view import ListView
+from impact.v1.helpers import IndustryHelper
+
+
+class IndustryListView(ListView):
+    helper_class = IndustryHelper

--- a/web/impact/impact/v1/views/user_confidential_view.py
+++ b/web/impact/impact/v1/views/user_confidential_view.py
@@ -1,0 +1,36 @@
+# MIT License
+# Copyright (c) 2017 MassChallenge, Inc.
+
+from django.contrib.auth import get_user_model
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from impact.permissions import (
+    V1ConfidentialAPIPermissions,
+)
+from impact.v1.metadata import (
+    ImpactMetadata,
+    OPTIONAL_STRING_TYPE,
+)
+from impact.v1.helpers import UserHelper
+
+User = get_user_model()
+
+
+class UserConfidentialView(APIView):
+    metadata_class = ImpactMetadata
+
+    permission_classes = (
+        V1ConfidentialAPIPermissions,
+    )
+
+    METADATA_ACTIONS = {"GET": {
+            "expert_group": OPTIONAL_STRING_TYPE,
+            "internal_notes": OPTIONAL_STRING_TYPE,
+            }}
+    CONFIDENTIAL_KEYS = ["id", "expert_group", "internal_notes"]
+
+    def get(self, request, pk):
+        user = User.objects.get(id=pk)
+        result = UserHelper(user).serialize(fields=self.CONFIDENTIAL_KEYS)
+        return Response(result)

--- a/web/impact/impact/v1/views/user_detail_view.py
+++ b/web/impact/impact/v1/views/user_detail_view.py
@@ -29,6 +29,11 @@ class UserDetailView(LoggingMixin, APIView):
     )
     metadata_class = ImpactMetadata
 
+    METADATA_ACTIONS = {
+        "GET": UserHelper.DETAIL_GET_METADATA,
+        "PATCH": UserHelper.DETAIL_PATCH_METADATA,
+        }
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 

--- a/web/impact/impact/v1/views/user_history_view.py
+++ b/web/impact/impact/v1/views/user_history_view.py
@@ -9,6 +9,7 @@ from impact.v1.events import (
     UserBecameFinalistEvent,
     UserCreatedEvent,
     UserJoinedStartupEvent,
+    UserReceivedNewsletterEvent,
 )
 
 User = get_user_model()
@@ -22,4 +23,5 @@ class UserHistoryView(BaseHistoryView):
                      UserBecameConfirmedMentorEvent,
                      UserBecameFinalistEvent,
                      UserCreatedEvent,
-                     UserJoinedStartupEvent]
+                     UserJoinedStartupEvent,
+                     UserReceivedNewsletterEvent]

--- a/web/impact/impact/v1/views/user_list_view.py
+++ b/web/impact/impact/v1/views/user_list_view.py
@@ -24,6 +24,11 @@ User = get_user_model()
 
 
 class UserListView(BaseListView):
+    METADATA_ACTIONS = {
+        "GET": UserHelper.DETAIL_GET_METADATA,
+        "POST": UserHelper.LIST_POST_METADATA,
+        }
+
     def post(self, request):
         user_args = self._user_args(request.POST)
         profile_args = self._profile_args(request.POST)

--- a/web/impact/impact/v1/views/user_organizations_view.py
+++ b/web/impact/impact/v1/views/user_organizations_view.py
@@ -11,7 +11,10 @@ from impact.models import (
     PartnerTeamMember,
     StartupTeamMember,
 )
-from impact.v1.metadata import ImpactMetadata
+from impact.v1.metadata import (
+    ImpactMetadata,
+    READ_ONLY_LIST_TYPE,
+)
 from impact.v1.views.utils import (
     coalesce_dictionaries,
     map_data,
@@ -24,6 +27,10 @@ class UserOrganizationsView(LoggingMixin, APIView):
     )
     metadata_class = ImpactMetadata
     model = get_user_model()
+
+    METADATA_ACTIONS = {
+        "GET": {"organizations": READ_ONLY_LIST_TYPE},
+        }
 
     def get(self, request, pk):
         self.instance = self.model.objects.get(pk=pk)


### PR DESCRIPTION
Work done:
- Improves handling of OPTIONS calls by localizing the data in the helper objects.  More redundancy could be removed here, but it would be better to wait until we have decided on a standard per AC-4855.
- Provides read-only Program Family Resource (/api/v1/program_family)
- Provides read-only Confidential User Call (/api/v1/user/<id>/confidential) which is managed by a separate permission.
- Added Judging Round id and name information to User History call
- Added Newsletter events to User History call

To test:
- Program Family Resource:
-- Go to http://localhost:8000/api/v1/program_family/, check the OPTIONS, pick an "id" and go to http://localhost:8000/api/v1/program_family/<id>

- Confidential User Information:
-- Visit http://localhost:8000/api/v1/user/182/confidential/ and see that you get a permission denied warning.
-- Give your user the appropriate Django permission:
```
HQ-Dev-8:impact-api nathan$ make shell
Starting impactapi_mysql_1 ... done
Starting impactapi_redis_1 ... done
Python 3.6.2 (default, Jul 24 2017, 19:47:39) 
Type "copyright", "credits" or "license" for more information.

IPython 4.0.0 -- An enhanced Interactive Python.
?         -> Introduction and overview of IPython's features.
%quickref -> Quick reference.
help      -> Python's own help system.
object?   -> Details about 'object', use 'object??' for extra details.

In [1]: import impact.models as im

In [2]: user = im.User.objects.get(id=13514)

In [3]: from django.contrib.auth.models import Group

In [4]: from django.conf import settings

In [5]: group = Group.objects.create(name=settings.V1_CONFIDENTIAL_API_GROUP)

In [6]: user.groups.add(group)

In [7]: user.save()
```
-- See this http://localhost:8000/api/v1/user/182/confidential/ succeed
-- Note that there is currently only information related to experts in this call.

- Judging Round information in User History call
-- Find a user who has been a confirmed judge, say the user with id=182
-- Make the appropriate User History call, e.g., http://localhost:8000/api/v1/user/182/history/
-- Search for the string "judging_round_name"

- Newsletter Events in User History call
-- On the above page search for "newsletter_name"

- Make sure the OPTIONS calls are reasonable for the above GET calls.