### PR TITLE
AC-5238 Add Nginx/Supervisord-level Papertrail Logging to Impact API

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update -y
 RUN apt-get install -y gettext mysql-client netcat nginx python-setuptools python2.7
 
 # Install remote_syslog2 to talk to papertrail
-RUN cd /tmp/ && curl -LO https://github.com/papertrail/remote_syslog2/releases/download/v0.20/remote-syslog2_0.20_amd64.deb
+RUN cd /tmp/ && curl -LOs https://github.com/papertrail/remote_syslog2/releases/download/v0.20/remote-syslog2_0.20_amd64.deb
 RUN dpkg -i /tmp/remote-syslog2_0.20_amd64.deb
 
 # Copy config files after installation so installers don't get tripped up

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -3,31 +3,29 @@ FROM python:3.6
 WORKDIR /wwwroot
 
 COPY impact /wwwroot
-
 COPY scripts/start.sh /usr/bin
-
 COPY scripts/start-nodaemon.sh /usr/bin
 
 RUN apt-get update -y
 
 # python2.7 is required to run supervisor
-RUN apt-get install -y netcat mysql-client python2.7 python-setuptools nginx
+RUN apt-get install -y gettext netcat mysql-client nginx python2.7 python-setuptools
 
+# Install remote_syslog2 to talk to papertrail
+RUN cd /tmp/ && curl -LO https://github.com/papertrail/remote_syslog2/releases/download/v0.20/remote-syslog2_0.20_amd64.deb
+RUN dpkg -i /tmp/remote-syslog2_0.20_amd64.deb
+
+# Copy config files after installation so installers don't get tripped up
+COPY log_files.yml /etc/log_files.yml
 COPY nginx/nginx.conf /etc/nginx
 
 RUN pip install --upgrade pip
-
 RUN easy_install-2.7 supervisor
-
 RUN pip3 install -r requirements/dev.txt
 
 RUN useradd -s /bin/bash -u 3000 -M impact_user
-
 RUN chown impact_user /usr/bin/start.sh
-
 RUN chown -R impact_user /wwwroot
-
-RUN apt-get install -y gettext
 
 USER impact_user
 

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -9,7 +9,7 @@ COPY scripts/start-nodaemon.sh /usr/bin
 RUN apt-get update -y
 
 # python2.7 is required to run supervisor
-RUN apt-get install -y gettext netcat mysql-client nginx python2.7 python-setuptools
+RUN apt-get install -y gettext mysql-client netcat nginx python-setuptools python2.7
 
 # Install remote_syslog2 to talk to papertrail
 RUN cd /tmp/ && curl -LO https://github.com/papertrail/remote_syslog2/releases/download/v0.20/remote-syslog2_0.20_amd64.deb

--- a/web/log_files.yml
+++ b/web/log_files.yml
@@ -1,0 +1,9 @@
+hostname: impact-api
+files: 
+  - /var/log/supervisord.log
+  - /var/log/nginx/access.log
+  - /var/log/nginx/error.log
+destination:
+  host: logs2.papertrailapp.com
+  port: 19120
+  protocol: tls

--- a/web/nginx/nginx.conf
+++ b/web/nginx/nginx.conf
@@ -25,8 +25,8 @@ http {
     ##
     # Logging Settings
     ##
-    access_log /dev/stdout;
-    error_log /dev/stdout info;
+    access_log /var/log/nginx/access.log;
+    error_log /var/log/nginx/access.log info;
 
     ##
     # Gzip Settings

--- a/web/nginx/nginx.conf
+++ b/web/nginx/nginx.conf
@@ -26,7 +26,7 @@ http {
     # Logging Settings
     ##
     access_log /var/log/nginx/access.log;
-    error_log /var/log/nginx/access.log info;
+    error_log /var/log/nginx/error.log info;
 
     ##
     # Gzip Settings

--- a/web/scripts/start.sh
+++ b/web/scripts/start.sh
@@ -13,3 +13,4 @@ python3 manage.py migrate --noinput
 python3 manage.py collectstatic --noinput
 service nginx restart
 supervisord -c supervisord.conf
+remote_syslog

--- a/web/scripts/start.sh
+++ b/web/scripts/start.sh
@@ -1,20 +1,22 @@
 #!/bin/bash
 cd /wwwroot
+
 if [ "${DJANGO_CONFIGURATION}" == "Dev" ]
 then
-echo "waiting on mysql"
-while ! mysqladmin ping -h"mysql" -u --silent 2>/dev/null; do
-        sleep 3
-        echo "..."
-done
+    echo "waiting on mysql"
+    while ! mysqladmin ping -h"mysql" -u --silent 2>/dev/null; do
+            sleep 3
+            echo "..."
+    done
 fi
 
 python3 manage.py migrate --noinput
 python3 manage.py collectstatic --noinput
-service nginx restart
-supervisord -c supervisord.conf
 
 if [ "${DJANGO_CONFIGURATION}" == "Prod" ]
 then
     remote_syslog
 fi
+
+service nginx restart
+supervisord -c supervisord.conf

--- a/web/scripts/start.sh
+++ b/web/scripts/start.sh
@@ -13,4 +13,8 @@ python3 manage.py migrate --noinput
 python3 manage.py collectstatic --noinput
 service nginx restart
 supervisord -c supervisord.conf
-remote_syslog
+
+if [ "${DJANGO_CONFIGURATION}" == "Prod" ]
+then
+    remote_syslog
+fi


### PR DESCRIPTION
## [AC-5238](https://masschallenge.atlassian.net/browse/AC-5238)

You can test this locally by changing [start.sh line 16](https://github.com/masschallenge/impact-api/blob/AC-5238/web/scripts/start.sh#L16) to say `"Dev"` instead of `"Prod"` -- then logs will be sent from your dev machine.

The system name on Papertrail is [impact-api](https://papertrailapp.com/systems/impact-api/events) and I've created an [Impact API](https://papertrailapp.com/groups/8659131) group in Papertrail to hold it.