### PR TITLE
[AC-5718] - BUG - Accessing the Directory requires the user to login twice

### DIFF
--- a/web/impact/impact/settings.py
+++ b/web/impact/impact/settings.py
@@ -151,6 +151,7 @@ class Base(Configuration):
     CORS_ALLOW_CREDENTIALS = True
     CORS_ORIGIN_WHITELIST = (
         'localhost:1234',
+        'localhost:8000',
         )
     ALGOLIA_INDEX_PREFIX = os.environ.get('ALGOLIA_INDEX_PREFIX', 'dev')
     ALGOLIA_INDEXES = [

--- a/web/impact/impact/urls.py
+++ b/web/impact/impact/urls.py
@@ -7,7 +7,6 @@ from django.conf.urls import (
     include,
     url,
 )
-from impact.views import AlgoliaApiKeyView
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.views.generic import TemplateView
@@ -18,12 +17,13 @@ from rest_framework_jwt.views import (
     refresh_jwt_token,
     verify_jwt_token,
 )
-from django.contrib.auth.decorators import login_required
+
 from impact.model_utils import model_name_to_snake
 from impact.schema import schema_view
 from impact.v0.urls import v0_urlpatterns
 from impact.v1.urls import v1_urlpatterns
 from impact.views import (
+    AlgoliaApiKeyView,
     GeneralViewSet,
     IndexView,
 )
@@ -86,11 +86,10 @@ urls = [
     url(r'^oauth/',
         include('oauth2_provider.urls', namespace='oauth2_provider')),
     url(r'^schema/$', schema_view, name='schema'),
-    url(r'^directory/(?P<app>\w+)/$', login_required(
-        TemplateView.as_view(template_name='directory.html')),
+    url(r'^directory/(?P<app>\w+)/$',
+        TemplateView.as_view(template_name='directory.html'),
         name="directory"),
-    url(r'^directory/$', login_required(
-        TemplateView.as_view(template_name='directory.html')),
+    url(r'^directory/$', TemplateView.as_view(template_name='directory.html'),
         name="directory"),
     url(r'^$', IndexView.as_view()),
 ]


### PR DESCRIPTION
**Changes Introduced in [AC-5718](https://masschallenge.atlassian.net/browse/AC-5718):**

- Remove the login_required decorator from impact-api's directory urls

**Why:**
- The directory has it its own mechanism to check for authentication. Therefore those views should be **login exempt**, not login required.

**Test:**
- bring the servers up.
- Login on accelerate, and go to the directory. See that you are recognized as logged in, and all is working.
- Logout on accelerate (or through the logout button on the directory). Go to the directory, see that you are redirected to login in accelerate (not in the browsable api login page on impact).

**Note:**
- The value of `?next=` is within localhost:8181, which is wrong, but @shanbady says that it's addressed by making the directory appear as served from the accelerate url, so this is not handled here.