### PR TITLE
[AC-5768] - Integrate The Directory To Our Build And Release Process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,6 @@ env:
     - MENTOR_DIRECTORY_REVISION=`./infer_repository_revision.sh "$BRANCH" https://$GITHUB_ACCESS_TOKEN@github.com/masschallenge/directory.git`
 
 before_install:
-- echo $MENTOR_DIRECTORY_REVISION
-- echo $DJANGO_ACCELERATOR_REVISION
 - echo -e "machine github.com\n  login $GITHUB_ACCESS_TOKEN" >> ~/.netrc
 - sudo apt-add-repository 'deb http://archive.ubuntu.com/ubuntu trusty-backports universe'
 - sudo apt-get update -qq

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ env:
     - IS_RELEASE=$(git ls-remote origin | grep "$TRAVIS_COMMIT\s\+refs/heads/release$")
     - RELEASE_TAG=$(git tag -l --points-at HEAD | head -n1)
     - BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
-    - DJANGO_ACCELERATOR_REVISION=`./infer_django_accelerator_revision.sh $BRANCH`
+    - DJANGO_ACCELERATOR_REVISION=`./infer_repository_revision.sh $BRANCH https://www.github.com/masschallenge/django-accelerator.git `
+    - MENTOR_DIRECTORY_REVISION=`./infer_repository_revision.sh $BRANCH https://$GITHUB_ACCESS_TOKEN@github.com/masschallenge/director.git`
 
 before_install:
 - echo -e "machine github.com\n  login $GITHUB_ACCESS_TOKEN" >> ~/.netrc
@@ -35,7 +36,7 @@ before_script:
 - for key in $keys; do echo "$key=${!key}" >> .prod.env; echo "" >> .prod.env; done
 - echo "DATABASE_URL=mysql://${DATABASE_USER}:${DATABASE_PASSWORD}@${DATABASE_HOST}/${DATABASE_NAME}" >> .prod.env
 - echo "" >> .prod.env
-- git clone https://$GITHUB_ACCESS_TOKEN@github.com/masschallenge/directory ../directory
+- git clone https://$GITHUB_ACCESS_TOKEN@github.com/masschallenge/directory -b $MENTOR_DIRECTORY_REVISION ../directory
 - cp .prod.env ../directory/.env
 - cp .prod.env .env
 - docker build --no-cache -t masschallenge/mentor-directory ../directory

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ env:
     - IS_RELEASE=$(git ls-remote origin | grep "$TRAVIS_COMMIT\s\+refs/heads/release$")
     - RELEASE_TAG=$(git tag -l --points-at HEAD | head -n1)
     - BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
-    - DJANGO_ACCELERATOR_REVISION=`./infer_repository_revision.sh $BRANCH https://www.github.com/masschallenge/django-accelerator.git `
-    - MENTOR_DIRECTORY_REVISION=`./infer_repository_revision.sh $BRANCH https://$GITHUB_ACCESS_TOKEN@github.com/masschallenge/director.git`
+    - DJANGO_ACCELERATOR_REVISION=`./infer_repository_revision.sh "$BRANCH" https://www.github.com/masschallenge/django-accelerator.git`
+    - MENTOR_DIRECTORY_REVISION=`./infer_repository_revision.sh "$BRANCH" https://$GITHUB_ACCESS_TOKEN@github.com/masschallenge/directory.git`
 
 before_install:
 - echo $MENTOR_DIRECTORY_REVISION

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ env:
     - MENTOR_DIRECTORY_REVISION=`./infer_repository_revision.sh $BRANCH https://$GITHUB_ACCESS_TOKEN@github.com/masschallenge/director.git`
 
 before_install:
+- echo $MENTOR_DIRECTORY_REVISION
+- echo $DJANGO_ACCELERATOR_REVISION
 - echo -e "machine github.com\n  login $GITHUB_ACCESS_TOKEN" >> ~/.netrc
 - sudo apt-add-repository 'deb http://archive.ubuntu.com/ubuntu trusty-backports universe'
 - sudo apt-get update -qq

--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,8 @@ code-check:
 ACCELERATE = ../accelerate
 DJANGO_ACCELERATOR = ../django-accelerator
 IMPACT_API = ../impact-api
-REPOS = $(ACCELERATE) $(DJANGO_ACCELERATOR) $(IMPACT_API)
+DIRECTORY = ../directory
+REPOS = $(ACCELERATE) $(DJANGO_ACCELERATOR) $(DIRECTORY) $(IMPACT_API)
 
 
 # Database migration related targets

--- a/create_release.sh
+++ b/create_release.sh
@@ -8,3 +8,5 @@ cd ../django-accelerator && git tag "v${TAG}"
 git push --tags 
 cd ../accelerate && git tag "v${TAG}"
 git push --tags
+cd ../directory && git tag "v${TAG}"
+git push --tags

--- a/infer_repository_revision.sh
+++ b/infer_repository_revision.sh
@@ -1,29 +1,37 @@
 #!/bin/bash
 DEFAULT_BRANCH=development
 
+REVISION_ARG=$1
+REPO_URL=$2
+
 # allow for an override, if DJANGO_ACCELERATOR_REVISION is already set in env.
-if ! [[ -z $DJANGO_ACCELERATOR_REVISION ]];then
+if [[  (! -z $DIRECTORY_REVISION) && $REPO_URL == *"django-accelerator"* ]];then
   echo $DJANGO_ACCELERATOR_REVISION
