### PR TITLE
[AC-5723] - new mentor directory: fix which mentors non staff users can see

### DIFF
--- a/web/impact/impact/tests/test_algolia_api_key_view.py
+++ b/web/impact/impact/tests/test_algolia_api_key_view.py
@@ -1,13 +1,27 @@
 # MIT License
 # Copyright (c) 2017 MassChallenge, Inc.
 
-from django.contrib.auth import get_user_model
-from rest_framework.test import APIClient
-from impact.tests.api_test_case import APITestCase
-from impact.views import AlgoliaApiKeyView
-from impact.tests.factories import UserFactory
-from django.urls import reverse
 import simplejson as json
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from accelerator.models import UserRole
+from accelerator.tests.factories import (
+    NamedGroupFactory,
+    ProgramFactory,
+    ProgramRoleFactory,
+    ProgramRoleGrantFactory,
+    UserRoleFactory,
+)
+from accelerator_abstract.models import (
+    ACTIVE_PROGRAM_STATUS,
+    UPCOMING_PROGRAM_STATUS,
+)
+from impact.tests.api_test_case import APITestCase
+from impact.tests.factories import UserFactory
+from impact.views import AlgoliaApiKeyView
+from impact.views.algolia_api_key_view import IS_CONFIRMED_MENTOR_FILTER
 
 User = get_user_model()  # pylint: disable=invalid-name
 
@@ -35,3 +49,88 @@ class TestAlgoliaApiKeyView(APITestCase):
             self.assertTrue(
                 response_data['detail'] == 'Authentication credentials '
                                            'were not provided.')
+
+    def test_staff_user_gets_empty_filters(self):
+        user = self.basic_user()
+        user.is_staff = True
+        user.save()
+        with self.settings(
+                ALGOLIA_APPLICATION_ID='test',
+                ALGOLIA_API_KEY='test'):
+            with self.login(email=user.email):
+                response = self.client.get(self.url)
+                response_data = json.loads(response.content)
+                self.assertEqual(response_data["filters"], [])
+
+    def test_finalist_user_gets_all_programs_in_program_group(self):
+        named_group = NamedGroupFactory()
+        programs = []
+        for _ in range(5):
+            programs.append(ProgramFactory(
+                mentor_program_group=named_group,
+                program_status=ACTIVE_PROGRAM_STATUS))
+        other_program = ProgramFactory(program_status=ACTIVE_PROGRAM_STATUS)
+        program = programs[0]
+        user = self._create_user_with_role_grant(program, UserRole.FINALIST)
+        with self.settings(
+                ALGOLIA_APPLICATION_ID='test',
+                ALGOLIA_API_KEY='test'):
+            with self.login(email=user.email):
+                response = self.client.get(self.url)
+                response_data = json.loads(response.content)
+
+                for program in programs:
+                    self.assertIn(program.name, response_data["filters"])
+                self.assertNotIn(other_program.name, response_data["filters"])
+
+    def test_finalist_user_gets_all_programs_in_past_or_present(self):
+        named_group = NamedGroupFactory()
+        programs = []
+        for _ in range(5):
+            programs.append(ProgramFactory(
+                mentor_program_group=named_group,
+                program_status=ACTIVE_PROGRAM_STATUS))
+        other_program = ProgramFactory(program_status=UPCOMING_PROGRAM_STATUS,
+                                       mentor_program_group=named_group)
+        program = programs[0]
+        user = self._create_user_with_role_grant(program, UserRole.FINALIST)
+        with self.settings(
+                ALGOLIA_APPLICATION_ID='test',
+                ALGOLIA_API_KEY='test'):
+            with self.login(email=user.email):
+                response = self.client.get(self.url)
+                response_data = json.loads(response.content)
+
+                for program in programs:
+                    self.assertIn(program.name, response_data["filters"])
+                self.assertNotIn(other_program.name, response_data["filters"])
+
+    def test_non_participant_user_sees_all_confirmed_mentors(self):
+        named_group = NamedGroupFactory()
+        programs = []
+        for _ in range(5):
+            programs.append(ProgramFactory(
+                mentor_program_group=named_group,
+                program_status=ACTIVE_PROGRAM_STATUS))
+        program = programs[0]
+        user = self._create_user_with_role_grant(program,
+                                                 UserRole.DESIRED_MENTOR)
+        with self.settings(
+                ALGOLIA_APPLICATION_ID='test',
+                ALGOLIA_API_KEY='test'):
+            with self.login(email=user.email):
+                response = self.client.get(self.url)
+                response_data = json.loads(response.content)
+
+                self.assertIn(IS_CONFIRMED_MENTOR_FILTER,
+                              response_data["filters"])
+
+    def _create_user_with_role_grant(self, program, user_role_name):
+        user_role = UserRoleFactory(name=user_role_name)
+        program_role = ProgramRoleFactory(
+            user_role=user_role,
+            program=program
+        )
+        user = self.basic_user()
+        ProgramRoleGrantFactory(person=user, program_role=program_role)
+        return user

