### PR TITLE
AC-4121 Provide 500x500 thumbnails through the API

### DIFF
--- a/web/impact/impact/settings.py
+++ b/web/impact/impact/settings.py
@@ -270,6 +270,9 @@ class Base(Configuration):
 
     CMS_FILE_ROOT = '/var/www/cms-files'
 
+    IMAGE_RESIZE_HOST = "https://dl4fx6jt7wkin.cloudfront.net"
+    IMAGE_RESIZE_TEMPLATE = "/fit-in/500x500/{}"
+
 
 class Dev(Base):
     DEBUG = True

--- a/web/impact/impact/settings.py
+++ b/web/impact/impact/settings.py
@@ -271,7 +271,7 @@ class Base(Configuration):
     CMS_FILE_ROOT = '/var/www/cms-files'
 
     IMAGE_RESIZE_HOST = "https://dl4fx6jt7wkin.cloudfront.net"
-    IMAGE_RESIZE_TEMPLATE = "/fit-in/500x500/{}"
+    IMAGE_RESIZE_TEMPLATE = "/fit-in/500x500/media/startup_pics/{}"
 
 
 class Dev(Base):

--- a/web/impact/impact/settings.py
+++ b/web/impact/impact/settings.py
@@ -271,7 +271,7 @@ class Base(Configuration):
     CMS_FILE_ROOT = '/var/www/cms-files'
 
     IMAGE_RESIZE_HOST = "https://dl4fx6jt7wkin.cloudfront.net"
-    IMAGE_RESIZE_TEMPLATE = "/fit-in/500x500/media/startup_pics/{}"
+    IMAGE_RESIZE_TEMPLATE = "/fit-in/500x500/media/{}"
 
 
 class Dev(Base):

--- a/web/impact/impact/tests/test_startup_detail_view.py
+++ b/web/impact/impact/tests/test_startup_detail_view.py
@@ -21,6 +21,7 @@ EMPTY_RESPONSE = {'startups': []}
 VIMEO_EXAMPLE = "https://vimeo.com/149212783"
 BAD_YOUTUBE_EXAMPLE = "https://www.youtube.com/x/y/z"
 UNKNOWN_VIDEO_EXAMPLE = "http://blahblahblah.com/149212783"
+STARTUP_DETAIL_URL = reverse("startup_detail")
 
 
 class TestStartupDetailView(APITestCase):
@@ -42,8 +43,7 @@ class TestStartupDetailView(APITestCase):
             program_startup_status__startup_list_include=True,
             startup=startup).program_startup_status.startup_status
         with self.login(email=self.basic_user().email):
-            url = reverse("startup_detail")
-            response = self.client.post(url,
+            response = self.client.post(STARTUP_DETAIL_URL,
                                         {"ProgramKey": program.id,
                                          "StartupKey": startup.id})
             assert startup.name == response.data["name"]
@@ -65,8 +65,7 @@ class TestStartupDetailView(APITestCase):
             program_startup_status__startup_list_include=True,
             startup=startup).program_startup_status.startup_status
         with self.login(email=self.basic_user().email):
