### PR TITLE
[AC-5836] Add API call for cloning criteria

### DIFF
--- a/web/impact/impact/tests/test_clone_criteria_view.py
+++ b/web/impact/impact/tests/test_clone_criteria_view.py
@@ -1,0 +1,41 @@
+# MIT License
+# Copyright (c) 2017 MassChallenge, Inc.
+
+from django.urls import reverse
+
+from impact.tests.api_test_case import APITestCase
+from impact.v1.views import CloneCriteriaView
+from accelerator.models import (
+    CriterionOptionSpec,
+    JudgingRound,
+)
+from accelerator.tests.factories import (
+    CriterionOptionSpecFactory,
+    JudgingRoundFactory,
+)
+
+class TestCloneCriteriaView(APITestCase):
+    def test_successful_clone(self):
+        option_spec = CriterionOptionSpecFactory()
+        old_round = option_spec.criterion.judging_round
+        new_round = JudgingRoundFactory()
+        url = reverse(CloneCriteriaView.view_name,
+                      args=[old_round.pk, new_round.pk])
+        with self.login(email=self.basic_user().email):
+            response=self.client.get(url)
+        assert CriterionOptionSpec.objects.filter(
+            option=option_spec.option,
+            weight=option_spec.weight,
+            count=option_spec.count,
+            criterion__judging_round=new_round).exists()
+
+    def test_judging_rounds_do_not_exist(self):
+        round_ids = [jr.pk for jr in JudgingRoundFactory.create_batch(2)]
+        JudgingRound.objects.filter(pk__in=round_ids).delete()
+        url = reverse(CloneCriteriaView.view_name,
+                      args=round_ids)
+        
+        with self.login(email=self.basic_user().email):
+            response=self.client.get(url)
+        self.assertEqual(response.status_code, 401)
+    

--- a/web/impact/impact/tests/test_clone_criteria_view.py
+++ b/web/impact/impact/tests/test_clone_criteria_view.py
@@ -23,7 +23,7 @@ class TestCloneCriteriaView(APITestCase):
         url = reverse(CloneCriteriaView.view_name,
                       args=[old_round.pk, new_round.pk])
         with self.login(email=self.basic_user().email):
-            self.client.get(url)
+            self.client.post(url)
         assert CriterionOptionSpec.objects.filter(
             option=option_spec.option,
             weight=option_spec.weight,
@@ -37,5 +37,5 @@ class TestCloneCriteriaView(APITestCase):
                       args=round_ids)
 
         with self.login(email=self.basic_user().email):
-            response = self.client.get(url)
+            response = self.client.post(url)
         self.assertEqual(response.status_code, 401)

--- a/web/impact/impact/tests/test_clone_criteria_view.py
+++ b/web/impact/impact/tests/test_clone_criteria_view.py
@@ -14,6 +14,7 @@ from accelerator.tests.factories import (
     JudgingRoundFactory,
 )
 
+
 class TestCloneCriteriaView(APITestCase):
     def test_successful_clone(self):
         option_spec = CriterionOptionSpecFactory()
@@ -22,7 +23,7 @@ class TestCloneCriteriaView(APITestCase):
         url = reverse(CloneCriteriaView.view_name,
                       args=[old_round.pk, new_round.pk])
         with self.login(email=self.basic_user().email):
-            response=self.client.get(url)
+            self.client.get(url)
         assert CriterionOptionSpec.objects.filter(
             option=option_spec.option,
             weight=option_spec.weight,
@@ -34,8 +35,7 @@ class TestCloneCriteriaView(APITestCase):
         JudgingRound.objects.filter(pk__in=round_ids).delete()
         url = reverse(CloneCriteriaView.view_name,
                       args=round_ids)
-        
+
         with self.login(email=self.basic_user().email):
-            response=self.client.get(url)
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 401)
-    

--- a/web/impact/impact/tests/test_criterion_list_view.py
+++ b/web/impact/impact/tests/test_criterion_list_view.py
@@ -61,7 +61,7 @@ class TestCriterionListView(APITestCase):
         judging_round_id = criterion.judging_round_id
         with self.login(email=self.basic_user().email):
             url = reverse(self.view.view_name)
-            url += "?judging_round_id={}".format(judging_round_id)
+            url += "?judging_round={}".format(judging_round_id)
             response = self.client.get(url)
             results = json.loads(response.content)['results']
             self.assertEqual(len(results), 1)

--- a/web/impact/impact/v1/helpers/criterion_helper.py
+++ b/web/impact/impact/v1/helpers/criterion_helper.py
@@ -75,6 +75,7 @@ class CriterionHelper(ModelHelper):
 
     @classmethod
     def clone_criteria(cls, source_judging_round_id, target_judging_round_id):
+
         cls.delete_existing_criteria(target_judging_round_id)
         criteria = cls.model.objects.filter(
             judging_round_id=source_judging_round_id)

--- a/web/impact/impact/v1/helpers/criterion_helper.py
+++ b/web/impact/impact/v1/helpers/criterion_helper.py
@@ -6,7 +6,6 @@ from django.db.models import (
     Sum,
 )
 from accelerator.models import Criterion
