### PR TITLE
[AC-5296] ripping out logging

### DIFF
--- a/web/impact/impact/v0/views/job_posting_detail_view.py
+++ b/web/impact/impact/v0/views/job_posting_detail_view.py
@@ -3,7 +3,6 @@
 
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from rest_framework_tracking.mixins import LoggingMixin
 
 from impact.permissions import V0APIPermissions
 from impact.v0.api_data.job_posting_detail_data import (
@@ -16,7 +15,7 @@ from impact.v0.views.utils import (
 )
 
 
-class JobPostingDetailView(LoggingMixin, APIView):
+class JobPostingDetailView(APIView):
     permission_classes = (V0APIPermissions,)
 
     def __init__(self, *args, **kwargs):

--- a/web/impact/impact/v0/views/job_posting_list_view.py
+++ b/web/impact/impact/v0/views/job_posting_list_view.py
@@ -4,7 +4,6 @@
 from django.db.models import Q
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from rest_framework_tracking.mixins import LoggingMixin
 
 from impact.models import (
     JobPosting,
@@ -37,7 +36,7 @@ JOBS_IN_PROGRAMS = [
     "in"]
 
 
-class JobPostingListView(LoggingMixin, APIView):
+class JobPostingListView(APIView):
     permission_classes = (V0APIPermissions,)
 
     def __init__(self, *args, **kwargs):

--- a/web/impact/impact/v0/views/startup_detail_view.py
+++ b/web/impact/impact/v0/views/startup_detail_view.py
@@ -9,7 +9,6 @@ from embed_video.backends import (
 )
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from rest_framework_tracking.mixins import LoggingMixin
 
 from impact.permissions import (
     V0APIPermissions,
@@ -52,7 +51,7 @@ MAX_VIDEO_WIDTH = 960
 MAX_VIDEO_HEIGHT = 720
 
 
-class StartupDetailView(LoggingMixin, APIView):
+class StartupDetailView(APIView):
     permission_classes = (
         V0APIPermissions,
     )

--- a/web/impact/impact/v0/views/startup_list_view.py
+++ b/web/impact/impact/v0/views/startup_list_view.py
@@ -6,7 +6,6 @@ from collections import OrderedDict
 from django.db.models import Q
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from rest_framework_tracking.mixins import LoggingMixin
 
 from impact.models import (
     Startup,
@@ -49,7 +48,7 @@ STARTUP_TO_STEALTH_STATUS = [
 ]
 
 
-class StartupListView(LoggingMixin, APIView):
+class StartupListView(APIView):
     permission_classes = (
         V0APIPermissions,
     )


### PR DESCRIPTION
in the interest of expediency (and because we may re-introduce the logging at some point) i've simply tugged out the mixin from all the views to disable logging to the database. we should get this out as soon as we possible (we will run out of disk space soon on the db prod api is pointed at)