### PR TITLE
AC-5559 - impact deploys are broken.

### DIFF
--- a/web/nginx/nginx.conf
+++ b/web/nginx/nginx.conf
@@ -62,7 +62,7 @@ http {
         }
 
         location / {
-            proxy_pass         http://0.0.0.0:8000/;
+            proxy_pass         http://0.0.0.0:8000;
             proxy_redirect     off;
             proxy_set_header   Host              $http_host;
             proxy_set_header   X-Real-IP         $remote_addr;


### PR DESCRIPTION
Its a bit of a mystery as to why this stopped working all of a sudden and why this one character fix is required to get it working. my suspicion is that some dependency of nginx changed which changes the behavior of trailing slashes in redirects. 

To test this:

- create a new task definition in ECS and deploy a non-working tag (v1.0.16) to a cluster
- note that it wont work.
- create another revision of that task definition with this branch as the tagged image and update the service on the cluster.
- note that after 5 mins (need to wait for ELB) the api is back up and running.