--- a/web/impact/impact/views/algolia_api_key_view.py
+++ b/web/impact/impact/views/algolia_api_key_view.py
@@ -71,7 +71,14 @@ def _get_filters(request):
     program_families = ProgramFamily.objects.filter(
         programs__mentor_program_group__in=program_groups).prefetch_related(
         'programs').distinct()
+    facet_filters = _facet_filters(program_families)
+    if len(facet_filters) > 0:
+        return " OR ".join(facet_filters)
+    else:
+        return IS_CONFIRMED_MENTOR_FILTER
 
+
+def _facet_filters(program_families):
     facet_filters = []
     for program_family in program_families:
         past_or_present_programs = program_family.programs.filter(
@@ -80,10 +87,7 @@ def _get_filters(request):
         if past_or_present_programs:
             facet_filters.append(CONFIRMED_MENTOR_IN_PROGRAM_FILTER.format(
                 program=past_or_present_programs.first().name))
-    if len(facet_filters) > 0:
-        return " OR ".join(facet_filters)
-    else:
-        return IS_CONFIRMED_MENTOR_FILTER
+    return facet_filters
 
 
 def _get_public_key(params, search_key):

--- a/web/impact/impact/views/algolia_api_key_view.py
+++ b/web/impact/impact/views/algolia_api_key_view.py
@@ -1,31 +1,16 @@
 # MIT License
 # Copyright (c) 2017 MassChallenge, Inc.
 
-from rest_framework.views import APIView
-from rest_framework.response import Response
-from rest_framework import permissions
-from algoliasearch import algoliasearch
-from django.conf import settings
-from accelerator_abstract.models import CURRENT_STATUSES
-from accelerator.models import UserRole
 import time
 
+from algoliasearch import algoliasearch
+from django.conf import settings
+from rest_framework import permissions
+from rest_framework.response import Response
+from rest_framework.views import APIView
 
-def _get_user_filters(request):
-        active_roles = UserRole.FINALIST_USER_ROLES
-        active_roles.append(UserRole.MENTOR)
-        facet_filters = []
-        for grant in request.user.programrolegrant_set.filter(
-                program_role__program__program_status__in=CURRENT_STATUSES,
-                program_role__user_role__name__in=active_roles
-        ):
-            facet_filters.append(
-                'confirmed_mentor_programs:"{active_program}"'.format(
-                    active_program=grant.program_role.program.name))
-        if len(facet_filters) > 0:
-            return " OR ".join(facet_filters)
-        else:
-            return "is_confirmed_mentor:true"
+from accelerator.models import UserRole
+from accelerator_abstract.models import CURRENT_STATUSES
 
 
 class AlgoliaApiKeyView(APIView):
@@ -38,25 +23,50 @@ class AlgoliaApiKeyView(APIView):
     actions = ["GET"]
 
     def get(self, request, format=None):
-        index_prefix = settings.ALGOLIA_INDEX_PREFIX
-        client = algoliasearch.Client(
-            settings.ALGOLIA_APPLICATION_ID,
-            settings.ALGOLIA_API_KEY)
+        search_key = _get_search_key(request)
+        filters = _get_filters(request)
         params = {
             'hitsPerPage': 24,
             'validUntil': int(time.time()) + 3600,
-            'userToken': request.user.id
+            'userToken': request.user.id,
+            'filters': filters
         }
-        search_key = settings.ALGOLIA_SEARCH_ONLY_API_KEY
-        if request.user.is_staff:
-            search_key = settings.ALGOLIA_STAFF_SEARCH_ONLY_API_KEY
-        else:
-            params['filters'] = _get_user_filters(request)
-        public_key = client.generateSecuredApiKey(
-            search_key,
-            params)
-
+        public_key = _get_public_key(params, search_key)
         return Response({
             'token': public_key,
-            'index_prefix': index_prefix,
-            'filters': params.get('filters', [])})
+            'index_prefix': settings.ALGOLIA_INDEX_PREFIX,
+            'filters': filters
+        })
+
+
+def _get_search_key(request):
+    if request.user.is_staff:
+        return settings.ALGOLIA_STAFF_SEARCH_ONLY_API_KEY
+    return settings.ALGOLIA_SEARCH_ONLY_API_KEY
+
+
+def _get_filters(request):
+    if request.user.is_staff:
+        return []
+    active_roles = UserRole.FINALIST_USER_ROLES
+    active_roles.append(UserRole.MENTOR)
+    facet_filters = []
+    for grant in request.user.programrolegrant_set.filter(
+            program_role__program__program_status__in=CURRENT_STATUSES,
+            program_role__user_role__name__in=active_roles
+    ):
+        facet_filters.append(
+            'confirmed_mentor_programs:"{active_program}"'.format(
+                active_program=grant.program_role.program.name))
+    if len(facet_filters) > 0:
+        return " OR ".join(facet_filters)
+    else:
+        return "is_confirmed_mentor:true"
+
+
+def _get_public_key(params, search_key):
+    client = algoliasearch.Client(
+        settings.ALGOLIA_APPLICATION_ID,
+        settings.ALGOLIA_API_KEY)
+    public_key = client.generateSecuredApiKey(search_key, params)
+    return public_key