+  exit
+fi
+# allow for an override, if DIRECTORY_REVISION is already set in env.
+if ! [[ (! -z $DIRECTORY_REVISION) && $REPO_URL == *"directory"* ]];then
+  echo DIRECTORY_REVISION
   exit
 fi
 
 # use default branch if input parameter is missing
-if [[ -z $1 ]]; then
+if [[ -z $REVISION_ARG ]]; then
   REQUESTED_REVISION=$DEFAULT_BRANCH
 else
-  REQUESTED_REVISION=$1
+  REQUESTED_REVISION=$REVISION_ARG
 fi
 
 # check if the requested revision exists in remote
-PARSED_REVISION=`git ls-remote https://www.github.com/masschallenge/django-accelerator.git $REQUESTED_REVISION | xargs echo | tr -s ' ' | cut -d ' ' -f 2 | cut -d'/' -f 3`
+PARSED_REVISION=`git ls-remote $REPO_URL $REQUESTED_REVISION | xargs echo | tr -s ' ' | cut -d ' ' -f 2 | cut -d'/' -f 3`
 
 # Use DEFAULT_BRANCH if PARSED_REVISION is empty
 if [[ -z $PARSED_REVISION ]]; then
   # check if exists as commit sha1
-  mkdir django-accelerator
-  cd django-accelerator
+  mkdir tmp-repo-dir
+  cd tmp-repo-dir
   git init -q
-  git remote add origin https://github.com/masschallenge/django-accelerator.git
+  git remote add origin $REPO_URL
   git fetch origin -qt --dry-run  # does not get files, but updates commit info
   REVISION_VALID_IF_EMPTY=`git cat-file -e $REQUESTED_REVISION 2>&1`
   # if variable is empty, then this is a valid revision, use it.
@@ -35,12 +43,11 @@ if [[ -z $PARSED_REVISION ]]; then
   fi
   # clean up the directory
   cd ..
-  rm -rf django-accelerator/
+  rm -rf tmp-repo-dir/
 else
   INFERRED_REVISION=$PARSED_REVISION
 fi
 
 # Return the inferred revision
-export DJANGO_ACCELERATOR_REVISION=$INFERRED_REVISION
 echo $INFERRED_REVISION
 exit

--- a/infer_repository_revision.sh
+++ b/infer_repository_revision.sh
@@ -10,7 +10,7 @@ if [[  (! -z $DJANGO_ACCELERATOR_REVISION) && $REPO_URL == *"django-accelerator"
   exit
 fi
 # allow for an override, if DIRECTORY_REVISION is already set in env.
-if ! [[ (! -z $DIRECTORY_REVISION) && $REPO_URL == *"directory"* ]];then
+if [[ (! -z $DIRECTORY_REVISION) && $REPO_URL == *"directory"* ]];then
   echo $DIRECTORY_REVISION
   exit
 fi
@@ -21,7 +21,6 @@ if [[ -z $REVISION_ARG ]]; then
 else
   REQUESTED_REVISION=$REVISION_ARG
 fi
-
 # check if the requested revision exists in remote
 PARSED_REVISION=`git ls-remote $REPO_URL $REQUESTED_REVISION | xargs echo | tr -s ' ' | cut -d ' ' -f 2 | cut -d'/' -f 3`
 

--- a/infer_repository_revision.sh
+++ b/infer_repository_revision.sh
@@ -5,13 +5,13 @@ REVISION_ARG=$1
 REPO_URL=$2
 
 # allow for an override, if DJANGO_ACCELERATOR_REVISION is already set in env.
-if [[  (! -z $DIRECTORY_REVISION) && $REPO_URL == *"django-accelerator"* ]];then
+if [[  (! -z $DJANGO_ACCELERATOR_REVISION) && $REPO_URL == *"django-accelerator"* ]];then
   echo $DJANGO_ACCELERATOR_REVISION
   exit
 fi
 # allow for an override, if DIRECTORY_REVISION is already set in env.
 if ! [[ (! -z $DIRECTORY_REVISION) && $REPO_URL == *"directory"* ]];then
-  echo DIRECTORY_REVISION
+  echo $DIRECTORY_REVISION
   exit
 fi
 


### PR DESCRIPTION
**Changes Introduced in [AC-5768](https://masschallenge.atlassian.net/browse/AC-5768):**
- infer the Directory revision to use as django-accelerator is inferred.
- add a DIRECTORY constant in makefile

**Test:**
- `make checkout` now checks out directory as well.
- see that `make release` would do the same (I suggest not actually testing it because reverting those changes would be laborious.
- testing travis:
  - Checkout a separate branch on top of this branch.
  - In travis.yml, in line 18 (right below `before_install`, add: `- echo $MENTOR_DIRECTORY_REVISION`
  - now try the following scenarios:
    - commit and push, see that the variable gets assigned the default branch - development
    - go to Directory, create a branch with the name of the off-branch, push. Restart the impact-api build. See that the variable is now the name of the branch.
    - delete the branch. Create a tag with that same name. restart the impact-api build. See that the behaviour is the same. delete the tag. 
    - use the override mechanism - in travis, go to settings, and add an env var `DIRECTORY_REVISION` with some value. restart the build. see that this value is the one that appears. delete this env var from the settings.


**Note:**
- This ticket does not address @pbx's concerns as expressed in https://masschallenge.atlassian.net/browse/AC-5759 , and does not address further points in https://masschallenge.atlassian.net/browse/AC-5783 which need to be discussed.