### PR TITLE
AC-5431 - fix authentication to ECR in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ after_success:
 - pip install awscli;
 - export PATH=$PATH:$HOME/.local/bin;
 - export TAG=$(if [ "$RELEASE_TAG" = "" ]; then echo "$BRANCH"; else echo "$RELEASE_TAG"; fi);
-- export ECR_TOKEN=`aws ecr get-authorization-token --output text --query 'authorizationData[].authorizationToken' | base64 -D | cut -d':' -f2`
+- export ECR_TOKEN=`aws ecr get-authorization-token --output text --query 'authorizationData[].authorizationToken' | cut -d':' -f2`
 - export ECR_HOST=$(aws ecr get-authorization-token --output text --query 'authorizationData[].proxyEndpoint')
 - export DOCKER_USER=AWS
 - export DOCKER_PASSWORD=$ECR_TOKEN

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,5 +49,4 @@ after_success:
 - export ECR_TOKEN=`aws ecr get-authorization-token --output text --query 'authorizationData[].authorizationToken' | base64 -D | cut -d':' -f2`
 - export ECR_HOST=$(aws ecr get-authorization-token --output text --query 'authorizationData[].proxyEndpoint')
 - echo $ECR_TOKEN | docker login -u AWS --password-stdin $ECR_HOST
-#- eval $(aws ecr get-login --region us-east-1 --no-include-email);
 - make travis-release AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY ENVIRONMENT=$DEPLOY_ENVIRONMENT DOCKER_REGISTRY=$DOCKER_REGISTRY IMAGE_TAG=$TAG;

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,9 +46,9 @@ after_success:
 - pip install awscli;
 - export PATH=$PATH:$HOME/.local/bin;
 - export TAG=$(if [ "$RELEASE_TAG" = "" ]; then echo "$BRANCH"; else echo "$RELEASE_TAG"; fi);
-- export ECR_TOKEN=`aws ecr get-authorization-token --output text --query 'authorizationData[].authorizationToken' | base64 --decode | cut -d':' -f2`
-- export ECR_HOST=$(aws ecr get-authorization-token --output text --query 'authorizationData[].proxyEndpoint')
+- export ECR_TOKEN=`aws ecr get-authorization-token --region us-east-1 --output text --query 'authorizationData[].authorizationToken' | base64 --decode | cut -d':' -f2`
+- export ECR_HOST=$(aws ecr get-authorization-token --region us-east-1 --output text --query 'authorizationData[].proxyEndpoint')
 - export DOCKER_USER=AWS
 - export DOCKER_PASSWORD=$ECR_TOKEN
-- echo DOCKER_PASSWORD | docker login -u $DOCKER_USER --password-stdin $ECR_HOST
+- echo $DOCKER_PASSWORD | docker login -u $DOCKER_USER --password-stdin $ECR_HOST
 - make travis-release AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY ENVIRONMENT=$DEPLOY_ENVIRONMENT DOCKER_REGISTRY=$DOCKER_REGISTRY IMAGE_TAG=$TAG;

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,5 +50,5 @@ after_success:
 - export ECR_HOST=$(aws ecr get-authorization-token --output text --query 'authorizationData[].proxyEndpoint')
 - export DOCKER_USER=AWS
 - export DOCKER_PASSWORD=$ECR_TOKEN
-- docker login -u $DOCKER_USER --p $DOCKER_PASSWORD $ECR_HOST
+- echo DOCKER_PASSWORD | docker login -u $DOCKER_USER --password-stdin $ECR_HOST
 - make travis-release AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY ENVIRONMENT=$DEPLOY_ENVIRONMENT DOCKER_REGISTRY=$DOCKER_REGISTRY IMAGE_TAG=$TAG;

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,5 +48,6 @@ after_success:
 - export TAG=$(if [ "$RELEASE_TAG" = "" ]; then echo "$BRANCH"; else echo "$RELEASE_TAG"; fi);
 - export ECR_TOKEN=`aws ecr get-authorization-token --output text --query 'authorizationData[].authorizationToken' | base64 -D | cut -d':' -f2`
 - export ECR_HOST=$(aws ecr get-authorization-token --output text --query 'authorizationData[].proxyEndpoint')
-- echo $ECR_TOKEN | docker login -u AWS --password-stdin $ECR_HOST
+- export DOCKER_USER=AWS
+- echo $ECR_TOKEN | docker login -u $DOCKER_USER --password-stdin $ECR_HOST
 - make travis-release AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY ENVIRONMENT=$DEPLOY_ENVIRONMENT DOCKER_REGISTRY=$DOCKER_REGISTRY IMAGE_TAG=$TAG;

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,5 +50,5 @@ after_success:
 - export ECR_HOST=$(aws ecr get-authorization-token --output text --query 'authorizationData[].proxyEndpoint')
 - export DOCKER_USER=AWS
 - export DOCKER_PASSWORD=$ECR_TOKEN
-- echo $ECR_TOKEN | docker login -u $DOCKER_USER --p $DOCKER_PASSWORD $ECR_HOST
+- docker login -u $DOCKER_USER --p $DOCKER_PASSWORD $ECR_HOST
 - make travis-release AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY ENVIRONMENT=$DEPLOY_ENVIRONMENT DOCKER_REGISTRY=$DOCKER_REGISTRY IMAGE_TAG=$TAG;

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ after_success:
 - pip install awscli;
 - export PATH=$PATH:$HOME/.local/bin;
 - export TAG=$(if [ "$RELEASE_TAG" = "" ]; then echo "$BRANCH"; else echo "$RELEASE_TAG"; fi);
