### PR TITLE
[AC-4935] Fix definition of V1_CONFIDENTIAL_API_GROUP

### DIFF
--- a/web/impact/impact/settings.py
+++ b/web/impact/impact/settings.py
@@ -147,7 +147,7 @@ class Base(Configuration):
     V1_API_GROUP = bytes(os.environ.get(
         'IMPACT_API_V1_API_GROUP', 'v1_clients'), 'utf-8')
 
-    V1_CONFIDENTIAL_API_GROUP = 'v1_confidential', 'utf-8'
+    V1_CONFIDENTIAL_API_GROUP = bytes('v1_confidential', 'utf-8')
 
     OAUTH2_PROVIDER = {
         # this is the list of available scopes


### PR DESCRIPTION
To test:
- `make dev`
- `make load-remote-db DB_FILE_NAME=initial_schema.sql.gz`
- `make grant-permissions PERMISSION_USER=demoadmin@masschallenge.org PERMISSION_CLASSES=v1_clients,v1_confidential`
- Login to http://localhost:8000/ as demoadmin@
- Visit http://localhost:8000/api/v1/user/182/confidential/
- On development get a permission denied result
```
HTTP 403 Forbidden
Allow: GET, HEAD, OPTIONS
Content-Type: application/json
Vary: Accept

{
    "detail": "You do not have permission to perform this action."
}
```

- On branch it should succeed.
```
HTTP 200 OK
Allow: GET, HEAD, OPTIONS
Content-Type: application/json
Vary: Accept

{
    "id": 182,
    "expert_group": "1",
    "internal_notes": ""
}
```
