### PR TITLE
[AC-5778] Add current mentees and previous mentees to expert profile object type

### DIFF
--- a/web/impact/impact/graphql/types/expert_profile_type.py
+++ b/web/impact/impact/graphql/types/expert_profile_type.py
@@ -13,7 +13,9 @@ from accelerator_abstract.models import (
     ENDED_PROGRAM_STATUS,
 )
 from impact.graphql.types.industry_type import IndustryType  # noqa: F401
-from impact.graphql.types.startup_mentor_relationship_type import StartupMentorRelationshipType  # noqa: E501
+from impact.graphql.types.startup_mentor_relationship_type import (
+    StartupMentorRelationshipType,
+)
 from impact.graphql.types.program_family_type import ProgramFamilyType  # noqa: F401, E501
 from impact.graphql.types.user_type import UserType  # noqa: F401
 from impact.graphql.types.functional_expertise_type import FunctionalExpertiseType  # noqa: F401, E501
@@ -86,26 +88,10 @@ class ExpertProfileType(DjangoObjectType):
                     mentor_id=self.user.id))
 
     def resolve_current_mentees(self, info, **kwargs):
-        mentee_filter = compose_filter([
-            'startup_mentor_tracking',
-            'program',
-            'program_status'
-        ], ACTIVE_PROGRAM_STATUS)
-        return self.user.startup_mentor_relationships.filter(
-            status=CONFIRMED_RELATIONSHIP,
-            **mentee_filter
-            )
+        return _get_mentees(self.user, ACTIVE_PROGRAM_STATUS)
 
     def resolve_previous_mentees(self, info, **kwargs):
-        mentee_filter = compose_filter([
-            'startup_mentor_tracking',
-            'program',
-            'program_status'
-        ], ENDED_PROGRAM_STATUS)
-        return self.user.startup_mentor_relationships.filter(
-            status=CONFIRMED_RELATIONSHIP,
-            **mentee_filter
-            )
+        return _get_mentees(self.user, ENDED_PROGRAM_STATUS)
 
 
 def _get_user_programs(user):
@@ -118,3 +104,15 @@ def _get_user_programs(user):
     )
     return Program.objects.filter(
         programrole__in=user_program_roles_as_participant).distinct()
+
+
+def _get_mentees(user, program_status):
+    mentee_filter = compose_filter([
+        'startup_mentor_tracking',
+        'program',
+        'program_status'
+    ], program_status)
+    return user.startup_mentor_relationships.filter(
+        status=CONFIRMED_RELATIONSHIP,
+        **mentee_filter
+    )

--- a/web/impact/impact/graphql/types/expert_profile_type.py
+++ b/web/impact/impact/graphql/types/expert_profile_type.py
@@ -112,7 +112,7 @@ def _get_mentees(user, program_status):
         'program',
         'program_status'
     ], program_status)
