### PR TITLE
AC-5199 - get impact-api deploy working

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,19 +229,9 @@ tool. Steps for setting this up can be found here:
 
 http://docs.aws.amazon.com/cli/latest/userguide/installing.html
 
-Note: On Dec. 18, 2017 we were not able to do the deploy with the
-latest version (1.14.11) and had to lock on a previous version using
-```sudo pip install 'awscli<1.12'```.  For Nathan this resulted in
-installed 1.12.190.  Yotam indicated that he used 1.11.75
-successfully.
+Install `aws` (version 1.14.14 or later): `pip install awscli`
 
-You must also install the ecs-deploy tool via:
-`pip install ecs-deploy`
-
-Note: On Dec. 18, 2017 Nathan used version 1.3.1 for this.  Yotam
-reports that he was using 1.4.3.
-
-This may require sudo depending on how your local host is configured.
+Install `ecs` (version 1.4.3 or later): `pip install ecs-deploy`
 
 You will also need to configure an AWS access key and secret key for
 doing the deploy.  Steps for creating access keys can be found here:


### PR DESCRIPTION
## [AC-5199](https://masschallenge.atlassian.net/browse/AC-5199) 

Summary of what I discovered: The deployment problem was not caused by **awscli**, but by **ecs-deploy**. This is detailed in [a comment](https://masschallenge.atlassian.net/browse/AC-5199?focusedCommentId=37760&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-37760).

The PR is to explicitly state the versions that we know work. (I didn't spend time testing older versions for failure, I saw no reason not to just use the latest of both.) 

I removed the note about `sudo` from the README because I think most developers will be using virtualenvs for this, and we don't say anything else about environment management in our docs. 
