### PR TITLE
[AC-5087] - Improve previous-next mechanism in BaseListView in impact-api

### DIFF
--- a/web/impact/impact/models/utils.py
+++ b/web/impact/impact/models/utils.py
@@ -31,7 +31,7 @@ def snake_to_model_name(value):
 
 def is_int(s):
     try:
-        int(s)
+        int(str(s))
     except ValueError:
         return False
-    return True
+    return

--- a/web/impact/impact/models/utils.py
+++ b/web/impact/impact/models/utils.py
@@ -34,4 +34,4 @@ def is_int(s):
         int(str(s))
     except ValueError:
         return False
-    return
+    return True

--- a/web/impact/impact/models/utils.py
+++ b/web/impact/impact/models/utils.py
@@ -4,7 +4,6 @@
 from django.core.exceptions import FieldDoesNotExist
 from django.utils.text import camel_case_to_spaces
 
-
 LABEL_LENGTH = 255
 
 
@@ -28,3 +27,11 @@ def model_name_to_snake(value):
 
 def snake_to_model_name(value):
     return "".join(map(str.title, value.split("_")))
+
+
+def is_int(s):
+    try:
+        int(s)
+    except ValueError:
+        return False
+    return True

--- a/web/impact/impact/tests/test_organization_list_view.py
+++ b/web/impact/impact/tests/test_organization_list_view.py
@@ -125,7 +125,7 @@ class TestOrganizationListView(APITestCase):
     def test_next_info_contains_filter(self):
         name = "foo"
         StartupFactory(organization__name=name)
-        StartupFactory.create_batch(10)
+        StartupFactory.create_batch(20)
         with self.login(email=self.basic_user().email):
             name_query_parameter = "name=%s" % name
             url = self.url + "?" + name_query_parameter

--- a/web/impact/impact/tests/test_organization_list_view.py
+++ b/web/impact/impact/tests/test_organization_list_view.py
@@ -124,8 +124,8 @@ class TestOrganizationListView(APITestCase):
 
     def test_next_info_contains_filter(self):
         name = "foo"
-        StartupFactory(organization__name=name)
-        StartupFactory.create_batch(20)
+        for i in range(20):
+            StartupFactory(organization__name=name + str(i))
         with self.login(email=self.basic_user().email):
             name_query_parameter = "name=%s" % name
             url = self.url + "?" + name_query_parameter

--- a/web/impact/impact/tests/test_user_list_view.py
+++ b/web/impact/impact/tests/test_user_list_view.py
@@ -202,6 +202,44 @@ class TestUserListView(APITestCase):
 
             assert response.data["next"] is None
 
+    def test_get_pagination_attrs_for_offset_equals_count(self):
+        limit = 4
+        for _ in range(limit * 5):
+            UserContext()
+        with self.login(email=self.basic_user().email):
+            current_offset = User.objects.count()
+            limit_arg = "limit={}".format(limit)
+            offset_arg = "offset={}".format(current_offset)
+            url = self.url + "?" + limit_arg + "&" + offset_arg
+
+            response = self.client.get(url)
+            results = response.data["results"]
+            assert len(results) == 0
+
+            prev_offset_arg = "offset={}".format(current_offset - limit)
+            assert prev_offset_arg in response.data["previous"]
+
+            assert response.data["next"] is None
+
+    def test_get_pagination_attrs_for_offset_greater_than_count(self):
+        limit = 4
+        for _ in range(limit * 5):
+            UserContext()
+        with self.login(email=self.basic_user().email):
+            count = User.objects.count()
+            current_offset = count + 1
+            limit_arg = "limit={}".format(limit)
+            offset_arg = "offset={}".format(current_offset)
+            url = self.url + "?" + limit_arg + "&" + offset_arg
+            response = self.client.get(url)
+            results = response.data["results"]
+            assert len(results) == 0
+
+            prev_offset_arg = "offset={}".format(count - limit)
+            assert prev_offset_arg in response.data["previous"]
+
+            assert response.data["next"] is None
+
     def test_get_adjacent_offsets_has_unique_users(self):
         limit = 3
         for _ in range(limit * 3):

