### PR TITLE
[AC-5679] Add and configure CORS support

### DIFF
--- a/web/impact/impact/settings.py
+++ b/web/impact/impact/settings.py
@@ -149,6 +149,9 @@ class Base(Configuration):
         },
     ]
     CORS_ALLOW_CREDENTIALS = True
+    CORS_ORIGIN_WHITELIST = (
+        'localhost:1234',
+        )
     ALGOLIA_INDEX_PREFIX = os.environ.get('ALGOLIA_INDEX_PREFIX', 'dev')
     ALGOLIA_INDEXES = [
         '{algolia_prefix}_mentor'.format(algolia_prefix=ALGOLIA_INDEX_PREFIX)
@@ -282,10 +285,6 @@ class Dev(Base):
     DEBUG_TOOLBAR_CONFIG = {
         'SHOW_TOOLBAR_CALLBACK': lambda x: True
     }
-
-    CORS_ORIGIN_WHITELIST = (
-        'localhost:1234',
-        )
 
 
 class Test(Base):

--- a/web/impact/impact/settings.py
+++ b/web/impact/impact/settings.py
@@ -148,6 +148,7 @@ class Base(Configuration):
             },
         },
     ]
+    CORS_ALLOW_CREDENTIALS = True
     ALGOLIA_INDEX_PREFIX = os.environ.get('ALGOLIA_INDEX_PREFIX', 'dev')
     ALGOLIA_INDEXES = [
         '{algolia_prefix}_mentor'.format(algolia_prefix=ALGOLIA_INDEX_PREFIX)
@@ -285,8 +286,6 @@ class Dev(Base):
     CORS_ORIGIN_WHITELIST = (
         'localhost:1234',
         )
-
-    CORS_ALLOW_CREDENTIALS = True
 
 
 class Test(Base):

--- a/web/impact/impact/settings.py
+++ b/web/impact/impact/settings.py
@@ -195,7 +195,6 @@ class Base(Configuration):
         }
     }
 
-    CORS_ORIGIN_ALLOW_ALL = True
     # settings.py
     REST_PROXY = {
         'HOST': os.environ.get('ACCELERATE_SITE_URL',
@@ -272,8 +271,8 @@ class Dev(Base):
     ]
 
     MIDDLEWARE_CLASSES = [
-                             'debug_toolbar.middleware.DebugToolbarMiddleware',
-                         ] + Base.MIDDLEWARE_CLASSES
+        'debug_toolbar.middleware.DebugToolbarMiddleware',
+    ] + Base.MIDDLEWARE_CLASSES
 
     INSTALLED_APPS = Base.INSTALLED_APPS + [
         'debug_toolbar',
@@ -282,6 +281,12 @@ class Dev(Base):
     DEBUG_TOOLBAR_CONFIG = {
         'SHOW_TOOLBAR_CALLBACK': lambda x: True
     }
+
+    CORS_ORIGIN_WHITELIST = (
+        'localhost:1234',
+        )
+
+    CORS_ALLOW_CREDENTIALS = True
 
 
 class Test(Base):

--- a/web/impact/impact/tests/test_cors_setup.py
+++ b/web/impact/impact/tests/test_cors_setup.py
@@ -9,4 +9,4 @@ class TestCorsSetup(TestCase):
     def test_expose_headers(self):
         resp = self.client.get('/', HTTP_ORIGIN='http://thirdparty.com')
         self.assertEqual(
-            resp['Access-Control-Allow-Origin'], '*')
+            resp['access-control-allow-credentials'], 'true')

--- a/web/impact/impact/tests/test_cors_setup.py
+++ b/web/impact/impact/tests/test_cors_setup.py
@@ -2,11 +2,13 @@
 # Copyright (c) 2017 MassChallenge, Inc.
 
 from django.test import TestCase
+from django.conf import settings
 
 
 class TestCorsSetup(TestCase):
 
     def test_expose_headers(self):
-        resp = self.client.get('/', HTTP_ORIGIN='http://thirdparty.com')
+        local_url = "http://" + settings.CORS_ORIGIN_WHITELIST[0]
+        resp = self.client.get('/', HTTP_ORIGIN=local_url)
         self.assertEqual(
             resp['access-control-allow-credentials'], 'true')

--- a/web/impact/impact/tests/test_cors_setup.py
+++ b/web/impact/impact/tests/test_cors_setup.py
@@ -7,8 +7,12 @@ from django.conf import settings
 
 class TestCorsSetup(TestCase):
 
-    def test_expose_headers(self):
+    def test_expose_headers_to_whitelist(self):
         local_url = "http://" + settings.CORS_ORIGIN_WHITELIST[0]
         resp = self.client.get('/', HTTP_ORIGIN=local_url)
         self.assertEqual(
             resp['access-control-allow-credentials'], 'true')
+
+    def test_dont_expose_headers_to_others(self):
+        resp = self.client.get('/', HTTP_ORIGIN='http://example.com')
+        self.assertTrue('access-control-allow-credentials' not in resp)

--- a/web/impact/requirements/base.txt
+++ b/web/impact/requirements/base.txt
@@ -25,6 +25,7 @@ gunicorn
 # Django
 dj-database-url
 dj-email-url
+django-cors-headers
 django-cors-middleware==1.3.1
 django-embed-video
 django-filter # Filtering support

--- a/web/impact/requirements/dev.txt
+++ b/web/impact/requirements/dev.txt
@@ -3,3 +3,4 @@
 
 -r test.txt
 
+django-cors-headers

--- a/web/impact/requirements/dev.txt
+++ b/web/impact/requirements/dev.txt
@@ -2,5 +2,3 @@
 # Copyright (c) 2017 MassChallenge, Inc.
 
 -r test.txt
-
-django-cors-headers


### PR DESCRIPTION
To test:
- On the branch run `make build; make run-server`
- Get a local version of accelerate running as well (`development` branch should be fine).  Login to your local version of accelerate.
- Git clone application-allocator and checkout branch AC-5679.
- Run `make run-server`
- It should report `http://localhost:1234`.  Go to that URL.
- You should see "Hello, World!" and the first name a last name of user 182.  The user info is coming from an API call.
- Log out of accelerate and refresh the application-allocator page.
- The name should disappear and the JavaScript console should report a 401.
- Log back into accelerate, do another refresh and see the name come back.

This can be merged before the corresponding PR on application-allocator, [AC-5679](https://github.com/masschallenge/application-allocator/pull/3).