### PR TITLE
[AC-5211] - Production Ready Impact-api Cluster - Register Correctly on Newrelic

### DIFF
--- a/web/impact/newrelic.ini
+++ b/web/impact/newrelic.ini
@@ -210,7 +210,7 @@ app_name = MC Impact API Production
 monitor_mode = true
 
 [newrelic:temp]
-app_name = MC Impact API Temp (Production DB)
+app_name = MC Impact API Temp
 monitor_mode = true
 
 # ---------------------------------------------------------------------------

--- a/web/impact/newrelic.ini
+++ b/web/impact/newrelic.ini
@@ -209,4 +209,8 @@ monitor_mode = true
 app_name = MC Impact API Production
 monitor_mode = true
 
+[newrelic:temp]
+app_name = MC Impact API Temp (Production DB)
+monitor_mode = true
+
 # ---------------------------------------------------------------------------

--- a/web/impact/newrelic.ini
+++ b/web/impact/newrelic.ini
@@ -192,7 +192,7 @@ thread_profiler.enabled = true
 # override the common environment settings. The settings related to a
 # specific environment will be used when the environment argument to the
 # newrelic.agent.initialize() function has been defined to be either
-# "development", "test", "staging" or "production".
+# "development", "test", "staging", "temp" or "production".
 #
 
 [newrelic:development]


### PR DESCRIPTION
**Changes Introduced:**

- Added a separate environment name for the "temp" cluster.

**Test:**
- Has no effect at the moment (will have only after merge with master).
  - post-merge, I'll create a release, and then reconfigure the "temp" cluster to use this new environment. After that, New Relic should have this new Environment available and collecting data from temp.api.masschallenge.org
  