--- a/web/impact/impact/tests/test_user_list_view.py
+++ b/web/impact/impact/tests/test_user_list_view.py
@@ -49,6 +49,7 @@ from impact.v1.views.base_list_view import (
     GREATER_THAN_MAX_LIMIT_ERROR,
     KWARG_VALUE_NOT_INTEGER_ERROR,
     KWARG_VALUE_IS_NON_POSITIVE_ERROR,
+    KWARG_VALUE_IS_NEGATIVE_ERROR,
 )
 from impact.v1.views.user_list_view import (
     EMAIL_EXISTS_ERROR,
@@ -317,7 +318,7 @@ class TestUserListView(APITestCase):
             url = self.url + "?" + offset_arg
             response = self.client.get(url)
             assert response.status_code == 401
-            error_msg = KWARG_VALUE_IS_NON_POSITIVE_ERROR.format("offset")
+            error_msg = KWARG_VALUE_IS_NEGATIVE_ERROR.format("offset")
             assert error_msg in response.data
 
     def test_get_offset_is_empty_returns_error(self):

--- a/web/impact/impact/tests/test_user_list_view.py
+++ b/web/impact/impact/tests/test_user_list_view.py
@@ -183,6 +183,25 @@ class TestUserListView(APITestCase):
             next_offset_arg = "offset={}".format(current_offset + limit)
             assert next_offset_arg in response.data["next"]
 
+    def test_get_pagination_attrs_for_offset_between_count_and_limit(self):
+        limit = 4
+        for _ in range(limit * 5):
+            UserContext()
+        current_offset = User.objects.count() - limit + 2
+        with self.login(email=self.basic_user().email):
+            limit_arg = "limit={}".format(limit)
+            offset_arg = "offset={}".format(current_offset)
+            url = self.url + "?" + limit_arg + "&" + offset_arg
+            response = self.client.get(url)
+            results = response.data["results"]
+            assert limit > len(results)
+            assert len(results) == response.data["count"] - current_offset
+
+            prev_offset_arg = "offset={}".format(current_offset - limit)
+            assert prev_offset_arg in response.data["previous"]
+
+            assert response.data["next"] is None
+
     def test_get_adjacent_offsets_has_unique_users(self):
         limit = 3
         for _ in range(limit * 3):

--- a/web/impact/impact/tests/test_user_list_view.py
+++ b/web/impact/impact/tests/test_user_list_view.py
@@ -48,6 +48,7 @@ from impact.v1.views.base_list_view import (
     DEFAULT_MAX_LIMIT,
     GREATER_THAN_MAX_LIMIT_ERROR,
     VALUE_OF_LIMIT_NOT_INTEGER_ERROR,
+    VALUE_OF_LIMIT_IS_NON_POSITIVE_ERROR,
 )
 from impact.v1.views.user_list_view import (
     EMAIL_EXISTS_ERROR,
@@ -286,6 +287,24 @@ class TestUserListView(APITestCase):
             response = self.client.get(url)
             assert response.status_code == 401
             assert VALUE_OF_LIMIT_NOT_INTEGER_ERROR in response.data
+
+    def test_get_limit_is_zero_returns_error(self):
+        with self.login(email=self.basic_user().email):
+            limit = '0'
+            limit_arg = "limit={}".format(limit)
+            url = self.url + "?" + limit_arg
+            response = self.client.get(url)
+            assert response.status_code == 401
+            assert VALUE_OF_LIMIT_IS_NON_POSITIVE_ERROR in response.data
+
+    def test_get_limit_is_below_zero_returns_error(self):
+        with self.login(email=self.basic_user().email):
+            limit = '-1'
+            limit_arg = "limit={}".format(limit)
+            url = self.url + "?" + limit_arg
+            response = self.client.get(url)
+            assert response.status_code == 401
+            assert VALUE_OF_LIMIT_IS_NON_POSITIVE_ERROR in response.data
 
     def test_get_adjacent_offsets_has_unique_users(self):
         limit = 3

--- a/web/impact/impact/tests/test_user_list_view.py
+++ b/web/impact/impact/tests/test_user_list_view.py
@@ -47,8 +47,8 @@ from impact.v1.helpers.model_helper import (
 from impact.v1.views.base_list_view import (
     DEFAULT_MAX_LIMIT,
     GREATER_THAN_MAX_LIMIT_ERROR,
-    VALUE_OF_LIMIT_NOT_INTEGER_ERROR,
-    VALUE_OF_LIMIT_IS_NON_POSITIVE_ERROR,
+    KWARG_VALUE_NOT_INTEGER_ERROR,
+    KWARG_VALUE_IS_NON_POSITIVE_ERROR,
 )
 from impact.v1.views.user_list_view import (
     EMAIL_EXISTS_ERROR,
@@ -277,7 +277,8 @@ class TestUserListView(APITestCase):
             url = self.url + "?" + limit_arg
             response = self.client.get(url)
             assert response.status_code == 401
-            assert VALUE_OF_LIMIT_NOT_INTEGER_ERROR in response.data
+            error_msg = KWARG_VALUE_NOT_INTEGER_ERROR.format("limit")
+            assert error_msg in response.data
 
     def test_get_limit_is_non_integer_return_error(self):
         with self.login(email=self.basic_user().email):
@@ -286,7 +287,8 @@ class TestUserListView(APITestCase):
             url = self.url + "?" + limit_arg
             response = self.client.get(url)
             assert response.status_code == 401
-            assert VALUE_OF_LIMIT_NOT_INTEGER_ERROR in response.data
+            error_msg = KWARG_VALUE_NOT_INTEGER_ERROR.format("limit")
+            assert error_msg in response.data
 
     def test_get_limit_is_zero_returns_error(self):
         with self.login(email=self.basic_user().email):
@@ -295,16 +297,58 @@ class TestUserListView(APITestCase):
             url = self.url + "?" + limit_arg
             response = self.client.get(url)
             assert response.status_code == 401
-            assert VALUE_OF_LIMIT_IS_NON_POSITIVE_ERROR in response.data
+            error_msg = KWARG_VALUE_IS_NON_POSITIVE_ERROR.format("limit")
+            assert error_msg in response.data
 
-    def test_get_limit_is_below_zero_returns_error(self):
+    def test_get_limit_is_negative_returns_error(self):
         with self.login(email=self.basic_user().email):
             limit = '-1'
             limit_arg = "limit={}".format(limit)
             url = self.url + "?" + limit_arg
             response = self.client.get(url)
             assert response.status_code == 401
-            assert VALUE_OF_LIMIT_IS_NON_POSITIVE_ERROR in response.data
+            error_msg = KWARG_VALUE_IS_NON_POSITIVE_ERROR.format("limit")
+            assert error_msg in response.data
+
+    def test_get_offset_is_negative_returns_error(self):
+        with self.login(email=self.basic_user().email):
+            offset = '-1'
+            offset_arg = "offset={}".format(offset)
+            url = self.url + "?" + offset_arg
+            response = self.client.get(url)
+            assert response.status_code == 401
+            error_msg = KWARG_VALUE_IS_NON_POSITIVE_ERROR.format("offset")
+            assert error_msg in response.data
+
+    def test_get_offset_is_empty_returns_error(self):
+        with self.login(email=self.basic_user().email):
+            offset = ''
+            offset_arg = "offset={}".format(offset)
+            url = self.url + "?" + offset_arg
+            response = self.client.get(url)
+            assert response.status_code == 401
+            error_msg = KWARG_VALUE_NOT_INTEGER_ERROR.format("offset")
+            assert error_msg in response.data
+
+    def test_get_offset_is_non_integer_returns_error(self):
+        with self.login(email=self.basic_user().email):
+            offset = '5.5'
+            offset_arg = "offset={}".format(offset)
+            url = self.url + "?" + offset_arg
+            response = self.client.get(url)
+            assert response.status_code == 401
+            error_msg = KWARG_VALUE_NOT_INTEGER_ERROR.format("offset")
+            assert error_msg in response.data
+
+    def test_get_offset_is_explicit_zero_returns_successfully(self):
+        with self.login(email=self.basic_user().email):
+            offset = '0'
+            offset_arg = "offset={}".format(offset)
+            url = self.url + "?" + offset_arg
+            response = self.client.get(url)
+            assert response.status_code == 200
+            implicit_zero_response = self.client.get(self.url)
+            assert response.data == implicit_zero_response.data
 
     def test_get_adjacent_offsets_has_unique_users(self):
         limit = 3

--- a/web/impact/impact/v1/views/base_list_view.py
+++ b/web/impact/impact/v1/views/base_list_view.py
@@ -55,20 +55,28 @@ class BaseListView(ImpactView):
         }
         return Response(result)
 
-    def _validate_kwarg(self, val, key="limit"):
+    def _validate_kwarg(self, val, key):
         if not is_int(val):
             self.errors.append(KWARG_VALUE_NOT_INTEGER_ERROR.format(key))
             return None
-        if int(val) > self.MAX_LIMIT and key == "limit":
+        if key == "limit":
+            self._validate_limit(key, val)
+        if key == "offset":
+            self._validate_offset(key, val)
+        return int(val)
+
+    def _validate_offset(self, key, val):
+        if int(val) < 0:
+            self.errors.append(
+                KWARG_VALUE_IS_NON_POSITIVE_ERROR.format(key))
+
+    def _validate_limit(self, key, val):
+        if int(val) > self.MAX_LIMIT:
             error_msg = GREATER_THAN_MAX_LIMIT_ERROR.format(self.MAX_LIMIT)
             self.errors.append(error_msg)
-        elif int(val) <= 0 and key == "limit":
+        elif int(val) <= 0:
             self.errors.append(
                 KWARG_VALUE_IS_NON_POSITIVE_ERROR.format(key))
-        elif int(val) < 0 and key == "offset":
-            self.errors.append(
-                KWARG_VALUE_IS_NON_POSITIVE_ERROR.format(key))
-        return int(val)
 
     def results(self, limit, offset):
         queryset = self.helper_class.all_objects()

--- a/web/impact/impact/v1/views/base_list_view.py
+++ b/web/impact/impact/v1/views/base_list_view.py
@@ -39,7 +39,7 @@ class BaseListView(ImpactView):
         result = {
             "count": count,
             "next": _next_url(base_url, limit, offset, count),
-            "previous": _previous_url(base_url, limit, offset),
+            "previous": _previous_url(base_url, limit, offset, count),
             "results": results,
         }
         return Response(result)
@@ -85,7 +85,7 @@ class BaseListView(ImpactView):
         return qs
 
 
-def _previous_url(base_url, limit, offset):
+def _previous_url(base_url, limit, offset, count):
     if offset == 0:
         return None
     elif 0 <= offset < limit:
@@ -93,7 +93,7 @@ def _previous_url(base_url, limit, offset):
         return url
     else:
         url = _update_query_param(base_url, "limit", limit)
-        url = _update_query_param(url, "offset", offset - limit)
+        url = _update_query_param(url, "offset", min(offset, count) - limit)
         return url
     # todo: refactor
 
@@ -105,6 +105,7 @@ def _next_url(base_url, limit, offset, count):
         url = _update_query_param(base_url, "limit", limit)
         url = _update_query_param(url, "offset", offset + limit)
         return url
+    # todo: refactor
     return None
 
 

--- a/web/impact/impact/v1/views/base_list_view.py
+++ b/web/impact/impact/v1/views/base_list_view.py
@@ -29,7 +29,7 @@ DEFAULT_MAX_LIMIT = 200
 class BaseListView(ImpactView):
     __metaclass__ = ABCMeta
     MAX_LIMIT = DEFAULT_MAX_LIMIT
-    DEFAULT_LIMIT = '10'
+    DEFAULT_LIMIT = 10
 
     def metadata(self):
         result = {}
@@ -41,7 +41,7 @@ class BaseListView(ImpactView):
 
     def get(self, request):
         limit = self._validate_limit(
-            request.GET.get('limit', self.DEFAULT_LIMIT))
+            request.GET.get('limit', str(self.DEFAULT_LIMIT)))
         if self.errors:
             return Response(status=401, data=self.errors)
         offset = int(request.GET.get('offset', 0))

--- a/web/impact/impact/v1/views/base_list_view.py
+++ b/web/impact/impact/v1/views/base_list_view.py
@@ -22,7 +22,6 @@ from impact.models.utils import model_has_field, is_int
 GREATER_THAN_MAX_LIMIT_ERROR = "maximum allowed value for 'limit' is {}."
 KWARG_VALUE_NOT_INTEGER_ERROR = "value of '{}' should be an integer."
 KWARG_VALUE_IS_NON_POSITIVE_ERROR = "value of '{}' should be positive."
-
 DEFAULT_MAX_LIMIT = 200
 
 
@@ -115,14 +114,13 @@ class BaseListView(ImpactView):
 def _previous_url(base_url, limit, offset, count):
     if offset == 0:
         return None
-    elif 0 <= offset < limit:
+    elif 0 < offset <= limit:
         url = _update_query_param(base_url, "limit", limit)
         return url
     else:
         url = _update_query_param(base_url, "limit", limit)
         url = _update_query_param(url, "offset", min(offset, count) - limit)
         return url
-    # todo: refactor
 
 
 def _next_url(base_url, limit, offset, count):
@@ -131,8 +129,6 @@ def _next_url(base_url, limit, offset, count):
     url = _update_query_param(base_url, "limit", limit)
     url = _update_query_param(url, "offset", offset + limit)
     return url
-    # todo: validate offset is always >=0
-    # todo: refactor
 
 
 def _base_url(request):

--- a/web/impact/impact/v1/views/base_list_view.py
+++ b/web/impact/impact/v1/views/base_list_view.py
@@ -38,8 +38,8 @@ class BaseListView(ImpactView):
         count, results = self.results(limit, offset)
         result = {
             "count": count,
-            "next": _url(base_url, limit, offset + limit),
-            "previous": _url(base_url, limit, offset - limit),
+            "next": _next_url(base_url, limit, offset),
+            "previous": _previous_url(base_url, limit, offset),
             "results": results,
         }
         return Response(result)
@@ -85,10 +85,23 @@ class BaseListView(ImpactView):
         return qs
 
 
-def _url(base_url, limit, offset):
+def _previous_url(base_url, limit, offset):
+    if offset == 0:
+        return None
+    elif 0 <= offset < limit:
+        url = _update_query_param(base_url, "limit", limit)
+        return url
+    else:
+        url = _update_query_param(base_url, "limit", limit)
+        url = _update_query_param(url, "offset", offset - limit)
+        return url
+    # todo: refactor
+
+
+def _next_url(base_url, limit, offset):
     if offset >= 0:
         url = _update_query_param(base_url, "limit", limit)
-        url = _update_query_param(url, "offset", offset)
+        url = _update_query_param(url, "offset", offset + limit)
         return url
     return None
 

--- a/web/impact/impact/v1/views/base_list_view.py
+++ b/web/impact/impact/v1/views/base_list_view.py
@@ -69,8 +69,8 @@ class BaseListView(ImpactView):
         return self._validate_limit(limit_input)
 
     def _validate_limit(self, val):
-        if not is_int(val):
-            self.errors.append(KWARG_VALUE_NOT_INTEGER_ERROR.format("limit"))
+        val = self._validate_integer(val, key="limit")
+        if val is None:
             return None
         val = int(val)
         if val > self.MAX_LIMIT:
@@ -82,12 +82,18 @@ class BaseListView(ImpactView):
         return val
 
     def _validate_offset(self, val):
-        if not is_int(val):
-            self.errors.append(KWARG_VALUE_NOT_INTEGER_ERROR.format("offset"))
+        val = self._validate_integer(val, key="offset")
+        if val is None:
             return None
         val = int(val)
         if val < 0:
             self.errors.append(KWARG_VALUE_IS_NEGATIVE_ERROR.format("offset"))
+        return val
+
+    def _validate_integer(self, val, key):
+        if not is_int(val):
+            self.errors.append(KWARG_VALUE_NOT_INTEGER_ERROR.format(key))
+            return None
         return val
 
     def results(self, limit, offset):

--- a/web/impact/impact/v1/views/base_list_view.py
+++ b/web/impact/impact/v1/views/base_list_view.py
@@ -17,10 +17,11 @@ from impact.v1.helpers import (
 )
 from impact.v1.views import ImpactView
 from impact.utils import parse_date
-from impact.models.utils import model_has_field
+from impact.models.utils import model_has_field, is_int
 
-VALUE_OF_LIMIT_NOT_INTEGER_ERROR = "value of 'limit' should be an integer"
-GREATER_THAN_MAX_LIMIT_ERROR = "maximum allowed value for 'limit' is {}"
+GREATER_THAN_MAX_LIMIT_ERROR = "maximum allowed value for 'limit' is {}."
+VALUE_OF_LIMIT_NOT_INTEGER_ERROR = "value of 'limit' should be an integer."
+VALUE_OF_LIMIT_IS_NON_POSITIVE_ERROR = "value of 'limit' should be positive."
 
 DEFAULT_MAX_LIMIT = 200
 
@@ -55,12 +56,14 @@ class BaseListView(ImpactView):
         return Response(result)
 
     def _validate_limit(self, limit):
-        if not limit.isdigit():
+        if not is_int(limit):
             self.errors.append(VALUE_OF_LIMIT_NOT_INTEGER_ERROR)
-            limit = self.DEFAULT_LIMIT
-        elif int(limit) > self.MAX_LIMIT:
-            self.errors.append(
-                GREATER_THAN_MAX_LIMIT_ERROR.format(self.MAX_LIMIT))
+            return None
+        if int(limit) > self.MAX_LIMIT:
+            error_msg = GREATER_THAN_MAX_LIMIT_ERROR.format(self.MAX_LIMIT)
+            self.errors.append(error_msg)
+        elif int(limit) <= 0:
+            self.errors.append(VALUE_OF_LIMIT_IS_NON_POSITIVE_ERROR)
         return int(limit)
 
     def results(self, limit, offset):

--- a/web/impact/impact/v1/views/base_list_view.py
+++ b/web/impact/impact/v1/views/base_list_view.py
@@ -38,7 +38,7 @@ class BaseListView(ImpactView):
         count, results = self.results(limit, offset)
         result = {
             "count": count,
-            "next": _next_url(base_url, limit, offset),
+            "next": _next_url(base_url, limit, offset, count),
             "previous": _previous_url(base_url, limit, offset),
             "results": results,
         }
@@ -98,7 +98,9 @@ def _previous_url(base_url, limit, offset):
     # todo: refactor
 
 
-def _next_url(base_url, limit, offset):
+def _next_url(base_url, limit, offset, count):
+    if offset+limit >= count:
+        return None
     if offset >= 0:
         url = _update_query_param(base_url, "limit", limit)
         url = _update_query_param(url, "offset", offset + limit)

--- a/web/impact/impact/v1/views/base_list_view.py
+++ b/web/impact/impact/v1/views/base_list_view.py
@@ -17,7 +17,10 @@ from impact.v1.helpers import (
 )
 from impact.v1.views import ImpactView
 from impact.utils import parse_date
-from impact.models.utils import model_has_field, is_int
+from impact.models.utils import (
+    is_int,
+    model_has_field,
+)
 
 GREATER_THAN_MAX_LIMIT_ERROR = "maximum allowed value for 'limit' is {}."
 KWARG_VALUE_NOT_INTEGER_ERROR = "value of '{}' should be an integer."


### PR DESCRIPTION
**Changes Introduced in [AC-5087](https://masschallenge.atlassian.net/browse/AC-5087):**

- validate offset and limit values to be correct (offset is a non-negative integer, limit is a positive integer smaller than MAX_LIMIT=200).
- fix generation of previous/next urls around edge cases (close to offset==0 or offset==count)

**Test:**

- glossary:
  - limit - the number of results returned in the response ("results per page").
  - offset - the index of the element that begins the response window ([offset:offset+limit])
  - count - the total number of results in a request (NOT a parameter)


- Setup:
  - `make dev; 
make load-remote-db DB_FILE_NAME=initial_schema.sql.gz; 
make grant-permissions PERMISSION_USER=test@example.org PERMISSION_CLASSES=v1_clients`
  - [Create an application](http://localhost:8000/oauth/applications/register/) for the user with the permissions.
  - Load [Postman collection](https://www.getpostman.com/collections/0a95773f88df764b15ee), initialize the token
  - in V1 folder, open v1 user list GET
  - make the default call, see that it works, and is the same as development
- Test:
  - set the query parameters ?limit=20 . Same as development.
  - set the query parameters ?limit=10&offset=5 . On development, "previous" would have a negative offset. On branch it does not (will be have an implicit offset=0).
  - set the query parameters ?limit=10&offset=15. Should be the same as development.
  - set the query parameters ?limit=10&offset=47915 (count=47920). "next" will be null on branch.
  - set the query parameters ?limit=10&offset=50000 (count=47920). "previous" will be 47910(= count-limit) on branch.
  - Go to "v1 program family list GET". set the query parameters ?limit=20 (count=11). "next" and "previous" should both be null on branch.
  - set the query parameters ?limit=300. See error on branch.
  - set the query parameters ?limit=5.5. See error on branch.
  - set the query parameters ?limit=0. See error on branch.
  - set the query parameters ?limit=-5. See error on branch.
  - set the query parameters ?limit=foo. See error on branch.
  - set the query parameters ?offset=5.5. See error on branch.
  - set the query parameters ?offset=-5. See error on branch.
  - set the query parameters ?offset=foo. See error on branch.
  - set the query parameters ?offset=0. The same as not adding the parameter, successful.