### PR TITLE
Add `.env` file to local dev docker-compose

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ before_script:
 - docker run -v $(pwd)/../directory/dist:/usr/src/app/dist -t masschallenge/mentor-directory
 - cp -r ../directory/dist web/impact/static/dist
 - cp ../directory/dist/index.html web/impact/templates/directory.html
+- touch .env
 - docker-compose -f docker-compose.travis.yml build --no-cache --build-arg DJANGO_ACCELERATOR_REVISION=$DJANGO_ACCELERATOR_REVISION
 - docker-compose -f docker-compose.travis.yml up -d
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,9 @@ services:
     links:
       - mysql
       - redis
-    env_file: .dev.env
+    env_file:
+      - .env
+      - .dev.env
     user: root
   start_dependencies:
     image: "python:3.6"


### PR DESCRIPTION
Why:

We would like to add secrets to the environment but not accidentally
commit them. Currently, we have to edit `.dev.env` which is not git
ignored to have secret env variables and it might be easy to commit
these by mistake.

This PR:

Adds `.env` as an `env_file` to the local dev docker-compose file.
`.env` is already git ignored so developers can now put secrets in a
local `.env` file and be safe from accidentally committing them.