-    return user.startup_mentor_relationships.filter(
+    return user.startupmentorrelationship_set.filter(
         status=CONFIRMED_RELATIONSHIP,
         **mentee_filter
     )

--- a/web/impact/impact/graphql/types/startup_mentor_relationship_type.py
+++ b/web/impact/impact/graphql/types/startup_mentor_relationship_type.py
@@ -1,0 +1,45 @@
+import graphene
+from graphene_django import DjangoObjectType
+
+from accelerator.models import StartupMentorRelationship
+
+
+class StartupMentorRelationshipType(DjangoObjectType):
+    program_location = graphene.String()
+    program_status = graphene.String()
+    program_year = graphene.String()
+    startup_id = graphene.String()
+    startup_name = graphene.String()
+    startup_high_resolution_logo = graphene.String()
+    startup_short_pitch = graphene.String()
+
+    class Meta:
+        model = StartupMentorRelationship
+
+    def resolve_program_location(self, info, **kwargs):
+        program = self.startup_mentor_tracking.program
+        return program and program.program_family.name
+
+    def resolve_program_year(self, info, **kwargs):
+        program = self.startup_mentor_tracking.program
+        return program and program.start_date.year
+
+    def resolve_program_status(self, info, **kwargs):
+        program = self.startup_mentor_tracking.program
+        return program and program.program_status
+
+    def resolve_startup_id(self, info, **kwargs):
+        startup = self.startup_mentor_tracking.startup
+        return startup and startup.id
+
+    def resolve_startup_name(self, info, **kwargs):
+        startup = self.startup_mentor_tracking.startup
+        return startup and startup.name
+
+    def resolve_startup_high_resolution_logo(self, info, **kwargs):
+        startup = self.startup_mentor_tracking.startup
+        return startup and startup.high_resolution_logo
+
+    def resolve_startup_short_pitch(self, info, **kwargs):
+        startup = self.startup_mentor_tracking.startup
+        return startup and startup.short_pitch

--- a/web/impact/impact/tests/test_graphql.py
+++ b/web/impact/impact/tests/test_graphql.py
@@ -5,8 +5,21 @@ from django.urls import reverse
 
 from impact.graphql.middleware import NOT_LOGGED_IN_MSG
 from impact.tests.api_test_case import APITestCase
-from impact.tests.factories import ExpertFactory, StartupMentorRelationshipFactory  # noqa: E501
+from impact.tests.factories import (
+    ExpertFactory,
+    StartupMentorRelationshipFactory,
+)
 from impact.tests.utils import capture_stderr
+
+MENTEE_FIELDS = """
+    startupId
+    startupName
+    startupHighResolutionLogo
+    startupShortPitch
+    programLocation
+    programYear
+    programStatus
+"""
 
 
 class TestGraphQL(APITestCase):
@@ -74,26 +87,15 @@ class TestGraphQL(APITestCase):
                 query {{
                     expertProfile(id: {id}) {{
                         currentMentees {{
-                            startupId
-                            startupName
-                            startupHighResolutionLogo
-                            startupShortPitch
-                            programLocation
-                            programYear
-                            programStatus
+                            {MENTEE_FIELDS}
                         }}
                         previousMentees {{
-                            startupId
-                            startupName
-                            startupHighResolutionLogo
-                            startupShortPitch
-                            programLocation
-                            programYear
-                            programStatus
+                            {MENTEE_FIELDS}
                         }}
                     }}
                 }}
-            """.format(id=obj.mentor.expertprofile.id)
+            """.format(id=obj.mentor.expertprofile.id,
+                       MENTEE_FIELDS=MENTEE_FIELDS)
             response = self.client.post(self.url, data={'query': query})
             self.assertJSONEqual(
                 str(response.content, encoding='utf8'),

--- a/web/impact/impact/tests/test_graphql.py
+++ b/web/impact/impact/tests/test_graphql.py
@@ -43,6 +43,8 @@ class TestGraphQL(APITestCase):
                     expertProfile(id: {id}) {{
                         user {{ firstName }}
                         bio
+                        currentMentees {{ startupName }}
+                        previousMentees {{ startupName }}
                     }}
                 }}
             """.format(id=user.expertprofile.id)
@@ -56,6 +58,8 @@ class TestGraphQL(APITestCase):
                                 'firstName': user.first_name,
                             },
                             'bio': user.expertprofile.bio,
+                            'currentMentees': [],
+                            'previousMentees': [],
                         }
                     }
                 }

--- a/web/impact/impact/tests/test_graphql.py
+++ b/web/impact/impact/tests/test_graphql.py
@@ -56,8 +56,6 @@ class TestGraphQL(APITestCase):
                     expertProfile(id: {id}) {{
                         user {{ firstName }}
                         bio
-                        currentMentees {{ startupName }}
-                        previousMentees {{ startupName }}
                     }}
                 }}
             """.format(id=user.expertprofile.id)
@@ -71,8 +69,6 @@ class TestGraphQL(APITestCase):
                                 'firstName': user.first_name,
                             },
                             'bio': user.expertprofile.bio,
-                            'currentMentees': [],
-                            'previousMentees': [],
                         }
                     }
                 }
@@ -80,9 +76,10 @@ class TestGraphQL(APITestCase):
 
     def test_requested_fields_for_startup_mentor_relationship_type(self):
         with self.login(email=self.basic_user().email):
-            obj = StartupMentorRelationshipFactory()
-            startup = obj.startup_mentor_tracking.startup
-            program = obj.startup_mentor_tracking.program
+            mentor = ExpertFactory()
+            relationship = StartupMentorRelationshipFactory(mentor=mentor)
+            startup = relationship.startup_mentor_tracking.startup
+            program = relationship.startup_mentor_tracking.program
             query = """
                 query {{
                     expertProfile(id: {id}) {{
@@ -94,7 +91,7 @@ class TestGraphQL(APITestCase):
                         }}
                     }}
                 }}
-            """.format(id=obj.mentor.expertprofile.id,
+            """.format(id=relationship.mentor.expertprofile.id,
                        MENTEE_FIELDS=MENTEE_FIELDS)
             response = self.client.post(self.url, data={'query': query})
             self.assertJSONEqual(


### PR DESCRIPTION
#### Changes added:
- Add a StartupMentorRelationshipType to represent the previous and current mentee fields and add it to the ExpertProfileType

#### Test:
- ~Ensure you have pulled and checkout out into the `AC-5778` branch of the `django-accelerator` to have new properties~ This is no longer needed. Current implementation is done without adding the related_name ref to the mentor field on the StartupMentorRelationship model.
Please discard changes on the `django-accelerator` `AC-5778` branch cc @jonkiparsky 
- Run the impact api with `make run-server`
- Open graphiql by going to the graphql endpoint in the browser e.g on localhost go to `http://localhost:8000/graphql/`
- Create a query to retrieve an expert profile and specify currentMentees and previousMentees as fields e.g

```
{
  expertProfile(id:ID){
    user{
      firstName
    }
    currentMentees{
      startupId
      startupName
      startupHighResolutionLogo
      startupShortPitch
      programLocation
      programYear
      programStatus
    }
    previousMentees{
      startupId
      startupName
      startupHighResolutionLogo
      startupShortPitch
      programLocation
      programYear
      programStatus
    }
  }
}
```
