### PR TITLE
AC-5601: filter mentor directory down to confirmed mentors in program relevant to the user

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -2,7 +2,6 @@ version: '2.3'
 services:
   web:
     image: 997386117669.dkr.ecr.us-east-1.amazonaws.com/impact-api
-    env_file: .prod.env
     user: root
     links:
       - redis

--- a/web/impact/impact/views/algolia_api_key_view.py
+++ b/web/impact/impact/views/algolia_api_key_view.py
@@ -19,18 +19,20 @@ class AlgoliaApiKeyView(APIView):
     actions = ["GET"]
 
     def get(self, request, format=None):
+        index_prefix = settings.ALGOLIA_INDEX_PREFIX
         client = algoliasearch.Client(
             settings.ALGOLIA_APPLICATION_ID,
             settings.ALGOLIA_API_KEY)
         params = {
             'hitsPerPage': 24,
-            'filters': '',
+            'filters': 'is_confirmed_mentor:true',
             'validUntil': int(time.time()) + 3600,
             'userToken': request.user.id
         }
         search_key = settings.ALGOLIA_SEARCH_ONLY_API_KEY
         if request.user.is_staff:
             search_key = settings.ALGOLIA_STAFF_SEARCH_ONLY_API_KEY
+            params['filters'] = 'is_confirmed_mentor:false'
 
         public_key = client.generateSecuredApiKey(
             search_key,
@@ -38,4 +40,4 @@ class AlgoliaApiKeyView(APIView):
 
         return Response({
             'token': public_key,
-            'index_prefix': settings.ALGOLIA_INDEX_PREFIX})
+            'index_prefix': index_prefix})

--- a/web/impact/impact/views/algolia_api_key_view.py
+++ b/web/impact/impact/views/algolia_api_key_view.py
@@ -6,6 +6,8 @@ from rest_framework.response import Response
 from rest_framework import permissions
 from algoliasearch import algoliasearch
 from django.conf import settings
+from accelerator_abstract.models import CURRENT_STATUSES
+from accelerator.models import UserRole
 import time
 
 
@@ -25,19 +27,32 @@ class AlgoliaApiKeyView(APIView):
             settings.ALGOLIA_API_KEY)
         params = {
             'hitsPerPage': 24,
-            'filters': 'is_confirmed_mentor:true',
             'validUntil': int(time.time()) + 3600,
             'userToken': request.user.id
         }
         search_key = settings.ALGOLIA_SEARCH_ONLY_API_KEY
         if request.user.is_staff:
             search_key = settings.ALGOLIA_STAFF_SEARCH_ONLY_API_KEY
-            params['filters'] = 'is_confirmed_mentor:false'
-
+        else:
+            active_roles = UserRole.FINALIST_USER_ROLES
+            active_roles.append(UserRole.MENTOR)
+            facet_filters = []
+            for grant in request.user.programrolegrant_set.filter(
+                    program_role__program__program_status__in=CURRENT_STATUSES,
+                    program_role__user_role__name__in=active_roles
+            ):
+                facet_filters.append(
+                    'confirmed_mentor_programs:"{active_program}"'.format(
+                        active_program=grant.program_role.program.name))
+            if len(facet_filters) > 0:
+                params['filters'] = " OR ".join(facet_filters)
+            else:
+                params['filters'] = "is_confirmed_mentor:true"
         public_key = client.generateSecuredApiKey(
             search_key,
             params)
 
         return Response({
             'token': public_key,
-            'index_prefix': index_prefix})
+            'index_prefix': index_prefix,
+            'filters': params.get('filters', [])})


### PR DESCRIPTION
to test:

- checkout this branch.
- in the .dev.env file add the following env vars **(ask me for the secret gist with appropriate values)**:
ALGOLIA_APPLICATION_ID=3WW3PBJ1CW
ALGOLIA_API_KEY=<in secret gist>
ALGOLIA_SEARCH_ONLY_API_KEY=<in secret gist>
ALGOLIA_STAFF_SEARCH_ONLY_API_KEY=<in secret gist>

- run ```make run-all-servers```

- login as a non-staff user in impact api.

- open up developer tools and in the console execute the following js which will return results from algolia:

```
var script = document.createElement('SCRIPT');
script.src = 'https://cdn.jsdelivr.net/algoliasearch/3/algoliasearch.min.js'
document.getElementsByTagName('HEAD')[0].appendChild(script);

var isscript = document.createElement('SCRIPT');
isscript.src = 'https://cdn.jsdelivr.net/npm/instantsearch.js@2.3/dist/instantsearch.min.js';
document.getElementsByTagName('HEAD')[0].appendChild(isscript);

$.get('/api/algolia/api_key/?t=4', {}, function(response){
console.log(response['token']);

var client = algoliasearch("3WW3PBJ1CW", response['token']);

var index = client.initIndex('dev_mentor');

index.search('shankar', function searchDone(err, content) {
  console.log(content.hits);
});
})
```
- note that the results will return mentors that have 'is_confirmed_mentor' set to true and that the 'mentoring_programs' contains only programs for which the user has a finalist or mentor user-role.

- log out, clear site data and re-login as a staff user.

- re-run the js snippet from above 

- note that the results contain all mentors (confirmed and unconfirmed) from all programs.
