### PR TITLE
AC-5001 - Clean up handling of organization URL slugs so they produce working URLs

### DIFF
--- a/web/impact/impact/models/organization.py
+++ b/web/impact/impact/models/organization.py
@@ -2,10 +2,7 @@
 # Copyright (c) 2017 MassChallenge, Inc.
 
 from django.db import models
-from django.core.validators import (
-    RegexValidator,
-    validate_slug
-)
+from django.core.validators import RegexValidator
 
 from impact.models.mc_model import MCModel
 from impact.models.utils import is_managed
@@ -26,9 +23,10 @@ class Organization(MCModel):
         blank=True,
         default="",  # This actually gets replaced by a real slug.
         unique=True,
-        validators=[RegexValidator(".*\D.*",
-                                   "Slug must contain a non-numeral."),
-                    validate_slug, ]
+        validators=[
+            RegexValidator(regex="^[\w-]+$",
+                           message="Alphanumeric characters and dashes only.")
+        ]
     )
 
     class Meta(MCModel.Meta):

--- a/web/impact/impact/models/organization.py
+++ b/web/impact/impact/models/organization.py
@@ -25,7 +25,7 @@ class Organization(MCModel):
         unique=True,
         validators=[
             RegexValidator(regex="^[\w-]+$",
-                           message="Alphanumeric characters and dashes only.")
+                           message="Letters, numbers, and dashes only.")
         ]
     )
 

--- a/web/impact/impact/v1/helpers/organization_helper.py
+++ b/web/impact/impact/v1/helpers/organization_helper.py
@@ -14,7 +14,6 @@ from impact.v1.helpers.model_helper import (
     STRING_FIELD,
     TWITTER_FIELD,
     URL_FIELD,
-    URL_SLUG_FIELD,
     json_array,
     json_schema,
     merge_fields,
@@ -44,6 +43,8 @@ STARTUP_INDUSTRY_FIELD = merge_fields(STARTUP_FIELD,
                                       json_schema(INDUSTRY_TYPE))
 STARTUP_INDUSTRY_ARRAY_FIELD = merge_fields(
     STARTUP_FIELD, json_schema(json_array(INDUSTRY_TYPE)))
+ORGANIZATION_URL_SLUG_FIELD = merge_fields(
+    STRING_FIELD, {"json-schema": {"pattern": "^[a-zA-Z0-9-]+$"}})
 
 ORGANIZATION_FIELDS = {
     "id": PK_FIELD,
@@ -53,7 +54,7 @@ ORGANIZATION_FIELDS = {
     "public_inquiry_email": EMAIL_FIELD,
     "twitter_handle": TWITTER_FIELD,
     "updated_at": READ_ONLY_STRING_FIELD,
-    "url_slug": URL_SLUG_FIELD,
+    "url_slug": ORGANIZATION_URL_SLUG_FIELD,
     "website_url": URL_FIELD,
 
     # Startup specific fields

--- a/web/impact/impact/v1/helpers/organization_helper.py
+++ b/web/impact/impact/v1/helpers/organization_helper.py
@@ -44,7 +44,7 @@ STARTUP_INDUSTRY_FIELD = merge_fields(STARTUP_FIELD,
 STARTUP_INDUSTRY_ARRAY_FIELD = merge_fields(
     STARTUP_FIELD, json_schema(json_array(INDUSTRY_TYPE)))
 ORGANIZATION_URL_SLUG_FIELD = merge_fields(
-    STRING_FIELD, {"json-schema": {"pattern": "^[a-zA-Z0-9-]+$"}})
+    STRING_FIELD, {"json-schema": {"pattern": "^[\w-]+$"}})
 
 ORGANIZATION_FIELDS = {
     "id": PK_FIELD,


### PR DESCRIPTION
## [AC-5001](https://masschallenge.atlassian.net/browse/AC-5001)

Also see the [accelerate PR](https://github.com/masschallenge/accelerate/pull/1649) (closed) and the  [django-accelerator PR](https://github.com/masschallenge/django-accelerator/pull/33).

**Database loading instructions**
* In accelerate, check out the AC-5001 branch
* In your vagrant box, run `django migrate` then run `dumpdb`
* In your impact-api clone, check out the AC-5001 branch
* `make build && make dev`
* In another terminal window, `make load-db GZ_FILE=../accelerate/db_cache/initial_schema.sql.gz`

**How to check the OPTIONS call**
* `make dev` (if it's not running already from above)
* `make grant-permissions PERMISSION_USER=demoadmin@masschallenge.org PERMISSION_CLASSES=v1_clients`
* Log in with the account you just granted perms to
* Go to the [v1 organization endpoint](http://localhost:8000/api/v1/organization/) and make an OPTIONS request
* Confirm the `url_slug` validation regex matches the ticket's DONE (note that the backslash gets doubled for escaping purposes)

