### PR TITLE
[AC-4642b] - Add Overview Start and End Times to the Program model

### DIFF
--- a/web/impact/impact/models/program.py
+++ b/web/impact/impact/models/program.py
@@ -110,8 +110,6 @@ class Program(MCModel):
         max_length=30,
         default="",
     )
-    # accepting_company_overviews =
-    #  models.BooleanField(default=False)  # todo: remove
     mentor_program_group = models.ForeignKey(
         NamedGroup,
         blank=True,

--- a/web/impact/impact/models/program.py
+++ b/web/impact/impact/models/program.py
@@ -11,7 +11,6 @@ from impact.models.program_manager import ProgramManager
 from impact.models.program_cycle import ProgramCycle
 from impact.models.utils import is_managed
 
-
 ACTIVE_PROGRAM_STATUS = "active"
 ENDED_PROGRAM_STATUS = "ended"
 HIDDEN_PROGRAM_STATUS = "hidden"
@@ -111,7 +110,8 @@ class Program(MCModel):
         max_length=30,
         default="",
     )
-    # accepting_company_overviews = models.BooleanField(default=False)  # todo: remove
+    # accepting_company_overviews =
+    #  models.BooleanField(default=False)  # todo: remove
     mentor_program_group = models.ForeignKey(
         NamedGroup,
         blank=True,
@@ -130,12 +130,3 @@ class Program(MCModel):
 
     def family_abbr(self):
         return self.program_family.url_slug.upper()
-
-    @property
-    def accepting_company_overviews(self):
-        if self.overview_start_date:
-            if self.overview_deadline_date:
-                return (self.overview_start_date <= timezone.now() <
-                        self.overview_deadline_date)
-            return self.overview_start_date <= timezone.now()
-        return False

--- a/web/impact/impact/models/program.py
+++ b/web/impact/impact/models/program.py
@@ -3,6 +3,7 @@
 
 
 from django.db import models
+from django.utils import timezone
 from impact.models.mc_model import MCModel
 from impact.models.named_group import NamedGroup
 from impact.models.program_family import ProgramFamily
@@ -33,7 +34,6 @@ REFUND_CODE_SUPPORT_VALUES = (
 
 
 class Program(MCModel):
-
     """a masschallenge program"""
 
     objects = ProgramManager()
@@ -111,11 +111,13 @@ class Program(MCModel):
         max_length=30,
         default="",
     )
-    accepting_company_overviews = models.BooleanField(default=False)
+    # accepting_company_overviews = models.BooleanField(default=False)  # todo: remove
     mentor_program_group = models.ForeignKey(
         NamedGroup,
         blank=True,
         null=True)
+    overview_start_date = models.DateTimeField(blank=True, null=True)
+    overview_deadline_date = models.DateTimeField(blank=True, null=True)
 
     class Meta(MCModel.Meta):
         db_table = 'mc_program'
@@ -128,3 +130,12 @@ class Program(MCModel):
 
     def family_abbr(self):
         return self.program_family.url_slug.upper()
+
+    @property
+    def accepting_company_overviews(self):
+        if self.overview_start_date:
+            if self.overview_deadline_date:
+                return (self.overview_start_date <= timezone.now() <
+                        self.overview_deadline_date)
+            return self.overview_start_date <= timezone.now()
+        return False

--- a/web/impact/impact/models/program.py
+++ b/web/impact/impact/models/program.py
@@ -3,7 +3,6 @@
 
 
 from django.db import models
-from django.utils import timezone
 from impact.models.mc_model import MCModel
 from impact.models.named_group import NamedGroup
 from impact.models.program_family import ProgramFamily

--- a/web/impact/impact/tests/factories/program_factory.py
+++ b/web/impact/impact/tests/factories/program_factory.py
@@ -19,7 +19,6 @@ from .program_cycle_factory import ProgramCycleFactory
 
 
 class ProgramFactory(DjangoModelFactory):
-
     class Meta:
         model = Program
 
@@ -55,5 +54,6 @@ class ProgramFactory(DjangoModelFactory):
     refund_code_support = "enabled"
     many_codes_per_partner = False
     url_slug = Sequence(lambda n: "p{0}".format(n))
-    accepting_company_overviews = False
     mentor_program_group = None
+    overview_start_date = None
+    overview_deadline_date = None


### PR DESCRIPTION
**Changes Introduced [AC-4642b](https://masschallenge.atlassian.net/browse/AC-4642):**

- add new fields to Program.
- remove deprecated field from Program.

**Test:**
- in impact-api, `make dev`
- in accelerate, checkout AC-4642a.
- run `resetdb`
- then dump the db: `mysqldump -u root -proot mc_dev | gzip > /vagrant/db_cache/initial_schema_AC_4642a.sql.gz`
- in impact-api, in a new terminal, run `make load-db GZ_FILE=../accelerate/db_cache/initial_schema_AC_4642a.sql.gz`
- login to browsable API as demoadmin, go to http://localhost:8000/api/impact/Program/
- see that the new fields are added, and that the old field is removed.

**Note:**
- AC-4642b should be deployed in impact-api only after AC-4642a is deployed in accelerate.
- AC-4642c in accelerate should be deployed only after AC-4642b.