### PR TITLE
[AC-5778-staging-fix] fix mentee ordering and startup logo url

### DIFF
--- a/web/impact/impact/graphql/types/expert_profile_type.py
+++ b/web/impact/impact/graphql/types/expert_profile_type.py
@@ -115,4 +115,4 @@ def _get_mentees(user, program_status):
     return user.startupmentorrelationship_set.filter(
         status=CONFIRMED_RELATIONSHIP,
         **mentee_filter
-    )
+    ).order_by('-startup_mentor_tracking__program__start_date')

--- a/web/impact/impact/graphql/types/startup_mentor_relationship_type.py
+++ b/web/impact/impact/graphql/types/startup_mentor_relationship_type.py
@@ -38,7 +38,8 @@ class StartupMentorRelationshipType(DjangoObjectType):
 
     def resolve_startup_high_resolution_logo(self, info, **kwargs):
         startup = self.startup_mentor_tracking.startup
-        return startup and startup.high_resolution_logo
+        return (startup and startup.high_resolution_logo and
+                startup.high_resolution_logo.url)
 
     def resolve_startup_short_pitch(self, info, **kwargs):
         startup = self.startup_mentor_tracking.startup

--- a/web/impact/impact/tests/test_graphql.py
+++ b/web/impact/impact/tests/test_graphql.py
@@ -106,7 +106,9 @@ class TestGraphQL(APITestCase):
                                 'startupId': str(startup.id),
                                 'startupName': startup.name,
                                 'startupHighResolutionLogo':
-                                    str(startup.high_resolution_logo),
+                                    (startup.high_resolution_logo and
+                                     startup.high_resolution_logo.url or
+                                     ''),
                                 'startupShortPitch': startup.short_pitch,
                                 'programLocation':
                                     program.program_family.name,


### PR DESCRIPTION
#### Changes introduced:
- Order mentees by descending order using their program start date
- Return the correct path for startup logos

#### How to test:
On localhost(`http://localhost:8000/graphql/`) If you run the query for a mentor with mentees in programs over several years
- the most recent mentees should be at the top 
- startupHighResolutionLogo should be in the shape `/media/startup_pics/example.png`
```
{
  expertProfile(id:user_id){
    previousMentees{
      startupName
      startupHighResolutionLogo
      programYear
    }
    previousMentees{
      startupName
      startupHighResolutionLogo
      programYear
    }
  }
}
```