### PR TITLE
AC-5961 Add high level Application information to Salesforce API

### DIFF
--- a/web/impact/impact/tests/test_application_detail_view.py
+++ b/web/impact/impact/tests/test_application_detail_view.py
@@ -1,0 +1,61 @@
+# MIT License
+# Copyright (c) 2017 MassChallenge, Inc.
+
+import json
+from jsonschema import Draft4Validator
+
+from django.urls import reverse
+from impact.tests.factories import ApplicationFactory
+from impact.tests.api_test_case import APITestCase
+from impact.tests.utils import assert_fields
+from impact.v1.views import ApplicationDetailView
+
+APPLICATION_GET_FIELDS = [
+    "id",
+    "created_at",
+    "updated_at",
+    "application_status",
+    "cycle",
+    "startup",
+    "application_type",
+]
+
+
+class TestApplicationDetailView(APITestCase):
+    def test_get(self):
+        application = ApplicationFactory()
+        with self.login(email=self.basic_user().email):
+            url = reverse(ApplicationDetailView.view_name,
+                          args=[application.id])
+            response = self.client.get(url)
+            assert response.data["created_at"] == application.created_at
+            assert response.data["updated_at"] == application.updated_at
+            assert (response.data["application_status"] ==
+                    application.application_status)
+            assert response.data["cycle"] == application.cycle.id
+            assert response.data["startup"] == application.startup.id
+            assert (response.data["application_type"] ==
+                    application.application_type.id)
+
+    def test_options(self):
+        application = ApplicationFactory()
+        with self.login(email=self.basic_user().email):
+            url = reverse(ApplicationDetailView.view_name,
+                          args=[application.id])
+            response = self.client.options(url)
+            assert response.status_code == 200
+            get_options = response.data["actions"]["GET"]["properties"]
+            assert_fields(APPLICATION_GET_FIELDS, get_options)
+
+    def test_options_against_get(self):
+        application = ApplicationFactory()
+        with self.login(email=self.basic_user().email):
+            url = reverse(ApplicationDetailView.view_name,
+                          args=[application.id])
+
+            options_response = self.client.options(url)
+            get_response = self.client.get(url)
+
+            schema = options_response.data["actions"]["GET"]
+            validator = Draft4Validator(schema)
+            assert validator.is_valid(json.loads(get_response.content))

--- a/web/impact/impact/tests/test_application_list_view.py
+++ b/web/impact/impact/tests/test_application_list_view.py
@@ -1,0 +1,50 @@
+import json
+from jsonschema import Draft4Validator
+
+from django.urls import reverse
+from impact.tests.factories import ApplicationFactory
+from impact.tests.api_test_case import APITestCase
+from impact.tests.utils import assert_fields
+from impact.v1.views import ApplicationListView
+
+APPLICATION_GET_FIELDS = [
+    "id",
+    "created_at",
+    "updated_at",
+    "application_status",
+    "cycle",
+    "startup",
+    "application_type",
+]
+
+
+class TestApplicationListView(APITestCase):
+    url = reverse(ApplicationListView.view_name)
+
+    def test_get(self):
+        count = 5
+        applications = ApplicationFactory.create_batch(count)
+        with self.login(email=self.basic_user().email):
+            response = self.client.get(self.url)
+            assert response.data["count"] == count
+            assert all([ApplicationListView.serialize(application)
+                        in response.data["results"]
+                        for application in applications])
+
+    def test_options(self):
+        with self.login(email=self.basic_user().email):
+            response = self.client.options(self.url)
+            assert response.status_code == 200
+            results = response.data["actions"]["GET"]["properties"]["results"]
+            get_options = results["item"]["properties"]
+            assert_fields(APPLICATION_GET_FIELDS, get_options)
+
+    def test_options_against_get(self):
+        with self.login(email=self.basic_user().email):
+
+            options_response = self.client.options(self.url)
+            get_response = self.client.get(self.url)
+
+            schema = options_response.data["actions"]["GET"]
+            validator = Draft4Validator(schema)
+            assert validator.is_valid(json.loads(get_response.content))

--- a/web/impact/impact/tests/test_application_list_view.py
+++ b/web/impact/impact/tests/test_application_list_view.py
@@ -7,15 +7,9 @@ from impact.tests.api_test_case import APITestCase
 from impact.tests.utils import assert_fields
 from impact.v1.views import ApplicationListView
 
-APPLICATION_GET_FIELDS = [
-    "id",
-    "created_at",
-    "updated_at",
-    "application_status",
-    "cycle",
-    "startup",
-    "application_type",
-]
+from impact.tests.test_application_detail_view import (
+    APPLICATION_GET_FIELDS,
+)
 
 
 class TestApplicationListView(APITestCase):

--- a/web/impact/impact/v1/helpers/__init__.py
+++ b/web/impact/impact/v1/helpers/__init__.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2017 MassChallenge, Inc.
 
 
+from impact.v1.helpers.application_helper import ApplicationHelper
 from impact.v1.helpers.functional_expertise_helper import (
     FunctionalExpertiseHelper,
 )

