### PR TITLE
[AC-5743] Build the directory into static/directory-dist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_script:
 - cp .prod.env .env
 - docker build --no-cache -t masschallenge/mentor-directory ../directory
 - docker run -v $(pwd)/../directory/dist:/usr/src/app/dist -t masschallenge/mentor-directory
-- cp -r ../directory/dist web/impact/static/dist
+- cp -r ../directory/dist web/impact/static/directory-dist
 - cp ../directory/dist/index.html web/impact/templates/directory.html
 - docker-compose -f docker-compose.travis.yml build --no-cache --build-arg DJANGO_ACCELERATOR_REVISION=$DJANGO_ACCELERATOR_REVISION
 - docker-compose -f docker-compose.travis.yml up -d

--- a/docker-compose.travis.yml
+++ b/docker-compose.travis.yml
@@ -44,7 +44,7 @@ services:
     volumes:
       - ./web/impact:/wwwroot
       - ./db_cache:/db_cache
-      - ../directory/dist:/wwwroot/static/dist
+      - ../directory/dist:/wwwroot/static/directory-dist
       - ./web/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
       - ./web/impact/media:/media:ro
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
     volumes:
       - ./web/impact:/wwwroot
       - ../django-accelerator:/packages/src/django-accelerator
-      - ../directory/dist:/wwwroot/static/dist
+      - ../directory/dist:/wwwroot/static/directory-dist
       - ./db_cache:/db_cache
       - ./web/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
       - ./web/impact/media:/media:ro

--- a/web/scripts/start.sh
+++ b/web/scripts/start.sh
@@ -8,9 +8,9 @@ if [ "${DJANGO_CONFIGURATION}" == "Dev" ]; then
   done
 fi
 
-if [ -e "/wwwroot/static/dist/index.html" ]
+if [ -e "/wwwroot/static/directory-dist/index.html" ]
 then
-	cp /wwwroot/static/dist/index.html templates/directory.html
+	cp /wwwroot/static/directory-dist/index.html templates/directory.html
 fi
 
 python3 manage.py migrate --noinput


### PR DESCRIPTION
~I've opened this to get travis to build and image. I'm planning to close this without merging.~

Some feedback on https://github.com/masschallenge/accelerate/pull/1834 requires renaming the `static/dist` directory to `static/directory-dist` which requires this change here.

Why:

We have some unconventional behavior where were serving these assets
from `impact-api` but the domain that their hosted under is
`accelerate`'s. To do this, we have a nginx proxy in `accelerate` that
proxies any resquests to `/static/directory-dist/*` to `impact`. We
decided that to avoid confusion and possible naming collisions to change
the folder name from `dist` to `directory-dist`.

This PR:

Changes the docker files to cp the directory's `dist` folder to
`static/dist-directory` instead of `static/dist`