### PR TITLE
[Ac 5766] Add filters for criterion and criterion_option_spec api calls

### DIFF
--- a/web/impact/impact/tests/test_criterion_list_view.py
+++ b/web/impact/impact/tests/test_criterion_list_view.py
@@ -54,3 +54,16 @@ class TestCriterionListView(APITestCase):
                         "judging_round_id": {"type": "integer",
                                              "required": True}}
         self.assert_options_include("POST", post_options)
+
+    def test_filter_by_judging_round(self):
+        good_criterion = CriterionFactory()
+        bad_criterion = CriterionFactory()
+        judging_round_id = good_criterion.judging_round_id
+        with self.login(email=self.basic_user().email):
+            url = reverse(self.view.view_name)
+            url += "?judging_round_id={}".format(judging_round_id)
+            response = self.client.get(url)
+            results = json.loads(response.content)['results']
+            self.assertEqual(len(results), 1)
+            for key, val in results[0].items():
+                self.assertEqual(val, getattr(good_criterion, key))

--- a/web/impact/impact/tests/test_criterion_option_spec_list_view.py
+++ b/web/impact/impact/tests/test_criterion_option_spec_list_view.py
@@ -72,3 +72,29 @@ class TestCriterionOptionSpecListView(APITestCase):
                         "criterion_id": {"type": "integer",
                                          "required": True}}
         self.assert_options_include("POST", post_options)
+
+    def test_filter_by_judging_round_id(self):
+        good_option_spec = CriterionOptionSpecFactory()
+        bad_option_spec = CriterionOptionSpecFactory()
+        judging_round_id = good_option_spec.criterion.judging_round_id
+        with self.login(email=self.basic_user().email):
+            url = reverse(self.view.view_name)
+            url += "?judging_round_id={}".format(judging_round_id)
+            response = self.client.get(url)
+            results = json.loads(response.content)['results']
+            self.assertEqual(len(results), 1)
+            for key, val in results[0].items():
+                self.assertEqual(val, getattr(good_option_spec, key))
+
+    def test_filter_by_criterion_id(self):
+        good_option_spec = CriterionOptionSpecFactory()
+        bad_option_spec = CriterionOptionSpecFactory()
+        criterion_id = good_option_spec.criterion.id
+        with self.login(email=self.basic_user().email):
+            url = reverse(self.view.view_name)
+            url += "?criterion_id={}".format(criterion_id)
+            response = self.client.get(url)
+            results = json.loads(response.content)['results']
+            self.assertEqual(len(results), 1)
+            for key, val in results[0].items():
+                self.assertEqual(val, getattr(good_option_spec, key))

--- a/web/impact/impact/tests/test_criterion_option_spec_list_view.py
+++ b/web/impact/impact/tests/test_criterion_option_spec_list_view.py
@@ -74,9 +74,8 @@ class TestCriterionOptionSpecListView(APITestCase):
         self.assert_options_include("POST", post_options)
 
     def test_filter_by_judging_round_id(self):
-        good_option_spec = CriterionOptionSpecFactory()
-        bad_option_spec = CriterionOptionSpecFactory()
-        judging_round_id = good_option_spec.criterion.judging_round_id
+        option_spec = CriterionOptionSpecFactory()
+        judging_round_id = option_spec.criterion.judging_round_id
         with self.login(email=self.basic_user().email):
             url = reverse(self.view.view_name)
             url += "?judging_round_id={}".format(judging_round_id)
@@ -84,12 +83,11 @@ class TestCriterionOptionSpecListView(APITestCase):
             results = json.loads(response.content)['results']
             self.assertEqual(len(results), 1)
             for key, val in results[0].items():
-                self.assertEqual(val, getattr(good_option_spec, key))
+                self.assertEqual(val, getattr(option_spec, key))
 
     def test_filter_by_criterion_id(self):
-        good_option_spec = CriterionOptionSpecFactory()
-        bad_option_spec = CriterionOptionSpecFactory()
-        criterion_id = good_option_spec.criterion.id
+        option_spec = CriterionOptionSpecFactory()
+        criterion_id = option_spec.criterion.id
         with self.login(email=self.basic_user().email):
             url = reverse(self.view.view_name)
             url += "?criterion_id={}".format(criterion_id)