-- export ECR_TOKEN=`aws ecr get-authorization-token --output text --query 'authorizationData[].authorizationToken' | cut -d':' -f2`
+- export ECR_TOKEN=`aws ecr get-authorization-token --output text --query 'authorizationData[].authorizationToken' | base64 --decode | cut -d':' -f2`
 - export ECR_HOST=$(aws ecr get-authorization-token --output text --query 'authorizationData[].proxyEndpoint')
 - export DOCKER_USER=AWS
 - export DOCKER_PASSWORD=$ECR_TOKEN

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,9 +46,7 @@ after_success:
 - pip install awscli;
 - export PATH=$PATH:$HOME/.local/bin;
 - export TAG=$(if [ "$RELEASE_TAG" = "" ]; then echo "$BRANCH"; else echo "$RELEASE_TAG"; fi);
-- export ECR_TOKEN=$(aws ecr get-authorization-token --output text \
-  --query 'authorizationData[].authorizationToken' \
-  | base64 -D | cut -d: -f2)
+- export ECR_TOKEN=`aws ecr get-authorization-token --output text --query 'authorizationData[].authorizationToken' | base64 -D | cut -d':' -f2`
 - export ECR_HOST=$(aws ecr get-authorization-token --output text --query 'authorizationData[].proxyEndpoint')
 - echo $ECR_TOKEN | docker login -u AWS --password-stdin $ECR_HOST
 #- eval $(aws ecr get-login --region us-east-1 --no-include-email);

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,5 +50,5 @@ after_success:
 - export ECR_HOST=$(aws ecr get-authorization-token --region us-east-1 --output text --query 'authorizationData[].proxyEndpoint')
 - export DOCKER_USER=AWS
 - export DOCKER_PASSWORD=$ECR_TOKEN
-- echo $DOCKER_PASSWORD | docker login -u $DOCKER_USER --password-stdin $ECR_HOST
+- echo $DOCKER_PASSWORD | docker login -u $DOCKER_USER -e none --password-stdin $ECR_HOST
 - make travis-release AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY ENVIRONMENT=$DEPLOY_ENVIRONMENT DOCKER_REGISTRY=$DOCKER_REGISTRY IMAGE_TAG=$TAG;

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,5 +50,5 @@ after_success:
 - export ECR_HOST=$(aws ecr get-authorization-token --output text --query 'authorizationData[].proxyEndpoint')
 - export DOCKER_USER=AWS
 - export DOCKER_PASSWORD=$ECR_TOKEN
-- docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
+- echo $ECR_TOKEN | docker login -u $DOCKER_USER --p $DOCKER_PASSWORD $ECR_HOST
 - make travis-release AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY ENVIRONMENT=$DEPLOY_ENVIRONMENT DOCKER_REGISTRY=$DOCKER_REGISTRY IMAGE_TAG=$TAG;

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,5 +46,10 @@ after_success:
 - pip install awscli;
 - export PATH=$PATH:$HOME/.local/bin;
 - export TAG=$(if [ "$RELEASE_TAG" = "" ]; then echo "$BRANCH"; else echo "$RELEASE_TAG"; fi);
-- eval $(aws ecr get-login --region us-east-1 --no-include-email);
+- export ECR_TOKEN=$(aws ecr get-authorization-token --output text \
+  --query 'authorizationData[].authorizationToken' \
+  | base64 -D | cut -d: -f2)
+- export ECR_HOST=$(aws ecr get-authorization-token --output text --query 'authorizationData[].proxyEndpoint')
+- echo $ECR_TOKEN | docker login -u AWS --password-stdin $ECR_HOST
+#- eval $(aws ecr get-login --region us-east-1 --no-include-email);
 - make travis-release AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY ENVIRONMENT=$DEPLOY_ENVIRONMENT DOCKER_REGISTRY=$DOCKER_REGISTRY IMAGE_TAG=$TAG;

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,5 +49,6 @@ after_success:
 - export ECR_TOKEN=`aws ecr get-authorization-token --output text --query 'authorizationData[].authorizationToken' | base64 -D | cut -d':' -f2`
 - export ECR_HOST=$(aws ecr get-authorization-token --output text --query 'authorizationData[].proxyEndpoint')
 - export DOCKER_USER=AWS
-- echo $ECR_TOKEN | docker login -u $DOCKER_USER --password-stdin $ECR_HOST
+- export DOCKER_PASSWORD=$ECR_TOKEN
+- docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
 - make travis-release AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY ENVIRONMENT=$DEPLOY_ENVIRONMENT DOCKER_REGISTRY=$DOCKER_REGISTRY IMAGE_TAG=$TAG;


### PR DESCRIPTION
This PR contains a fix for an issue where travis does not push images at the end of the build. The issue can be seen at the bottom of this travis log (search for "no basic auth"): https://api.travis-ci.org/v3/job/365195234/log.txt

to see that its working - look at the travis build for this PR. At the very bottom of the log you should not longer see the authentication error and you should see that the images are being pushed to ECR.