### PR TITLE
[AC-5889] Make the new person profiles reference User ID and not Expert ID

### DIFF
--- a/web/impact/impact/graphql/query.py
+++ b/web/impact/impact/graphql/query.py
@@ -14,7 +14,6 @@ class Query(graphene.ObjectType):
 
     def resolve_expert_profile(self, info, **kwargs):
         user_id = kwargs.get('id')
-
         User = get_user_model()
 
         try:

--- a/web/impact/impact/graphql/query.py
+++ b/web/impact/impact/graphql/query.py
@@ -1,12 +1,7 @@
 import graphene
-from django.contrib.auth import get_user_model
-from django.core.exceptions import ObjectDoesNotExist
-from graphql import GraphQLError
 
 from impact.graphql.types.expert_profile_type import ExpertProfileType
-from accelerator_abstract.models.base_base_profile import (
-    EXPERT_USER_TYPE,
-)
+from accelerator.models.expert_profile import ExpertProfile
 
 
 class Query(graphene.ObjectType):
@@ -14,14 +9,8 @@ class Query(graphene.ObjectType):
 
     def resolve_expert_profile(self, info, **kwargs):
         user_id = kwargs.get('id')
-        User = get_user_model()
 
-        try:
-            user = User.objects.get(id=user_id)
-            profile = user.get_profile()
-            if profile.user_type.upper() == EXPERT_USER_TYPE:
-                return profile
-        except ObjectDoesNotExist:
-            raise GraphQLError('User not found')
+        if user_id is not None:
+            return ExpertProfile.objects.get(user_id=user_id)
 
         return None

--- a/web/impact/impact/graphql/query.py
+++ b/web/impact/impact/graphql/query.py
@@ -1,4 +1,5 @@
 import graphene
+from django.core.exceptions import ObjectDoesNotExist
 
 from impact.graphql.types.expert_profile_type import ExpertProfileType
 from accelerator.models.expert_profile import ExpertProfile
@@ -10,4 +11,8 @@ class Query(graphene.ObjectType):
     def resolve_expert_profile(self, info, **kwargs):
         user_id = kwargs.get('id')
 
-        return ExpertProfile.objects.get(user_id=user_id) if user_id else None
+        try:
+            return (ExpertProfile.objects.get(user_id=user_id)
+                    if user_id else None)
+        except ObjectDoesNotExist:
+            return None