-            url = reverse("startup_detail")
-            response = self.client.post(url,
+            response = self.client.post(STARTUP_DETAIL_URL,
                                         {"StartupKey": startup.id})
             assert startup.name == response.data["name"]
             statuses = [status["status_name"]
@@ -81,8 +80,7 @@ class TestStartupDetailView(APITestCase):
         startup = member.startup
         program = ProgramFactory()
         with self.login(email=self.basic_user().email):
-            url = reverse("startup_detail")
-            response = self.client.post(url,
+            response = self.client.post(STARTUP_DETAIL_URL,
                                         {"ProgramKey": program.id,
                                          "StartupKey": startup.id})
             assert EMPTY_DETAIL_RESULT == response.data
@@ -93,9 +91,8 @@ class TestStartupDetailView(APITestCase):
         startup = member.startup
         program = ProgramFactory()
         with self.login(email=self.basic_user().email):
-            url = reverse("startup_detail")
             response = self.client.post(
-                url,
+                STARTUP_DETAIL_URL,
                 {"ProgramKey": program.id,
                  "StartupKey": startup.organization.url_slug})
             assert startup.name == response.data["name"]
@@ -107,8 +104,7 @@ class TestStartupDetailView(APITestCase):
         startup = member.startup
         program = ProgramFactory()
         with self.login(email=self.basic_user().email):
-            url = reverse("startup_detail")
-            response = self.client.post(url,
+            response = self.client.post(STARTUP_DETAIL_URL,
                                         {"ProgramKey": program.id,
                                          "StartupKey": startup.id})
             assert startup.name == response.data["name"]
@@ -122,8 +118,7 @@ class TestStartupDetailView(APITestCase):
         startup = member.startup
         program = ProgramFactory()
         with self.login(email=self.basic_user().email):
-            url = reverse("startup_detail")
-            response = self.client.post(url,
+            response = self.client.post(STARTUP_DETAIL_URL,
                                         {"ProgramKey": program.id,
                                          "StartupKey": startup.id})
             assert "iframe" in response.data["video_elevator_pitch_url"]
@@ -137,8 +132,7 @@ class TestStartupDetailView(APITestCase):
         startup = member.startup
         program = ProgramFactory()
         with self.login(email=self.basic_user().email):
-            url = reverse("startup_detail")
-            response = self.client.post(url,
+            response = self.client.post(STARTUP_DETAIL_URL,
                                         {"ProgramKey": program.id,
                                          "StartupKey": startup.id})
             assert "" == response.data["video_elevator_pitch_url"]
@@ -152,8 +146,7 @@ class TestStartupDetailView(APITestCase):
         startup = member.startup
         program = ProgramFactory()
         with self.login(email=self.basic_user().email):
-            url = reverse("startup_detail")
-            response = self.client.post(url,
+            response = self.client.post(STARTUP_DETAIL_URL,
                                         {"ProgramKey": program.id,
                                          "StartupKey": startup.id})
             assert "" == response.data["video_elevator_pitch_url"]
@@ -164,8 +157,7 @@ class TestStartupDetailView(APITestCase):
         startup.delete()
         program = ProgramFactory()
         with self.login(email=self.basic_user().email):
-            url = reverse("startup_detail")
-            response = self.client.post(url,
+            response = self.client.post(STARTUP_DETAIL_URL,
                                         {"ProgramKey": program.id,
                                          "StartupKey": startup_id})
             assert response.status_code == 404
@@ -175,8 +167,7 @@ class TestStartupDetailView(APITestCase):
     def test_missing_startup(self):
         program = ProgramFactory()
         with self.login(email=self.basic_user().email):
-            url = reverse("startup_detail")
-            response = self.client.post(url,
+            response = self.client.post(STARTUP_DETAIL_URL,
                                         {"ProgramKey": program.id})
             assert response.status_code == 404
             assert match_errors({"StartupKey": "'None'"},

--- a/web/impact/impact/tests/test_startup_detail_view.py
+++ b/web/impact/impact/tests/test_startup_detail_view.py
@@ -1,6 +1,7 @@
 # MIT License
 # Copyright (c) 2017 MassChallenge, Inc.
 
+from django.conf import settings
 from django.urls import reverse
 
 from impact.tests.factories import (
@@ -185,5 +186,5 @@ class TestStartupDetailView(APITestCase):
             response = self.client.post(STARTUP_DETAIL_URL,
                                         {"ProgramKey": program.id,
                                          "StartupKey": startup.id})
-            self.assertTrue("dl4fx6jt7wkin.cloudfront.net"
+            self.assertTrue(settings.IMAGE_RESIZE_HOST
                             in response.data["logo_url"])

--- a/web/impact/impact/tests/test_startup_detail_view.py
+++ b/web/impact/impact/tests/test_startup_detail_view.py
@@ -186,5 +186,6 @@ class TestStartupDetailView(APITestCase):
             response = self.client.post(STARTUP_DETAIL_URL,
                                         {"ProgramKey": program.id,
                                          "StartupKey": startup.id})
-            self.assertTrue(settings.IMAGE_RESIZE_HOST
-                            in response.data["logo_url"])
+            url_base = (settings.IMAGE_RESIZE_HOST +
+                        settings.IMAGE_RESIZE_TEMPLATE).format("")
+            self.assertTrue(url_base in response.data["logo_url"])

--- a/web/impact/impact/tests/test_startup_detail_view.py
+++ b/web/impact/impact/tests/test_startup_detail_view.py
@@ -172,3 +172,18 @@ class TestStartupDetailView(APITestCase):
             assert response.status_code == 404
             assert match_errors({"StartupKey": "'None'"},
                                 response.data)
+
+    def test_logos_are_resized(self):
+        path = "startup_pics/yuge.png"
+        context = UserContext()
+        member = StartupTeamMemberFactory(user=context.user)
+        startup = member.startup
+        startup.high_resolution_logo = path
+        startup.save()
+        program = ProgramFactory()
+        with self.login(email=self.basic_user().email):
+            response = self.client.post(STARTUP_DETAIL_URL,
+                                        {"ProgramKey": program.id,
+                                         "StartupKey": startup.id})
+            self.assertTrue("dl4fx6jt7wkin.cloudfront.net"
+                            in response.data["logo_url"])

--- a/web/impact/impact/v0/views/utils.py
+++ b/web/impact/impact/v0/views/utils.py
@@ -55,8 +55,7 @@ def logo_url(startup):
     elif "startup_pics/" not in logo_field.url:
         return logo_field.url
     else:
-        # Get just the filename and drop any S3 auth params
-        filename = logo_field.url.split("startup_pics/")[1].split("?")[0]
+        filename = logo_field.name
         template = settings.IMAGE_RESIZE_HOST + settings.IMAGE_RESIZE_TEMPLATE
         return template.format(filename)
 

--- a/web/impact/impact/v0/views/utils.py
+++ b/web/impact/impact/v0/views/utils.py
@@ -45,9 +45,20 @@ def _pad(text):
 
 
 def logo_url(startup):
-    if not startup.high_resolution_logo:
+    """
+    Turns the stored *.s3.amazonaws.com URL into one that uses our
+    CloudFormation image resizer; returns empty string for None
+    """
+    logo_field = startup.high_resolution_logo
+    if not logo_field:
         return ""
-    return startup.high_resolution_logo.url
+    elif "startup_pics/" not in logo_field.url:
+        return logo_field.url
+    else:
+        url_template = "https://dl4fx6jt7wkin.cloudfront.net/fit-in/500x500/{}"
+        # Get just the filename and drop any S3 auth params
+        filename = logo_field.url.split("startup_pics/")[1].split("?")[0]
+        return url_template.format(filename)
 
 
 def status_description(status):

--- a/web/impact/impact/v0/views/utils.py
+++ b/web/impact/impact/v0/views/utils.py
@@ -46,18 +46,14 @@ def _pad(text):
 
 def logo_url(startup):
     """
-    Turns the stored *.s3.amazonaws.com URL into one that uses our
-    CloudFormation image resizer; returns empty string for None
+    Use the stored filename to generate a ServerlessImageHandler URL
     """
     logo_field = startup.high_resolution_logo
     if not logo_field:
         return ""
-    elif "startup_pics/" not in logo_field.url:
-        return logo_field.url
     else:
-        filename = logo_field.name
         template = settings.IMAGE_RESIZE_HOST + settings.IMAGE_RESIZE_TEMPLATE
-        return template.format(filename)
+        return template.format(logo_field.name)
 
 
 def status_description(status):

--- a/web/impact/impact/v0/views/utils.py
+++ b/web/impact/impact/v0/views/utils.py
@@ -55,10 +55,10 @@ def logo_url(startup):
     elif "startup_pics/" not in logo_field.url:
         return logo_field.url
     else:
-        url_template = "https://dl4fx6jt7wkin.cloudfront.net/fit-in/500x500/{}"
         # Get just the filename and drop any S3 auth params
         filename = logo_field.url.split("startup_pics/")[1].split("?")[0]
-        return url_template.format(filename)
+        template = settings.IMAGE_RESIZE_HOST + settings.IMAGE_RESIZE_TEMPLATE
+        return template.format(filename)
 
 
 def status_description(status):


### PR DESCRIPTION
## [AC-4121](https://masschallenge.atlassian.net/browse/AC-4121)

This feature relies heavily on a Cloudfront-based solution (detailed in the ticket comments) which includes the following:
* an endpoint through which all `startup_pics` image requests are made
* an AWS lambda function that's called by that endpoint
* an image resizing utility ("Thumbor") called by that Lambda function as needed
* a cloudfront cache where the resized images are stored

This solution is currently set up to load and process images from the `media/startup_pics` directory in the [accelerate-assets-staging](https://s3.console.aws.amazon.com/s3/buckets/accelerate-assets-staging/?region=us-east-1&tab=overview) S3 bucket.

The code changes make the `api/v0/startup_detail` endpoint change the `logo_url` values it returns, to use the resizer.

For production use we'll either update the resizer to watch the {{accelerate-assets-production}} bucket, or (if we feel that there's some use in keeping it available for staging) add a second processor that uses that production bucket.

**TO TEST**:
* Make a Postman request to the `/api/v0/startup_detail/` endppoint for a startup with a logo
* See that the `logo_url` returned uses the Cloudfront host `dl4fx6jt7wkin.cloudfront.net`