### PR TITLE
[AC-4960] fixing pagination protocol via setting appropriate protocol headers

### DIFF
--- a/web/impact/impact/settings.py
+++ b/web/impact/impact/settings.py
@@ -28,6 +28,8 @@ class Base(Configuration):
 
     USE_TZ = True
 
+    USE_X_FORWARDED_HOST = True
+
     ALLOWED_HOSTS = [
         '*'
     ]
@@ -208,8 +210,8 @@ class Dev(Base):
     ]
 
     MIDDLEWARE_CLASSES = [
-                             'debug_toolbar.middleware.DebugToolbarMiddleware',
-                         ] + Base.MIDDLEWARE_CLASSES
+        'debug_toolbar.middleware.DebugToolbarMiddleware',
+    ] + Base.MIDDLEWARE_CLASSES
 
     INSTALLED_APPS = Base.INSTALLED_APPS + [
         'debug_toolbar',

--- a/web/nginx/nginx.conf
+++ b/web/nginx/nginx.conf
@@ -67,7 +67,7 @@ http {
             proxy_set_header   Host              $http_host;
             proxy_set_header   X-Real-IP         $remote_addr;
             proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
-            proxy_set_header   X-Forwarded-Proto $scheme;
+            proxy_set_header   X-Forwarded-Proto $http_x_forwarded_proto;
             proxy_pass_request_headers on;
             proxy_no_cache $cookie_nocache  $arg_nocache$arg_comment;
             proxy_no_cache $http_pragma     $http_authorization;

--- a/web/nginx/nginx.conf
+++ b/web/nginx/nginx.conf
@@ -76,7 +76,10 @@ http {
 
             # redirect to https if we are on prod and the request is insecure (http)
             if ($host = 'api.masschallenge.org'){
-             set $local_and_insecure  "prod"; 
+             set $local_and_insecure  "prod";
+            }
+            if ($host = 'staging.api.masschallenge.org'){
+             set $local_and_insecure  "prod";
             }
             if ($http_x_forwarded_proto != 'https'){
              set $local_and_insecure  "${local_and_insecure}insecure"; 


### PR DESCRIPTION
The fix for this turned out to be far simpler - the reason for it was that nginx was using the "$scheme" variable which reports incorrectly when sitting under an ELB which in turn affected what djkango was seeing for protocol. Django latches on the X-Forwarded-Proto to determine http vs https.

Unfortunately testing this is a bit pauinful and involves setting up a sidecar letsencrypt image or a self-signed cert in nginx and fiddling with the settings.
However I have gone through this pain and tested and verified that this works.

EDIT - We have setup an elb for staging and I've pushed this branch out there for testing. 

to test:
- Login using your superuser masschallenge account here: https://staging.api.masschallenge.org
- visit a view that paginates (https://staging.api.masschallenge.org/api/impact/Industry/) and note that the "next" field shows https for a protocol instead of http (as you would see in a local environment)