-
 from impact.v1.helpers.model_helper import (
     REQUIRED_INTEGER_FIELD,
     ModelHelper,
@@ -75,5 +74,28 @@ class CriterionHelper(ModelHelper):
         return results
 
     @classmethod
+    def clone_criteria(cls, source_judging_round_id, target_judging_round_id):
+        cls.delete_existing_criteria(target_judging_round_id)
+        criteria = cls.model.objects.filter(
+            judging_round_id=source_judging_round_id)
+        return [cls.clone_criterion(criterion, target_judging_round_id)
+                for criterion in criteria]
+
+    @classmethod
+    def delete_existing_criteria(cls, judging_round_id):
+        criteria = cls.model.objects.filter(judging_round_id=judging_round_id)
+        for criterion in criteria:
+            criterion.criterionoptionspec_set.all().delete()
+        criteria.delete()
+
+    @classmethod
     def fields(cls):
         return ALL_FIELDS
+
+    @classmethod
+    def clone_criterion(cls, criterion, target_judging_round_id):
+        clone = cls.model.objects.create(
+            judging_round_id=target_judging_round_id,
+            type=criterion.type,
+            name=criterion.name)
+        return criterion.pk, clone.pk

--- a/web/impact/impact/v1/helpers/criterion_option_spec_helper.py
+++ b/web/impact/impact/v1/helpers/criterion_option_spec_helper.py
@@ -1,6 +1,5 @@
 # MIT License
 # Copyright (c) 2017 MassChallenge, Inc.
-
 from accelerator.models import CriterionOptionSpec
 
 from impact.v1.helpers.model_helper import (
@@ -75,3 +74,18 @@ class CriterionOptionSpecHelper(ModelHelper):
     @classmethod
     def fields(cls):
         return CRITERION_OPTION_SPEC_FIELDS
+
+    @classmethod
+    def clone_option_specs(cls, clones):
+        for original_id, copy_id in clones:
+            cls.clone_options(original_id, copy_id)
+
+    @classmethod
+    def clone_options(cls, original_id, copy_id):
+        option_specs = cls.model.objects.filter(criterion_id=original_id)
+        cls.model.objects.bulk_create([
+            cls.model(option=spec.option,
+                      count=spec.count,
+                      weight=spec.weight,
+                      criterion_id=copy_id)
+            for spec in option_specs])

--- a/web/impact/impact/v1/urls.py
+++ b/web/impact/impact/v1/urls.py
@@ -3,6 +3,7 @@ from django.conf.urls import url
 from impact.v1.views import (
     AllocateApplicationsView,
     AnalyzeJudgingRoundView,
+    CloneCriteriaView,
     CreditCodeDetailView,
     CreditCodeListView,
     CriterionDetailView,
@@ -39,6 +40,9 @@ v1_urlpatterns = [
     url(r"^analyze_judging_round/(?P<pk>[0-9]+)/$",
         AnalyzeJudgingRoundView.as_view(),
         name=AnalyzeJudgingRoundView.view_name),
+    url(r"^clone_criteria/(?P<source_pk>[0-9]+)/(?P<target_pk>[0-9]+)/$",
+        CloneCriteriaView.as_view(),
+        name=CloneCriteriaView.view_name),
     url(r"^credit_code/(?P<pk>[0-9]+)/$",
         CreditCodeDetailView.as_view(),
         name=CreditCodeDetailView.view_name),

--- a/web/impact/impact/v1/views/__init__.py
+++ b/web/impact/impact/v1/views/__init__.py
@@ -11,6 +11,7 @@ from impact.v1.views.allocate_applications_view import (
 )
 from impact.v1.views.analyze_judging_round_view import AnalyzeJudgingRoundView
 from impact.v1.views.base_list_view import INVALID_IS_ACTIVE_ERROR
+from impact.v1.views.clone_criteria_view import CloneCriteriaView
 from impact.v1.views.credit_code_detail_view import CreditCodeDetailView
 from impact.v1.views.credit_code_list_view import CreditCodeListView
 from impact.v1.views.criterion_detail_view import CriterionDetailView

--- a/web/impact/impact/v1/views/clone_criteria_view.py
+++ b/web/impact/impact/v1/views/clone_criteria_view.py
@@ -43,4 +43,4 @@ class CloneCriteriaView(ImpactView):
     def get(self, request, source_pk, target_pk):
         clones = CriterionHelper.clone_criteria(source_pk, target_pk)
         CriterionOptionSpecHelper.clone_option_specs(clones)
-        return Response({"results": "Success"})
+        return Response(status=204)

--- a/web/impact/impact/v1/views/clone_criteria_view.py
+++ b/web/impact/impact/v1/views/clone_criteria_view.py
@@ -26,7 +26,7 @@ class CloneCriteriaView(ImpactView):
     def fields(cls):
         return {}
 
-    def get(self, request, source_pk, target_pk):
+    def post(self, request, source_pk, target_pk):
         self._validate_judging_round_exists(source_pk)
         self._validate_judging_round_exists(target_pk)
         if self.errors:

--- a/web/impact/impact/v1/views/clone_criteria_view.py
+++ b/web/impact/impact/v1/views/clone_criteria_view.py
@@ -15,22 +15,6 @@ from impact.v1.helpers import (
     CriterionOptionSpecHelper,
 )
 
-ANALYZE_JUDGING_ROUND_FIELDS = {
-    "criterion_option_spec_id": READ_ONLY_ID_FIELD,
-    "weight": READ_ONLY_INTEGER_FIELD,
-    "count": READ_ONLY_INTEGER_FIELD,
-    "criterion_name": READ_ONLY_STRING_FIELD,
-    "option": READ_ONLY_STRING_FIELD,
-    "total_required_reads": READ_ONLY_INTEGER_FIELD,
-    "completed_required_reads": READ_ONLY_INTEGER_FIELD,
-    "needs_distribution": READ_ONLY_OBJECT_FIELD,
-    "satisfied_apps": READ_ONLY_INTEGER_FIELD,
-    "needy_apps": READ_ONLY_INTEGER_FIELD,
-    "remaining_needed_reads": READ_ONLY_INTEGER_FIELD,
-    "total_capacity": READ_ONLY_INTEGER_FIELD,
-    "remaining_capacity": READ_ONLY_INTEGER_FIELD,
-}
-
 ROUND_DOES_NOT_EXIST_ERROR = "Judging Round {} does not exist"
 
 
@@ -40,7 +24,7 @@ class CloneCriteriaView(ImpactView):
 
     @classmethod
     def fields(cls):
-        return ANALYZE_JUDGING_ROUND_FIELDS
+        return {}
 
     def get(self, request, source_pk, target_pk):
         self._validate_judging_round_exists(source_pk)

--- a/web/impact/impact/v1/views/clone_criteria_view.py
+++ b/web/impact/impact/v1/views/clone_criteria_view.py
@@ -1,0 +1,46 @@
+# MIT License
+# Copyright (c) 2017 MassChallenge, Inc.
+from rest_framework.response import Response
+
+from accelerator.models import JudgingRound
+from impact.v1.views.impact_view import ImpactView
+from impact.v1.helpers.model_helper import (
+    READ_ONLY_ID_FIELD,
+    READ_ONLY_INTEGER_FIELD,
+    READ_ONLY_OBJECT_FIELD,
+    READ_ONLY_STRING_FIELD,
+)
+from impact.v1.helpers import (
+    CriterionHelper,
+    CriterionOptionSpecHelper,
+)
+
+ANALYZE_JUDGING_ROUND_FIELDS = {
+    "criterion_option_spec_id": READ_ONLY_ID_FIELD,
+    "weight": READ_ONLY_INTEGER_FIELD,
+    "count": READ_ONLY_INTEGER_FIELD,
+    "criterion_name": READ_ONLY_STRING_FIELD,
+    "option": READ_ONLY_STRING_FIELD,
+    "total_required_reads": READ_ONLY_INTEGER_FIELD,
+    "completed_required_reads": READ_ONLY_INTEGER_FIELD,
+    "needs_distribution": READ_ONLY_OBJECT_FIELD,
+    "satisfied_apps": READ_ONLY_INTEGER_FIELD,
+    "needy_apps": READ_ONLY_INTEGER_FIELD,
+    "remaining_needed_reads": READ_ONLY_INTEGER_FIELD,
+    "total_capacity": READ_ONLY_INTEGER_FIELD,
+    "remaining_capacity": READ_ONLY_INTEGER_FIELD,
+}
+
+
+class CloneCriteriaView(ImpactView):
+    view_name = "clone_criteria"
+    model = JudgingRound
+
+    @classmethod
+    def fields(cls):
+        return ANALYZE_JUDGING_ROUND_FIELDS
+
+    def get(self, request, source_pk, target_pk):
+        clones = CriterionHelper.clone_criteria(source_pk, target_pk)
+        CriterionOptionSpecHelper.clone_option_specs(clones)
+        return Response({"results": "Success"})

--- a/web/impact/impact/v1/views/criterion_list_view.py
+++ b/web/impact/impact/v1/views/criterion_list_view.py
@@ -14,10 +14,11 @@ class CriterionListView(BaseListView,
 
     def get(self, request):
         self.validate_id(request, 'judging_round_id')
+
         return super().get(request)
 
     def filter(self, qs):
         return self._filter_by_judging_round_id(super().filter(qs))
 
     def _filter_by_judging_round_id(self, qs):
-        return self.filter_by_field("judging_round_id", qs)
+        return self.filter_by_field("judging_round", qs)


### PR DESCRIPTION
To test: Create a new judging round and get its id, call this TARGET. Find a judging round for which criteria exist and get its id, call this SOURCE. 
hit http://localhost:8000/api/v1/clone_criteria/SOURCE/TARGET to clone criteria

http://localhost:8000/api/v1/criterion/?judging_round=SOURCE
should return the original criteria
http://localhost:8000/api/v1/criterion/?judging_round=TARGET
should return the new criteria