### PR TITLE
[AC-5147] Add UserBecameDesiredJudgeEvent

### DIFF
--- a/web/impact/impact/tests/test_user_history_view.py
+++ b/web/impact/impact/tests/test_user_history_view.py
@@ -25,6 +25,7 @@ from impact.tests.utils import (
 from impact.v1.events import (
     UserBecameConfirmedJudgeEvent,
     UserBecameConfirmedMentorEvent,
+    UserBecameDesiredJudgeEvent,
     UserBecameFinalistEvent,
     UserCreatedEvent,
     UserJoinedStartupEvent,
@@ -163,8 +164,27 @@ class TestUserHistoryView(APITestCase):
                                  UserBecameConfirmedJudgeEvent.EVENT_TYPE)
             self.assertEqual(1, len(events))
             format_string = UserBecameConfirmedJudgeEvent.PROGRAM_ROLE_FORMAT
-            self.assertEqual(format_string.format(name=prg.program_role.name,
-                                                  id=prg.program_role.id),
+            self.assertEqual(format_string.format(
+                    user_role=UserBecameConfirmedJudgeEvent.USER_ROLE,
+                    name=prg.program_role.name,
+                    id=prg.program_role.id),
+                             events[0]["description"])
+
+    def test_user_became_confirmed_judge_with_missing_label(self):
+        prg = ProgramRoleGrantFactory(
+            program_role__user_role__name=UserRole.JUDGE,
+            program_role__user_label=None)
+        with self.login(email=self.basic_user().email):
+            url = reverse(UserHistoryView.view_name, args=[prg.person.id])
+            response = self.client.get(url)
+            events = find_events(response.data["results"],
+                                 UserBecameConfirmedJudgeEvent.EVENT_TYPE)
+            self.assertEqual(1, len(events))
+            format_string = UserBecameConfirmedJudgeEvent.PROGRAM_ROLE_FORMAT
+            self.assertEqual(format_string.format(
+                    user_role=UserBecameConfirmedJudgeEvent.USER_ROLE,
+                    name=prg.program_role.name,
+                    id=prg.program_role.id),
                              events[0]["description"])
 
     def test_user_became_confirmed_judge_with_judging_round(self):
@@ -179,8 +199,10 @@ class TestUserHistoryView(APITestCase):
                                  UserBecameConfirmedJudgeEvent.EVENT_TYPE)
             self.assertEqual(1, len(events))
             format_string = UserBecameConfirmedJudgeEvent.JUDGING_ROUND_FORMAT
-            self.assertEqual(format_string.format(name=jr.short_name(),
-                                                  id=jr.id),
+            self.assertEqual(format_string.format(
+                    user_role=UserBecameConfirmedJudgeEvent.USER_ROLE,
+                    name=jr.short_name(),
+                    id=jr.id),
                              events[0]["description"])
             self.assertEqual(jr.id, events[0]["judging_round_id"])
             self.assertEqual(jr.short_name(), events[0]["judging_round_name"])
@@ -198,8 +220,43 @@ class TestUserHistoryView(APITestCase):
                                  UserBecameConfirmedJudgeEvent.EVENT_TYPE)
             self.assertEqual(1, len(events))
             format_string = UserBecameConfirmedJudgeEvent.JUDGING_ROUND_FORMAT
-            self.assertEqual(format_string.format(name=jr.short_name(),
-                                                  id=jr.id),
+            self.assertEqual(format_string.format(
+                    user_role=UserBecameConfirmedJudgeEvent.USER_ROLE,
+                    name=jr.short_name(),
+                    id=jr.id),
+                             events[0]["description"])
+
+    def test_user_became_desired_judge(self):
+        prg = ProgramRoleGrantFactory(
+            program_role__user_role__name=UserRole.DESIRED_JUDGE)
+        with self.login(email=self.basic_user().email):
+            url = reverse(UserHistoryView.view_name, args=[prg.person.id])
+            response = self.client.get(url)
+            events = find_events(response.data["results"],
+                                 UserBecameDesiredJudgeEvent.EVENT_TYPE)
+            self.assertEqual(1, len(events))
+            format_string = UserBecameDesiredJudgeEvent.PROGRAM_ROLE_FORMAT
+            self.assertEqual(format_string.format(
+                    user_role=UserBecameDesiredJudgeEvent.USER_ROLE,
+                    name=prg.program_role.name,
+                    id=prg.program_role.id),
+                             events[0]["description"])
+
+    def test_user_became_desired_judge_with_missing_label(self):
+        prg = ProgramRoleGrantFactory(
+            program_role__user_role__name=UserRole.DESIRED_JUDGE,
+            program_role__user_label=None)
+        with self.login(email=self.basic_user().email):
+            url = reverse(UserHistoryView.view_name, args=[prg.person.id])
+            response = self.client.get(url)
+            events = find_events(response.data["results"],
+                                 UserBecameDesiredJudgeEvent.EVENT_TYPE)
+            self.assertEqual(1, len(events))
+            format_string = UserBecameDesiredJudgeEvent.PROGRAM_ROLE_FORMAT
+            self.assertEqual(format_string.format(
+                    user_role=UserBecameDesiredJudgeEvent.USER_ROLE,
+                    name=prg.program_role.name,
+                    id=prg.program_role.id),
                              events[0]["description"])
 
     def test_user_became_confirmed_mentor(self):

--- a/web/impact/impact/v1/events/__init__.py
+++ b/web/impact/impact/v1/events/__init__.py
@@ -18,6 +18,9 @@ from impact.v1.events.user_became_confirmed_judge_event import (
 from impact.v1.events.user_became_confirmed_mentor_event import (
     UserBecameConfirmedMentorEvent,
 )
+from impact.v1.events.user_became_desired_judge_event import (
+    UserBecameDesiredJudgeEvent,
+)
 from impact.v1.events.user_became_finalist_event import (
     UserBecameFinalistEvent,
 )

--- a/web/impact/impact/v1/events/base_user_became_judge_event.py
+++ b/web/impact/impact/v1/events/base_user_became_judge_event.py
@@ -1,0 +1,56 @@
+# MIT License
+# Copyright (c) 2017 MassChallenge, Inc.
+
+from abc import (
+    ABCMeta,
+    abstractmethod,
+)
+from impact.models import UserRole
+from impact.v1.events.base_user_role_grant_event import (
+    BaseUserRoleGrantEvent,
+)
+from impact.v1.helpers import (
+    INTEGER_FIELD,
+    STRING_FIELD,
+)
+
+
+class BaseUserBecameJudgeEvent(BaseUserRoleGrantEvent):
+    __metaclass__ = ABCMeta
+
+    PROGRAM_ROLE_FORMAT = "Granted {user_role} Program Role {name} ({id})"
+    JUDGING_ROUND_FORMAT = "{user_role} for Judging Round {name} ({id})"
+
+    CLASS_FIELDS = {
+        "judging_round_id": INTEGER_FIELD,
+        "judging_round_name": STRING_FIELD,
+        }
+
+    def __init__(self, program_role_grant):
+        super().__init__(program_role_grant)
+        label = program_role_grant.program_role.user_label
+        self.judging_round = self.judging_round_from_label(label)
+
+    @abstractmethod
+    def judging_round_from_label(self, label):
+        pass  # pragma: no cover
+
+    def description(self):
+        if self.judging_round:
+            return self.JUDGING_ROUND_FORMAT.format(
+                user_role=self.USER_ROLE,
+                name=self.judging_round.short_name(),
+                id=self.judging_round.id)
+        program_role = self.program_role_grant.program_role
+        return self.PROGRAM_ROLE_FORMAT.format(
+            user_role=self.USER_ROLE,
+            name=program_role.name,
+            id=program_role.id)
+
+    def judging_round_id(self):
+        if self.judging_round:
+            return self.judging_round.id
+
+    def judging_round_name(self):
+        if self.judging_round:
+            return self.judging_round.short_name()

--- a/web/impact/impact/v1/events/user_became_desired_judge_event.py
+++ b/web/impact/impact/v1/events/user_became_desired_judge_event.py
@@ -7,11 +7,11 @@ from impact.v1.events.base_user_became_judge_event import (
 )
 
 
-class UserBecameConfirmedJudgeEvent(BaseUserBecameJudgeEvent):
-    EVENT_TYPE = "became confirmed judge"
-    USER_ROLE = UserRole.JUDGE
+class UserBecameDesiredJudgeEvent(BaseUserBecameJudgeEvent):
+    EVENT_TYPE = "became desired judge"
+    USER_ROLE = UserRole.DESIRED_JUDGE
 
     def judging_round_from_label(self, label):
         if label:
-            return label.rounds_confirmed_for.first()
+            return label.rounds_desired_for.first()
         return None

--- a/web/impact/impact/v1/views/user_history_view.py
+++ b/web/impact/impact/v1/views/user_history_view.py
@@ -6,6 +6,7 @@ from impact.v1.views.base_history_view import BaseHistoryView
 from impact.v1.events import (
     UserBecameConfirmedJudgeEvent,
     UserBecameConfirmedMentorEvent,
+    UserBecameDesiredJudgeEvent,
     UserBecameFinalistEvent,
     UserCreatedEvent,
     UserJoinedStartupEvent,
@@ -20,6 +21,7 @@ class UserHistoryView(BaseHistoryView):
     model = User
     event_classes = [UserBecameConfirmedJudgeEvent,
                      UserBecameConfirmedMentorEvent,
+                     UserBecameDesiredJudgeEvent,
                      UserBecameFinalistEvent,
                      UserCreatedEvent,
                      UserJoinedStartupEvent,


### PR DESCRIPTION
Also refactored UserBecameConfirmedJudgeEvent to create shared
base class BaseUserBecameJudgeEvent

To test:
Go to the history for an expert that has been a desired judge, e.g. localhost:8000/api/v1/user/182/history, and search for "became desired judge" and confirm that the data looks reasonable.  Events from before 6/6/2017 don't have precise "latest_datetime".
