### PR TITLE
[AC-4972] - Fix travis builds for tags (impact-api)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ before_install:
 - docker-compose --version
 
 before_script:
-
 - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
 - if [ -z $TRAVIS_TAG ]; then git remote set-branches origin $BRANCH; fi
 - git fetch

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,9 @@ before_install:
 - docker-compose --version
 
 before_script:
+
 - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
-- git remote set-branches origin $BRANCH
+- if [ -z $TRAVIS_TAG ]; then git remote set-branches origin $BRANCH; fi
 - git fetch
 - git checkout $BRANCH
 - echo "" >> .prod.env


### PR DESCRIPTION
**Changes introduced in [AC-4972](https://masschallenge.atlassian.net/browse/AC-4972)**
- don't set a tag as a remote branch before fetching

**Test:**

- See that the [tag generated build](https://travis-ci.org/masschallenge/impact-api/builds/296968918 succeeds
- See Branch generated build, below that is not affected by this change.
- See PR generated build, below, that should also pass.