### PR TITLE
AC-5899: Test all Graphql Expert Profile Type Resolvers

### DIFF
--- a/web/impact/impact/tests/test_graphql.py
+++ b/web/impact/impact/tests/test_graphql.py
@@ -1,6 +1,5 @@
 # MIT License
 # Copyright (c) 2017 MassChallenge, Inc.
-import json
 from django.urls import reverse
 
 from impact.graphql.middleware import NOT_LOGGED_IN_MSG
@@ -132,14 +131,16 @@ class TestGraphQL(APITestCase):
                     }}
                 }}
             """.format(id=user.id)
-            response = self.client.post(self.url, data={'query': query})
-            response_payload = json.loads(response.content)
+
+            with capture_stderr(self.client.post,
+                                self.url,
+                                data={'query': query}) as (response, _):
+                error_messages = [x['message'] for x in
+                                  response.json()['errors']]
+
+            self.assertIn(EXPERT_NOT_FOUND_MESSAGE, error_messages)
             self.assertEqual(
-                response_payload['errors'][0]['message'],
-                EXPERT_NOT_FOUND_MESSAGE
-            )
-            self.assertEqual(
-                response_payload['data']['expertProfile'],
+                response.json()['data']['expertProfile'],
                 None
             )
 
@@ -152,13 +153,15 @@ class TestGraphQL(APITestCase):
                     }}
                 }}
             """.format(id=0)
-            response = self.client.post(self.url, data={'query': query})
-            response_payload = json.loads(response.content)
+
+            with capture_stderr(self.client.post,
+                                self.url,
+                                data={'query': query}) as (response, _):
+                error_messages = [x['message'] for x in
+                                  response.json()['errors']]
+
+            self.assertIn(EXPERT_NOT_FOUND_MESSAGE, error_messages)
             self.assertEqual(
-                response_payload['errors'][0]['message'],
-                EXPERT_NOT_FOUND_MESSAGE
-            )
-            self.assertEqual(
-                response_payload['data']['expertProfile'],
+                response.json()['data']['expertProfile'],
                 None
             )

--- a/web/impact/impact/tests/test_graphql.py
+++ b/web/impact/impact/tests/test_graphql.py
@@ -94,34 +94,35 @@ class TestGraphQL(APITestCase):
             )
 
     def test_office_url_field_returns_correct_value(self):
-        with self.login(email=self.basic_user().email):
-            program = ProgramFactory()
-            confirmed = ExpertFactory()
-            confirmed_role = UserRoleFactory(name=UserRole.MENTOR)
-            program_role = ProgramRoleFactory(program=program,
-                                              user_role=confirmed_role)
-            program_grant_role = ProgramRoleGrantFactory(
-                person=confirmed,
-                program_role=program_role)
-            mentor_profile = confirmed.get_profile()
-            mentor_program = program_grant_role.program_role.program
-            family_slug = mentor_program.program_family.url_slug
-            program_slug = mentor_program.url_slug
-            office_hours_url = ("/officehours/{family_slug}/{program_slug}/"
-                                .format(
-                                    family_slug=family_slug,
-                                    program_slug=program_slug) + (
-                                    '?mentor_id={mentor_id}'.format(
-                                        mentor_id=mentor_profile.user_id)))
+        program = ProgramFactory()
+        confirmed = ExpertFactory()
+        confirmed_role = UserRoleFactory(name=UserRole.MENTOR)
+        program_role = ProgramRoleFactory(program=program,
+                                          user_role=confirmed_role)
+        program_grant_role = ProgramRoleGrantFactory(
+            person=confirmed,
+            program_role=program_role)
+        mentor_profile = confirmed.get_profile()
+        mentor_program = program_grant_role.program_role.program
+        family_slug = mentor_program.program_family.url_slug
+        program_slug = mentor_program.url_slug
+        office_hours_url = ("/officehours/{family_slug}/{program_slug}/"
+                            .format(
+                                family_slug=family_slug,
+                                program_slug=program_slug) + (
+                                '?mentor_id={mentor_id}'.format(
+                                    mentor_id=mentor_profile.user_id)))
 
-            query = """
-                query {{
-                    expertProfile(id: {id}) {{
-                        user {{ firstName }}
-                        officeHoursUrl
-                    }}
+        query = """
+            query {{
+                expertProfile(id: {id}) {{
+                    user {{ firstName }}
+                    officeHoursUrl
                 }}
-            """.format(id=mentor_profile.user_id)
+            }}
+        """.format(id=mentor_profile.user_id)
+
+        with self.login(email=self.basic_user().email):
             response = self.client.post(self.url, data={'query': query})
             self.assertJSONEqual(
                 str(response.content, encoding='utf8'),


### PR DESCRIPTION
#### Changes made on [AC-5899](https://masschallenge.atlassian.net/browse/AC-5899):
- Write tests to invoke all expert profile type resolvers

#### How to Test
- Run `make coverage-html` on impact to run the tests and generate a coverage report
- The coverage on the file expert_profile_type.py should be 100%