### PR TITLE
[AC-5495] - Allow for custom tagging when using `make release`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,9 @@ target_help = \
   '\tRelease name defaults release-<version>.<number> where <version> is' \
   '\tthe first line of impact-api/VERSION and <number> is the next unused' \
   '\tnon-negative integer (0,1,2,...).' \
-  '\t$$(release_name) overrides the entire release name.' \
+  '\t$$(TAG) overrides the entire release name.' \
+  '\tThe TAG can be set by adding an optional TAG="custom-tag" to the command' \
+  '\te.g. make release TAG="XX-XXXX" ' \
   'deploy - Deploy $$(release_name) to a $$(target).' \
   '\tValid targets include "staging" (the default), "production",' \
   '\t "test-1", and "test-2"' \
@@ -403,8 +405,6 @@ release-list:
 
 
 release:
-	@git commit --allow-empty -m "generating a new release"
-	@git push
 	@bash create_release.sh
 
 

--- a/Makefile
+++ b/Makefile
@@ -405,6 +405,8 @@ release-list:
 
 
 release:
+	@git commit --allow-empty -m "generating a new release"
+	@git push
 	@bash create_release.sh
 
 

--- a/create_release.sh
+++ b/create_release.sh
@@ -1,8 +1,6 @@
 
 # if a tag hasn't been passed in as a parameter, create a semantic one
 if [ ! -n "$TAG" ]; then
-    git commit --allow-empty -m "generating a new release"
-	git push
     docker run --rm  -v"$(pwd)":/app  -ti semantic-release  -- semantic-release version
     export pwd=$(pwd)
     export TAG=$(docker run --tty=false --rm  -v$pwd:/app  -i semantic-release -- semantic-release version --noop | grep "Current version: " | cut -d ' ' -f 3 | sed -e "s/\r//")

--- a/create_release.sh
+++ b/create_release.sh
@@ -1,7 +1,20 @@
-docker run --rm  -v"$(pwd)":/app  -ti semantic-release  -- semantic-release version
-export pwd=$(pwd)
-export TAG=$(docker run --tty=false --rm  -v$pwd:/app  -i semantic-release -- semantic-release version --noop | grep "Current version: " | cut -d ' ' -f 3 | sed -e "s/\r//")
+
+# if a tag hasn't been passed in as a parameter, create a semantic one
+if [ ! -n "$TAG" ]; then
+    git commit --allow-empty -m "generating a new release"
+	git push
+    docker run --rm  -v"$(pwd)":/app  -ti semantic-release  -- semantic-release version
+    export pwd=$(pwd)
+    export TAG=$(docker run --tty=false --rm  -v$pwd:/app  -i semantic-release -- semantic-release version --noop | grep "Current version: " | cut -d ' ' -f 3 | sed -e "s/\r//")
+else
+    echo "You passed in '$TAG' as the custom tag"
+    # TR == test release
+    echo "We're going to refactor the tag into 'TR-$TAG' to avoid any conflicts."
+    TAG="TR-$TAG"
+fi
+
 echo $TAG
+
 git push
 git push --tags
 cd ../django-accelerator && git tag "v${TAG}"


### PR DESCRIPTION
Changes Introduced in [AC-5495](https://masschallenge.atlassian.net/browse/AC-5495):

- allow use of `TAG` argument when using `make release` for custom tagging