### PR TITLE
[AC-5711] - BUG - JWT expires causing 403 status codes but the user is still logged in through accelerate.

### DIFF
--- a/web/impact/impact/settings.py
+++ b/web/impact/impact/settings.py
@@ -1,9 +1,9 @@
 # MIT License
 # Copyright (c) 2017 MassChallenge, Inc.
 
-import datetime
 import os
 
+import datetime
 from configurations import (
     Configuration,
     values,
@@ -232,12 +232,15 @@ class Base(Configuration):
         'simpleuser.email_model_backend.EmailModelBackend',
         'django.contrib.auth.backends.ModelBackend',
     )
+    SESSION_COOKIE_AGE = 3600 * 24 * 7 * 2  # default
     JWT_AUTH = {
         'JWT_ALLOW_REFRESH': False,
-        'JWT_EXPIRATION_DELTA': datetime.timedelta(days=7),
+        'JWT_EXPIRATION_DELTA': datetime.timedelta(
+            seconds=(SESSION_COOKIE_AGE * 2)),
         # after timedelta has passed, token is no longer valid, and cannot
         # be refreshed any longer
-        'JWT_REFRESH_EXPIRATION_DELTA': datetime.timedelta(days=7),
+        'JWT_REFRESH_EXPIRATION_DELTA': datetime.timedelta(
+            seconds=(SESSION_COOKIE_AGE * 2)),
         # after timedelta has passed since first obtaining the token,
         # it is no longer possible to refresh the token, even if the token
         # did not expire
@@ -275,8 +278,8 @@ class Dev(Base):
     ]
 
     MIDDLEWARE_CLASSES = [
-        'debug_toolbar.middleware.DebugToolbarMiddleware',
-    ] + Base.MIDDLEWARE_CLASSES
+                             'debug_toolbar.middleware.DebugToolbarMiddleware',
+                         ] + Base.MIDDLEWARE_CLASSES
 
     INSTALLED_APPS = Base.INSTALLED_APPS + [
         'debug_toolbar',

--- a/web/impact/impact/settings.py
+++ b/web/impact/impact/settings.py
@@ -233,7 +233,7 @@ class Base(Configuration):
         'django.contrib.auth.backends.ModelBackend',
     )
     JWT_AUTH = {
-        'JWT_ALLOW_REFRESH': True,
+        'JWT_ALLOW_REFRESH': False,
         'JWT_EXPIRATION_DELTA': datetime.timedelta(days=7),
         # after timedelta has passed, token is no longer valid, and cannot
         # be refreshed any longer


### PR DESCRIPTION
**Changes Introduced in [AC-5711](https://masschallenge.atlassian.net/browse/AC-5711):**

- Set django session and jwt expiration deltas to be:
  - the same as accelerate
  - jwt = 2 * session
- Disable token refresh functionality in impact

**Test:**
- checkout AC-5711 on both accelerate and impact-api.
- In accelerate and in impact, rewrite `SESSION_COOKIE_AGE` to be a minute long or so.
- login on accelerate, go to directory, see that you're logged in.
- wait for that time delta to pass.
- refresh the directory, see that you're logged out (redirected to impact's login page unless #155 got merged in). Go back to accelerate. See that in accelerate you're also logged-out.

**Note:**
- This PR doesn't solve the double-login bug, it's handled here: #155 