### PR TITLE
AC-5123: Make cycle_id and program_id just integers for "became finalist"

### DIFF
--- a/web/impact/impact/tests/test_organization_history_view.py
+++ b/web/impact/impact/tests/test_organization_history_view.py
@@ -311,7 +311,9 @@ class TestOrganizationHistoryView(APITestCase):
             self.assertEqual(1, len(events))
             self.assertTrue(program.name in events[0]["description"])
             self.assertEqual(program.name, events[0]["program"])
+            self.assertEqual(program.id, events[0]["program_id"])
             self.assertEqual(program.cycle.name, events[0]["cycle"])
+            self.assertEqual(program.cycle.id, events[0]["cycle_id"])
 
     def test_startup_became_finalist_no_created_at(self):
         startup = StartupFactory()

--- a/web/impact/impact/v1/events/organization_became_finalist_event.py
+++ b/web/impact/impact/v1/events/organization_became_finalist_event.py
@@ -51,10 +51,10 @@ class OrganizationBecameFinalistEvent(BaseHistoryEvent):
         return self._program.cycle.name
 
     def cycle_id(self):
-        return self._program.cycle.id,
+        return self._program.cycle.id
 
     def program(self):
         return self._program.name
 
     def program_id(self):
-        return self._program.id,
+        return self._program.id


### PR DESCRIPTION
To test:
/api/v1/organization/66/history/ should have an integer for "cycle_id" and "program_id" in the "became finalist" event rather than a single element list.
On the clean database you should be able to go their as 13514-user@example.com.