--- a/web/impact/impact/views/algolia_api_key_view.py
+++ b/web/impact/impact/views/algolia_api_key_view.py
@@ -9,8 +9,19 @@ from rest_framework import permissions
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from accelerator.models import UserRole
-from accelerator_abstract.models import CURRENT_STATUSES
+from accelerator.models import (
+    Program,
+    ProgramFamily,
+    ProgramRole,
+    UserRole,
+)
+from accelerator_abstract.models import (
+    ACTIVE_PROGRAM_STATUS,
+    ENDED_PROGRAM_STATUS,
+)
+
+IS_CONFIRMED_MENTOR_FILTER = "is_confirmed_mentor:true"
+CONFIRMED_MENTOR_IN_PROGRAM_FILTER = 'confirmed_mentor_programs:"{program}"'
 
 
 class AlgoliaApiKeyView(APIView):
@@ -48,20 +59,31 @@ def _get_search_key(request):
 def _get_filters(request):
     if request.user.is_staff:
         return []
-    active_roles = UserRole.FINALIST_USER_ROLES
-    active_roles.append(UserRole.MENTOR)
+    participant_roles = UserRole.FINALIST_USER_ROLES
+    participant_roles.append(UserRole.MENTOR)
+    user_program_roles_as_participant = ProgramRole.objects.filter(
+        programrolegrant__person=request.user,
+        user_role__name__in=participant_roles
+    )
+    program_groups = Program.objects.filter(
+        programrole__in=user_program_roles_as_participant).values_list(
+        'mentor_program_group', flat=True).distinct()
+    program_families = ProgramFamily.objects.filter(
+        programs__mentor_program_group__in=program_groups).prefetch_related(
+        'programs').distinct()
+
     facet_filters = []
-    for grant in request.user.programrolegrant_set.filter(
-            program_role__program__program_status__in=CURRENT_STATUSES,
-            program_role__user_role__name__in=active_roles
-    ):
-        facet_filters.append(
-            'confirmed_mentor_programs:"{active_program}"'.format(
-                active_program=grant.program_role.program.name))
+    for program_family in program_families:
+        past_or_present_programs = program_family.programs.filter(
+            program_status__in=(ACTIVE_PROGRAM_STATUS, ENDED_PROGRAM_STATUS)
+        ).order_by('-start_date')
+        if past_or_present_programs:
+            facet_filters.append(CONFIRMED_MENTOR_IN_PROGRAM_FILTER.format(
+                program=past_or_present_programs.first().name))
     if len(facet_filters) > 0:
         return " OR ".join(facet_filters)
     else:
-        return "is_confirmed_mentor:true"
+        return IS_CONFIRMED_MENTOR_FILTER
 
 
 def _get_public_key(params, search_key):


### PR DESCRIPTION
**Changes Introduced in [AC-5723](https://masschallenge.atlassian.net/browse/AC-5723):**
- Change the mechanism for setting algolia filters according to the user roles.

**Test:**
- Go to test4's directory as a current finalist/mentor in any of our regular programs.
- See that the displayed mentors are all confirmed mentors from all the regular programs, for current programs or latest ended.
- See that a Staff user sees all confirmed mentors from the entirety of time and place.
- See that a user with is_staff (django admin user) sees unconfirmed mentors as well.