--- a/web/impact/impact/graphql/query.py
+++ b/web/impact/impact/graphql/query.py
@@ -1,6 +1,7 @@
 import graphene
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ObjectDoesNotExist
+from graphql import GraphQLError
 
 from impact.graphql.types.expert_profile_type import ExpertProfileType
 from accelerator_abstract.models.base_base_profile import (
@@ -21,6 +22,6 @@ class Query(graphene.ObjectType):
             if profile.user_type.upper() == EXPERT_USER_TYPE:
                 return profile
         except ObjectDoesNotExist:
-            return None
+            raise GraphQLError('User not found')
 
         return None

--- a/web/impact/impact/graphql/query.py
+++ b/web/impact/impact/graphql/query.py
@@ -8,9 +8,6 @@ class Query(graphene.ObjectType):
     expert_profile = graphene.Field(ExpertProfileType, id=graphene.Int())
 
     def resolve_expert_profile(self, info, **kwargs):
-        expert_profile_id = kwargs.get('id')
+        user_id = kwargs.get('id')
 
-        if expert_profile_id is not None:
-            return ExpertProfile.objects.get(pk=expert_profile_id)
-
-        return None
+        return ExpertProfile.objects.get(user_id=user_id) if user_id else None

--- a/web/impact/impact/graphql/query.py
+++ b/web/impact/impact/graphql/query.py
@@ -3,7 +3,6 @@ from django.contrib.auth import get_user_model
 from django.core.exceptions import ObjectDoesNotExist
 
 from impact.graphql.types.expert_profile_type import ExpertProfileType
-from accelerator.models.expert_profile import ExpertProfile
 from accelerator_abstract.models.base_base_profile import (
     EXPERT_USER_TYPE,
 )
@@ -18,8 +17,9 @@ class Query(graphene.ObjectType):
 
         try:
             user = User.objects.get(id=user_id)
-            if user.get_profile().user_type.upper() == EXPERT_USER_TYPE:
-                return ExpertProfile.objects.get(user_id=user_id)
+            profile = user.get_profile()
+            if profile.user_type.upper() == EXPERT_USER_TYPE:
+                return profile
         except ObjectDoesNotExist:
             return None
 

--- a/web/impact/impact/graphql/query.py
+++ b/web/impact/impact/graphql/query.py
@@ -1,8 +1,12 @@
 import graphene
+from django.contrib.auth import get_user_model
 from django.core.exceptions import ObjectDoesNotExist
 
 from impact.graphql.types.expert_profile_type import ExpertProfileType
 from accelerator.models.expert_profile import ExpertProfile
+from accelerator_abstract.models.base_base_profile import (
+    EXPERT_USER_TYPE,
+)
 
 
 class Query(graphene.ObjectType):
@@ -11,8 +15,13 @@ class Query(graphene.ObjectType):
     def resolve_expert_profile(self, info, **kwargs):
         user_id = kwargs.get('id')
 
+        User = get_user_model()
+
         try:
-            return (ExpertProfile.objects.get(user_id=user_id)
-                    if user_id else None)
+            user = User.objects.get(id=user_id)
+            if user.get_profile().user_type.upper() == EXPERT_USER_TYPE:
+                return ExpertProfile.objects.get(user_id=user_id)
         except ObjectDoesNotExist:
             return None
+
+        return None

--- a/web/impact/impact/tests/test_graphql.py
+++ b/web/impact/impact/tests/test_graphql.py
@@ -16,7 +16,7 @@ class TestGraphQL(APITestCase):
     def test_anonymous_user_cannot_access_main_graphql_view(self):
         user = ExpertFactory()
         query = """query {{ expertProfile(id: {id}) {{ title }} }}
-            """.format(id=user.expertprofile.id)
+            """.format(id=user.id)
 
         with capture_stderr(self.client.post,
                             self.url,
@@ -45,7 +45,7 @@ class TestGraphQL(APITestCase):
                         bio
                     }}
                 }}
-            """.format(id=user.expertprofile.id)
+            """.format(id=user.id)
             response = self.client.post(self.url, data={'query': query})
             self.assertJSONEqual(
                 str(response.content, encoding='utf8'),

--- a/web/impact/impact/tests/test_graphql.py
+++ b/web/impact/impact/tests/test_graphql.py
@@ -151,6 +151,20 @@ class TestGraphQL(APITestCase):
             self.assertJSONEqual(
                 str(response.content, encoding='utf8'),
                 {
+                    'errors': [
+                        {
+                            'message': 'User not found',
+                            'locations': [
+                                {
+                                    'line': 3,
+                                    'column': 21
+                                }
+                            ],
+                            'path': [
+                                'expertProfile'
+                            ]
+                        }
+                    ],
                     'data': {
                         'expertProfile': None
                     }

--- a/web/impact/impact/tests/test_graphql.py
+++ b/web/impact/impact/tests/test_graphql.py
@@ -141,7 +141,7 @@ class TestGraphQL(APITestCase):
                 None
             )
 
-    def test_query_with_non_existant_user_id(self):
+    def test_query_with_non_existent_user_id(self):
         with self.login(email=self.basic_user().email):
             query = """
                 query {{

--- a/web/impact/impact/tests/test_graphql.py
+++ b/web/impact/impact/tests/test_graphql.py
@@ -1,6 +1,6 @@
 # MIT License
 # Copyright (c) 2017 MassChallenge, Inc.
-
+import json
 from django.urls import reverse
 
 from impact.graphql.middleware import NOT_LOGGED_IN_MSG
@@ -21,6 +21,8 @@ MENTEE_FIELDS = """
     programYear
     programStatus
 """
+
+EXPERT_NOT_FOUND_MESSAGE = 'ExpertProfile matching query does not exist.'
 
 
 class TestGraphQL(APITestCase):
@@ -129,13 +131,14 @@ class TestGraphQL(APITestCase):
                 }}
             """.format(id=user.id)
             response = self.client.post(self.url, data={'query': query})
-            self.assertJSONEqual(
-                str(response.content, encoding='utf8'),
-                {
-                    'data': {
-                        'expertProfile': None
-                    }
-                }
+            response_payload = json.loads(response.content)
+            self.assertEqual(
+                response_payload['errors'][0]['message'],
+                EXPERT_NOT_FOUND_MESSAGE
+            )
+            self.assertEqual(
+                response_payload['data']['expertProfile'],
+                None
             )
 
     def test_query_with_non_existant_user_id(self):
@@ -148,25 +151,12 @@ class TestGraphQL(APITestCase):
                 }}
             """.format(id=0)
             response = self.client.post(self.url, data={'query': query})
-            self.assertJSONEqual(
-                str(response.content, encoding='utf8'),
-                {
-                    'errors': [
-                        {
-                            'message': 'User not found',
-                            'locations': [
-                                {
-                                    'line': 3,
-                                    'column': 21
-                                }
-                            ],
-                            'path': [
-                                'expertProfile'
-                            ]
-                        }
-                    ],
-                    'data': {
-                        'expertProfile': None
-                    }
-                }
+            response_payload = json.loads(response.content)
+            self.assertEqual(
+                response_payload['errors'][0]['message'],
+                EXPERT_NOT_FOUND_MESSAGE
+            )
+            self.assertEqual(
+                response_payload['data']['expertProfile'],
+                None
             )

--- a/web/impact/impact/tests/test_graphql.py
+++ b/web/impact/impact/tests/test_graphql.py
@@ -137,3 +137,22 @@ class TestGraphQL(APITestCase):
                     }
                 }
             )
+
+    def test_query_with_non_existant_user_id(self):
+        with self.login(email=self.basic_user().email):
+            query = """
+                query {{
+                    expertProfile(id: {id}) {{
+                        user {{ firstName }}
+                    }}
+                }}
+            """.format(id=0)
+            response = self.client.post(self.url, data={'query': query})
+            self.assertJSONEqual(
+                str(response.content, encoding='utf8'),
+                {
+                    'data': {
+                        'expertProfile': None
+                    }
+                }
+            )


### PR DESCRIPTION
#### Changes introduced in [AC-5889](https://masschallenge.atlassian.net/browse/AC-5889):
- Retrieve `user id` from API request instead of the `expert id` and query the Expert Profile using this user id

#### How to test

- Run the graphiql interface on `http://localhost:8000/graphql`
- Run this query:
```
{
  expertProfile(id:user_id){
    user{
      firstName
    }
    bio
  }
}
```
If the user id is valid and belongs to an expert you should get the correct response. Otherwise the response should be null