### PR TITLE
[AC-5723] - Re-opened - new mentor directory: fix which mentors non staff users can see

### DIFF
--- a/web/impact/impact/views/algolia_api_key_view.py
+++ b/web/impact/impact/views/algolia_api_key_view.py
@@ -40,8 +40,9 @@ class AlgoliaApiKeyView(APIView):
             'hitsPerPage': 24,
             'validUntil': int(time.time()) + 3600,
             'userToken': request.user.id,
-            'filters': filters
         }
+        if filters:
+            params['filters'] = filters
         public_key = _get_public_key(params, search_key)
         return Response({
             'token': public_key,


### PR DESCRIPTION
**Changes Introduced in [AC-5723](https://masschallenge.atlassian.net/browse/AC-5723):**
- Change the mechanism for setting algolia filters according to the user roles.

**Test:**
- Go to test4's directory as a current finalist/mentor in any of our regular programs.
- See that the displayed mentors are all confirmed mentors from all the regular programs, for current programs or latest ended.
- See that a Staff user sees all confirmed mentors from the entirety of time and place.
- See that a user with is_staff (django admin user) sees unconfirmed mentors as well.