--- a/web/impact/impact/v1/helpers/application_helper.py
+++ b/web/impact/impact/v1/helpers/application_helper.py
@@ -2,8 +2,40 @@
 # Copyright (c) 2017 MassChallenge, Inc.
 
 from accelerator.models import Application
-from impact.v1.helpers.mptt_model_helper import MPTTModelHelper
+from impact.v1.helpers.model_helper import (
+    ModelHelper,
+    OPTIONAL_INTEGER_FIELD,
+    OPTIONAL_STRING_FIELD,
+    PK_FIELD,
+)
+
+APPLICATION_FIELDS = {
+    "application_status": OPTIONAL_STRING_FIELD,
+    "application_type": OPTIONAL_INTEGER_FIELD,
+    "created_at": OPTIONAL_STRING_FIELD,
+    "cycle": OPTIONAL_INTEGER_FIELD,
+    "id": PK_FIELD,
+    "startup": OPTIONAL_INTEGER_FIELD,
+    "submission_datetime": OPTIONAL_STRING_FIELD,
+    "updated_at": OPTIONAL_STRING_FIELD,
+}
 
 
-class ApplicationHelper(MPTTModelHelper):
+class ApplicationHelper(ModelHelper):
     model = Application
+
+    @classmethod
+    def fields(cls):
+        return APPLICATION_FIELDS
+
+    @property
+    def application_type(self):
+        return self.field_element("application_type", "id")
+
+    @property
+    def cycle(self):
+        return self.field_element("cycle", "id")
+
+    @property
+    def startup(self):
+        return self.field_element("startup", "id")

--- a/web/impact/impact/v1/helpers/application_helper.py
+++ b/web/impact/impact/v1/helpers/application_helper.py
@@ -1,0 +1,9 @@
+# MIT License
+# Copyright (c) 2017 MassChallenge, Inc.
+
+from accelerator.models import Application
+from impact.v1.helpers.mptt_model_helper import MPTTModelHelper
+
+
+class ApplicationHelper(MPTTModelHelper):
+    model = Application

--- a/web/impact/impact/v1/helpers/application_helper.py
+++ b/web/impact/impact/v1/helpers/application_helper.py
@@ -6,18 +6,19 @@ from impact.v1.helpers.model_helper import (
     ModelHelper,
     OPTIONAL_INTEGER_FIELD,
     OPTIONAL_STRING_FIELD,
+    READ_ONLY_STRING_FIELD,
     PK_FIELD,
 )
 
 APPLICATION_FIELDS = {
     "application_status": OPTIONAL_STRING_FIELD,
     "application_type": OPTIONAL_INTEGER_FIELD,
-    "created_at": OPTIONAL_STRING_FIELD,
+    "created_at": READ_ONLY_STRING_FIELD,
     "cycle": OPTIONAL_INTEGER_FIELD,
     "id": PK_FIELD,
     "startup": OPTIONAL_INTEGER_FIELD,
     "submission_datetime": OPTIONAL_STRING_FIELD,
-    "updated_at": OPTIONAL_STRING_FIELD,
+    "updated_at": READ_ONLY_STRING_FIELD,
 }
 
 

--- a/web/impact/impact/v1/helpers/application_helper.py
+++ b/web/impact/impact/v1/helpers/application_helper.py
@@ -6,19 +6,18 @@ from impact.v1.helpers.model_helper import (
     ModelHelper,
     OPTIONAL_INTEGER_FIELD,
     OPTIONAL_STRING_FIELD,
-    READ_ONLY_STRING_FIELD,
     PK_FIELD,
 )
 
 APPLICATION_FIELDS = {
     "application_status": OPTIONAL_STRING_FIELD,
     "application_type": OPTIONAL_INTEGER_FIELD,
-    "created_at": READ_ONLY_STRING_FIELD,
+    "created_at": OPTIONAL_STRING_FIELD,
     "cycle": OPTIONAL_INTEGER_FIELD,
     "id": PK_FIELD,
     "startup": OPTIONAL_INTEGER_FIELD,
     "submission_datetime": OPTIONAL_STRING_FIELD,
-    "updated_at": READ_ONLY_STRING_FIELD,
+    "updated_at": OPTIONAL_STRING_FIELD,
 }
 
 

