### PR TITLE
[AC-5489] - fix incorrect Router definitions:

### DIFF
--- a/mysql/conf.d/my.cnf
+++ b/mysql/conf.d/my.cnf
@@ -16,7 +16,7 @@ character-set-server = "utf8mb4"
 collation-server = "utf8mb4_unicode_ci"
 server-id = 1
 log_bin = /var/log/mysql/masschallenge
-
+general_log_file = /var/lib/mysql/masschallenge.log
 autocommit = 1
 max_allowed_packet = 1G
 wait_timeout = 2000

--- a/mysql/conf.d/my.cnf
+++ b/mysql/conf.d/my.cnf
@@ -1,7 +1,3 @@
-[client]
-max_allowed_packet = 1024M
-default-character-set = utf8mb4
-
 [mysqldump]
 quote-names
 max_allowed_packet = 1024M
@@ -18,6 +14,9 @@ character-set-client-handshake = FALSE
 block_encryption_mode = "aes-256-cbc"
 character-set-server = "utf8mb4"
 collation-server = "utf8mb4_unicode_ci"
+server-id = 1
+log_bin = /var/log/mysql/masschallenge
+
 autocommit = 1
 max_allowed_packet = 1G
 wait_timeout = 2000


### PR DESCRIPTION
**Changes Introduced in [AC-5489](https://masschallenge.atlassian.net/browse/AC-5489):**
- Make mysql Query Logging accessible, in order for the testing of [Accelerate:AC-5489](https://github.com/masschallenge/accelerate/pull/1789) to work properly. Also, having the logs accessible is a Good Thing.
- remove deprecated mysql [client] configurations.

**Test:**
- See https://github.com/masschallenge/accelerate/pull/1789