### PR TITLE
AC-5970 - fix impact-api dependencies

### DIFF
--- a/web/impact/requirements/base.txt
+++ b/web/impact/requirements/base.txt
@@ -32,7 +32,7 @@ django-embed-video
 django-filter # Filtering support
 django-oauth-toolkit<1.1
 django-redis-cache
-django-registration
+django-registration==2.5.2
 django-rest-framework-proxy
 django-rest-swagger
 django-paypal

--- a/web/impact/requirements/base.txt
+++ b/web/impact/requirements/base.txt
@@ -29,7 +29,7 @@ dj-email-url
 django-cors-headers
 django-cors-middleware==1.3.1
 django-embed-video
-django-filter # Filtering support
+django-filter==1.1.0
 django-oauth-toolkit<1.1
 django-redis-cache
 django-registration==2.5.2

--- a/web/impact/requirements/base.txt
+++ b/web/impact/requirements/base.txt
@@ -24,30 +24,31 @@ gunicorn
 numpy
 
 # Django
+boto3==1.6.0
 dj-database-url
 dj-email-url
 django-cors-headers
 django-cors-middleware==1.3.1
 django-embed-video
+django-environ==0.4.4
 django-filter==1.1.0
+django-mptt==0.9.0
+django-multidb-router
 django-oauth-toolkit<1.1
+django-paypal
+django-polymorphic==1.3
 django-redis-cache
 django-registration==2.5.2
 django-rest-framework-proxy
 django-rest-swagger
-django-paypal
+django-storages==1.6.5
 Django==1.10.8
-django-multidb-router
 djangorestframework
 djangorestframework-jwt
 drf-schema-adapter
 drf-tracking
-sorl-thumbnail==12.4.1
-django-storages==1.6.5
-boto3==1.6.0
 graphene-django>=2.0
-django-environ==0.4.4
-django-polymorphic==1.3
+sorl-thumbnail==12.4.1
 
 
 # django-configurations from Git master (needed for Django 1.8 support)

--- a/web/impact/requirements/base.txt
+++ b/web/impact/requirements/base.txt
@@ -32,7 +32,6 @@ django-cors-middleware==1.3.1
 django-embed-video
 django-environ==0.4.4
 django-filter==1.1.0
-django-mptt==0.9.0
 django-multidb-router
 django-oauth-toolkit<1.1
 django-paypal


### PR DESCRIPTION
## [AC-5970](https://masschallenge.atlassian.net/browse/AC-5970)

Two of our unpinned dependencies got version bumps in the past few days that broke compatibility with Django 1.10. This PR locks them to compatible versions.

(The diff is noisy because I also sorted the reqs I was editing.)

To test: check out the branch and run `make test`, or look at Travis output. You should see no errors and no failures.

To reproduce the errors that this PR fixes: check out impact API at 7fc4974 or earlier (e.g. v1.0.44), run `make build && make test`, and see 240+ errors.