--- a/web/impact/impact/v1/urls.py
+++ b/web/impact/impact/v1/urls.py
@@ -1,6 +1,7 @@
 from django.conf.urls import url
 
 from impact.v1.views import (
+    ApplicationDetailView,
     AllocateApplicationsView,
     AnalyzeJudgingRoundView,
     ApplicationListView,
@@ -42,6 +43,9 @@ v1_urlpatterns = [
     url(r"^analyze_judging_round/(?P<pk>[0-9]+)/$",
         AnalyzeJudgingRoundView.as_view(),
         name=AnalyzeJudgingRoundView.view_name),
+    url(r"^application/(?P<pk>[0-9]+)/$",
+        ApplicationDetailView.as_view(),
+        name=ApplicationDetailView.view_name),
     url(r"^application/$",
         ApplicationListView.as_view(),
         name=ApplicationListView.view_name),

--- a/web/impact/impact/v1/urls.py
+++ b/web/impact/impact/v1/urls.py
@@ -3,6 +3,7 @@ from django.conf.urls import url
 from impact.v1.views import (
     AllocateApplicationsView,
     AnalyzeJudgingRoundView,
+    ApplicationListView,
     CloneCriteriaView,
     CreditCodeDetailView,
     CreditCodeListView,
@@ -41,6 +42,9 @@ v1_urlpatterns = [
     url(r"^analyze_judging_round/(?P<pk>[0-9]+)/$",
         AnalyzeJudgingRoundView.as_view(),
         name=AnalyzeJudgingRoundView.view_name),
+    url(r"^application/$",
+        ApplicationListView.as_view(),
+        name=ApplicationListView.view_name),
     url(r"^clone_criteria/$",
         CloneCriteriaView.as_view(),
         name=CloneCriteriaView.view_name),

--- a/web/impact/impact/v1/urls.py
+++ b/web/impact/impact/v1/urls.py
@@ -1,9 +1,9 @@
 from django.conf.urls import url
 
 from impact.v1.views import (
-    ApplicationDetailView,
     AllocateApplicationsView,
     AnalyzeJudgingRoundView,
+    ApplicationDetailView,
     ApplicationListView,
     CloneCriteriaView,
     CreditCodeDetailView,
@@ -23,12 +23,12 @@ from impact.v1.views import (
     OrganizationHistoryView,
     OrganizationListView,
     OrganizationUsersView,
-    ProgramDetailView,
-    ProgramListView,
     ProgramCycleDetailView,
     ProgramCycleListView,
+    ProgramDetailView,
     ProgramFamilyDetailView,
     ProgramFamilyListView,
+    ProgramListView,
     UserConfidentialView,
     UserDetailView,
     UserHistoryView,

--- a/web/impact/impact/v1/views/__init__.py
+++ b/web/impact/impact/v1/views/__init__.py
@@ -17,6 +17,7 @@ from impact.v1.views.clone_criteria_view import (
     SOURCE_JUDGING_ROUND_KEY,
     TARGET_JUDGING_ROUND_KEY,
 )
+from impact.v1.views.application_list_view import ApplicationListView
 from impact.v1.views.credit_code_detail_view import CreditCodeDetailView
 from impact.v1.views.credit_code_list_view import CreditCodeListView
 from impact.v1.views.criterion_detail_view import CriterionDetailView

--- a/web/impact/impact/v1/views/__init__.py
+++ b/web/impact/impact/v1/views/__init__.py
@@ -17,6 +17,7 @@ from impact.v1.views.clone_criteria_view import (
     SOURCE_JUDGING_ROUND_KEY,
     TARGET_JUDGING_ROUND_KEY,
 )
+from impact.v1.views.application_detail_view import ApplicationDetailView
 from impact.v1.views.application_list_view import ApplicationListView
 from impact.v1.views.credit_code_detail_view import CreditCodeDetailView
 from impact.v1.views.credit_code_list_view import CreditCodeListView

--- a/web/impact/impact/v1/views/application_detail_view.py
+++ b/web/impact/impact/v1/views/application_detail_view.py
@@ -1,0 +1,10 @@
+# MIT License
+# Copyright (c) 2017 MassChallenge, Inc.
+
+from impact.v1.helpers import ApplicationHelper
+from impact.v1.views.base_detail_view import BaseDetailView
+
+
+class ApplicationDetailView(BaseDetailView):
+    view_name = "application_detail"
+    helper_class = ApplicationHelper

--- a/web/impact/impact/v1/views/application_list_view.py
+++ b/web/impact/impact/v1/views/application_list_view.py
@@ -1,8 +1,8 @@
 # MIT License
 # Copyright (c) 2017 MassChallenge, Inc.
 
-from impact.v1.views.base_list_view import BaseListView
 from impact.v1.helpers import ApplicationHelper
+from impact.v1.views.base_list_view import BaseListView
 
 
 class ApplicationListView(BaseListView):

--- a/web/impact/impact/v1/views/application_list_view.py
+++ b/web/impact/impact/v1/views/application_list_view.py
@@ -1,0 +1,10 @@
+# MIT License
+# Copyright (c) 2017 MassChallenge, Inc.
+
+from impact.v1.views.base_list_view import BaseListView
+from impact.v1.helpers import ApplicationHelper
+
+
+class ApplicationListView(BaseListView):
+    view_name = "application"
+    helper_class = ApplicationHelper


### PR DESCRIPTION
Changes introduced in [AC-5961](https://masschallenge.atlassian.net/browse/AC-5961):
- Add application list view to impact V1
- Add application detail view to impact V1

How to test (on localhost):
- Make sure you are logged in as a user who belongs to the `v1_clients` user group. (You can add the user to the group here `http://localhost:8181/admin`)
-Enter the url `http://localhost:8000/api/v1/application/` in the browser to view the results of a GET request to that route
- -Enter the url `http://localhost:8000/api/v1/application/{application_id}` in the browser to view the results of a GET request to that route