### PR TITLE
[AC-5289-impact] Update impact-api to point to current django-accelerator release

### DIFF
--- a/web/impact/requirements/base.txt
+++ b/web/impact/requirements/base.txt
@@ -36,7 +36,7 @@ djangorestframework
 djangorestframework-jwt
 drf-schema-adapter
 drf-tracking
-git+https://github.com/masschallenge/django-accelerator.git@2017.11.09#egg=django-accelerator
+git+https://github.com/masschallenge/django-accelerator.git@2018.12.29#egg=django-accelerator
 
 # django-configurations from Git master (needed for Django 1.8 support)
 git+https://github.com/jezdez/django-configurations

--- a/web/impact/requirements/base.txt
+++ b/web/impact/requirements/base.txt
@@ -36,7 +36,7 @@ djangorestframework
 djangorestframework-jwt
 drf-schema-adapter
 drf-tracking
-git+https://github.com/masschallenge/django-accelerator.git@2018.12.29#egg=django-accelerator
+git+https://github.com/masschallenge/django-accelerator.git@2018.01.29#egg=django-accelerator
 
 # django-configurations from Git master (needed for Django 1.8 support)
 git+https://github.com/jezdez/django-configurations


### PR DESCRIPTION
AC-5289 triggered a new release of impact-api, this PR just keeps the api repo in sync with that latest release