@@ -97,4 +95,4 @@ class TestCriterionOptionSpecListView(APITestCase):
             results = json.loads(response.content)['results']
             self.assertEqual(len(results), 1)
             for key, val in results[0].items():
-                self.assertEqual(val, getattr(good_option_spec, key))
+                self.assertEqual(val, getattr(option_spec, key))

--- a/web/impact/impact/v1/helpers/__init__.py
+++ b/web/impact/impact/v1/helpers/__init__.py
@@ -28,6 +28,7 @@ from impact.v1.helpers.model_helper import (
     json_simple_list,
 )
 from impact.v1.helpers.validators import (
+    INVALID_INTEGER_ERROR,
     validate_boolean,
     validate_choices,
     validate_regex,

--- a/web/impact/impact/v1/helpers/criterion_option_spec_helper.py
+++ b/web/impact/impact/v1/helpers/criterion_option_spec_helper.py
@@ -4,11 +4,11 @@
 from accelerator.models import CriterionOptionSpec
 
 from impact.v1.helpers.model_helper import (
-    REQUIRED_INTEGER_FIELD,
     ModelHelper,
     OPTIONAL_FLOAT_FIELD,
     OPTIONAL_INTEGER_FIELD,
     PK_FIELD,
+    REQUIRED_INTEGER_FIELD,
     REQUIRED_STRING_FIELD,
 )
 from impact.v1.helpers.validators import (

--- a/web/impact/impact/v1/views/base_list_view.py
+++ b/web/impact/impact/v1/views/base_list_view.py
@@ -12,6 +12,7 @@ from urllib.parse import (
 from rest_framework.response import Response
 
 from impact.v1.helpers import (
+    INVALID_INTEGER_ERROR,
     json_list_wrapper,
     json_object,
 )
@@ -163,6 +164,16 @@ class BaseListView(ImpactView):
         if is_active is not None:
             return qs.filter(is_active=is_active)
         return qs
+
+    def validate_id(self, request, field_name):
+        id_from_query = request.query_params.get(field_name)
+        if id_from_query is not None:
+            try:
+                int(id_from_query)
+            except ValueError:
+                self.errors.append(INVALID_INTEGER_ERROR.format(
+                    field=field_name,
+                    value=id_from_query))
 
 
 def _previous_url(base_url, limit, offset, count):

--- a/web/impact/impact/v1/views/base_list_view.py
+++ b/web/impact/impact/v1/views/base_list_view.py
@@ -175,6 +175,13 @@ class BaseListView(ImpactView):
                     field=field_name,
                     value=id_from_query))
 
+    def filter_by_field(self, field_name, queryset, lookup=None):
+        field_value = self.request.query_params.get(field_name)
+        lookup = lookup or field_name
+        if field_value is not None:
+            return queryset.filter(**{lookup: field_value})
+        return queryset
+
 
 def _previous_url(base_url, limit, offset, count):
     if offset == 0:

--- a/web/impact/impact/v1/views/criterion_list_view.py
+++ b/web/impact/impact/v1/views/criterion_list_view.py
@@ -4,7 +4,7 @@
 from impact.v1.views.base_list_view import BaseListView
 from impact.v1.views.post_mixin import PostMixin
 from impact.v1.helpers import CriterionHelper
-from impact.v1.helpers.validators import INVALID_INTEGER_ERROR
+
 
 class CriterionListView(BaseListView,
                         PostMixin):
@@ -13,25 +13,15 @@ class CriterionListView(BaseListView,
     actions = ['GET', 'POST']  # Should get this from PostMixin
 
     def get(self, request):
-        self._validate_judging_round_id(request)
+        self.validate_id(request, 'judging_round_id')
         return super().get(request)
-    
-    def _validate_judging_round_id(self, request):
-        judging_round_id = request.query_params.get("judging_round_id")
-        if judging_round_id is not None:
-            try:
-                judging_round_id = int(judging_round_id)
-            except ValueError:
-                self.errors.append(INVALID_INTEGER_ERROR % ("judging_round_id",
-                                                            judging_round_id))
-        
+
     def filter(self, qs):
         return self._filter_by_judging_round_id(qs)
 
     def _filter_by_judging_round_id(self, qs):
-        judging_round_id = self.request.query_params.get("judging_round_id", None)
+        judging_round_id = self.request.query_params.get("judging_round_id",
+                                                         None)
         if judging_round_id is not None:
             return qs.filter(judging_round_id=judging_round_id)
         return qs
-
-    

--- a/web/impact/impact/v1/views/criterion_list_view.py
+++ b/web/impact/impact/v1/views/criterion_list_view.py
@@ -4,10 +4,34 @@
 from impact.v1.views.base_list_view import BaseListView
 from impact.v1.views.post_mixin import PostMixin
 from impact.v1.helpers import CriterionHelper
-
+from impact.v1.helpers.validators import INVALID_INTEGER_ERROR
 
 class CriterionListView(BaseListView,
                         PostMixin):
     view_name = "criterion"
     helper_class = CriterionHelper
     actions = ['GET', 'POST']  # Should get this from PostMixin
+
+    def get(self, request):
+        self._validate_judging_round_id(request)
+        return super().get(request)
+    
+    def _validate_judging_round_id(self, request):
+        judging_round_id = request.query_params.get("judging_round_id")
+        if judging_round_id is not None:
+            try:
+                judging_round_id = int(judging_round_id)
+            except ValueError:
+                self.errors.append(INVALID_INTEGER_ERROR % ("judging_round_id",
+                                                            judging_round_id))
+        
+    def filter(self, qs):
+        return self._filter_by_judging_round_id(qs)
+
+    def _filter_by_judging_round_id(self, qs):
+        judging_round_id = self.request.query_params.get("judging_round_id", None)
+        if judging_round_id is not None:
+            return qs.filter(judging_round_id=judging_round_id)
+        return qs
+
+    

--- a/web/impact/impact/v1/views/criterion_list_view.py
+++ b/web/impact/impact/v1/views/criterion_list_view.py
@@ -20,8 +20,4 @@ class CriterionListView(BaseListView,
         return self._filter_by_judging_round_id(qs)
 
     def _filter_by_judging_round_id(self, qs):
-        judging_round_id = self.request.query_params.get("judging_round_id",
-                                                         None)
-        if judging_round_id is not None:
-            return qs.filter(judging_round_id=judging_round_id)
-        return qs
+        return self.filter_by_field("judging_round_id", qs)

--- a/web/impact/impact/v1/views/criterion_list_view.py
+++ b/web/impact/impact/v1/views/criterion_list_view.py
@@ -17,7 +17,7 @@ class CriterionListView(BaseListView,
         return super().get(request)
 
     def filter(self, qs):
-        return self._filter_by_judging_round_id(qs)
+        return self._filter_by_judging_round_id(super().filter(qs))
 
     def _filter_by_judging_round_id(self, qs):
         return self.filter_by_field("judging_round_id", qs)

--- a/web/impact/impact/v1/views/criterion_option_spec_list_view.py
+++ b/web/impact/impact/v1/views/criterion_option_spec_list_view.py
@@ -22,14 +22,8 @@ class CriterionOptionSpecListView(BaseListView,
         return self._filter_by_judging_round_id(qs)
 
     def _filter_by_judging_round_id(self, qs):
-        judging_round_id = self.request.query_params.get("judging_round_id",
-                                                         None)
-        if judging_round_id is not None:
-            return qs.filter(criterion__judging_round_id=judging_round_id)
-        return qs
+        lookup = "criterion__judging_round_id"
+        return self.filter_by_field("judging_round_id", qs, lookup)
 
     def _filter_by_criterion_id(self, qs):
-        criterion_id = self.request.query_params.get("criterion_id", None)
-        if criterion_id is not None:
-            return qs.filter(criterion_id=criterion_id)
-        return qs
+        return self.filter_by_field("criterion_id", qs)

--- a/web/impact/impact/v1/views/criterion_option_spec_list_view.py
+++ b/web/impact/impact/v1/views/criterion_option_spec_list_view.py
@@ -11,3 +11,43 @@ class CriterionOptionSpecListView(BaseListView,
     helper_class = CriterionOptionSpecHelper
     view_name = "criterion_option_spec"
     actions = ['GET', 'POST']  # Should get this from PostMixin
+
+    def get(self, request):
+        self._validate_judging_round_id(request)
+        self._validate_criterion_id(request)
+        return super().get(request)
+    
+    def _validate_judging_round_id(self, request):
+        judging_round_id = request.query_params.get("judging_round_id")
+        if judging_round_id is not None:
+            try:
+                judging_round_id = int(judging_round_id)
+            except ValueError:
+                self.errors.append(INVALID_INTEGER_ERROR % ("judging_round_id",
+                                                            judging_round_id))
+
+    def _validate_criterion_id(self, request):
+        criterion_id = request.query_params.get("criterion_id")
+        if criterion_id is not None:
+            try:
+                criterion_id = int(criterion_id)
+            except ValueError:
+                self.errors.append(INVALID_INTEGER_ERROR % ("criterion_id",
+                                                            criterion_id))
+                
+    def filter(self, qs):
+        qs = self._filter_by_criterion_id(qs)
+        return self._filter_by_judging_round_id(qs)
+
+    def _filter_by_judging_round_id(self, qs):
+        judging_round_id = self.request.query_params.get("judging_round_id", None)
+        if judging_round_id is not None:
+            return qs.filter(criterion__judging_round_id=judging_round_id)
+        return qs
+
+    def _filter_by_criterion_id(self, qs):
+        criterion_id = self.request.query_params.get("criterion_id", None)
+        if criterion_id is not None:
+            return qs.filter(criterion_id=criterion_id)
+        return qs
+    

--- a/web/impact/impact/v1/views/criterion_option_spec_list_view.py
+++ b/web/impact/impact/v1/views/criterion_option_spec_list_view.py
@@ -18,6 +18,7 @@ class CriterionOptionSpecListView(BaseListView,
         return super().get(request)
 
     def filter(self, qs):
+        qs = super().filter(qs)
         qs = self._filter_by_criterion_id(qs)
         return self._filter_by_judging_round_id(qs)
 

--- a/web/impact/impact/v1/views/criterion_option_spec_list_view.py
+++ b/web/impact/impact/v1/views/criterion_option_spec_list_view.py
@@ -13,34 +13,17 @@ class CriterionOptionSpecListView(BaseListView,
     actions = ['GET', 'POST']  # Should get this from PostMixin
 
     def get(self, request):
-        self._validate_judging_round_id(request)
-        self._validate_criterion_id(request)
+        self.validate_id(request, 'judging_round_id')
+        self.validate_id(request, 'criterion_id')
         return super().get(request)
-    
-    def _validate_judging_round_id(self, request):
-        judging_round_id = request.query_params.get("judging_round_id")
-        if judging_round_id is not None:
-            try:
-                judging_round_id = int(judging_round_id)
-            except ValueError:
-                self.errors.append(INVALID_INTEGER_ERROR % ("judging_round_id",
-                                                            judging_round_id))
 
-    def _validate_criterion_id(self, request):
-        criterion_id = request.query_params.get("criterion_id")
-        if criterion_id is not None:
-            try:
-                criterion_id = int(criterion_id)
-            except ValueError:
-                self.errors.append(INVALID_INTEGER_ERROR % ("criterion_id",
-                                                            criterion_id))
-                
     def filter(self, qs):
         qs = self._filter_by_criterion_id(qs)
         return self._filter_by_judging_round_id(qs)
 
     def _filter_by_judging_round_id(self, qs):
-        judging_round_id = self.request.query_params.get("judging_round_id", None)
+        judging_round_id = self.request.query_params.get("judging_round_id",
+                                                         None)
         if judging_round_id is not None:
             return qs.filter(criterion__judging_round_id=judging_round_id)
         return qs
@@ -50,4 +33,3 @@ class CriterionOptionSpecListView(BaseListView,
         if criterion_id is not None:
             return qs.filter(criterion_id=criterion_id)
         return qs
-    


### PR DESCRIPTION
To test: 
modify some criterion to point to a round other than 48. Append ?judging_round_id=48 to a criterion or criterion_option_spec list call and see that the appropriate objects come back
option specs can also be filtered by criterion id. 