### PR TITLE
[Ac 5901] Reduce number of queries for analyze_judging_round

### DIFF
--- a/web/impact/impact/tests/test_analyze_judging_round_view.py
+++ b/web/impact/impact/tests/test_analyze_judging_round_view.py
@@ -11,9 +11,6 @@ from accelerator.tests.contexts import AnalyzeJudgingContext
 from impact.tests.api_test_case import APITestCase
 from impact.tests.utils import assert_fields
 from impact.v1.views import AnalyzeJudgingRoundView
-from impact.v1.helpers.matching_program_criterion_helper import (
-    MatchingProgramCriterionHelper,
-)
 
 
 class TestAnalyzeJudgingRoundView(APITestCase):
@@ -115,8 +112,6 @@ class TestAnalyzeJudgingRoundView(APITestCase):
                                         options=[""])
         # This is where I gave up and just hard coded it!
         dists = {context.program.program_family.name: {0: 1, 1: 1}}
-        # clear cache since we added a new program family!
-        MatchingProgramCriterionHelper.program_families = None
         self.assert_option_distributions(context, dists)
 
     def assert_option_distributions(self, context, dists):

--- a/web/impact/impact/tests/test_analyze_judging_round_view.py
+++ b/web/impact/impact/tests/test_analyze_judging_round_view.py
@@ -11,6 +11,9 @@ from accelerator.tests.contexts import AnalyzeJudgingContext
 from impact.tests.api_test_case import APITestCase
 from impact.tests.utils import assert_fields
 from impact.v1.views import AnalyzeJudgingRoundView
+from impact.v1.helpers.matching_program_criterion_helper import (
+    MatchingProgramCriterionHelper,
+)
 
 
 class TestAnalyzeJudgingRoundView(APITestCase):
@@ -112,6 +115,8 @@ class TestAnalyzeJudgingRoundView(APITestCase):
                                         options=[""])
         # This is where I gave up and just hard coded it!
         dists = {context.program.program_family.name: {0: 1, 1: 1}}
+        # clear cache since we added a new program family!
+        MatchingProgramCriterionHelper.program_families = None
         self.assert_option_distributions(context, dists)
 
     def assert_option_distributions(self, context, dists):

--- a/web/impact/impact/v1/classes/option_analysis.py
+++ b/web/impact/impact/v1/classes/option_analysis.py
@@ -39,11 +39,17 @@ CriterionHelper.register_helper(MatchingProgramCriterionHelper,
 class OptionAnalysis(object):
     _judge_to_count = None
 
-    def __init__(self, option_spec, apps, judging_round, application_counts):
+    def __init__(self,
+                 option_spec,
+                 apps,
+                 app_ids,
+                 judging_round,
+                 application_counts):
         self.option_spec = option_spec
         self.judging_round = judging_round
         self.helper = CriterionOptionSpecHelper(option_spec)
         self.apps = apps
+        self.app_ids = app_ids
         self.application_counts = application_counts
 
     def analyses(self):

--- a/web/impact/impact/v1/helpers/criterion_option_spec_helper.py
+++ b/web/impact/impact/v1/helpers/criterion_option_spec_helper.py
@@ -64,11 +64,11 @@ class CriterionOptionSpecHelper(ModelHelper):
             commitments=commitments,
             option_name=option_name)
 
-    def remaining_capacity(self, commitments, assignments, option_name):
+    def remaining_capacity(self, commitments, assignment_counts, option_name):
         return self.criterion_helper.remaining_capacity(
-            assignments=assignments,
-            commitments=commitments,
-            option_name=option_name)
+            commitments,
+            assignment_counts,
+            option_name)
 
     @classmethod
     def fields(cls):

--- a/web/impact/impact/v1/helpers/matching_criterion_helper.py
+++ b/web/impact/impact/v1/helpers/matching_criterion_helper.py
@@ -33,6 +33,6 @@ class MatchingCriterionHelper(CriterionHelper):
         if not self._app_ids_to_targets:
             self.calc_app_ids_to_targets(apps)
 
-    @classmethod
-    def cache_instances_by_name(cls, model):
+    @staticmethod
+    def instances_by_name(model):
         return {instance.name: instance for instance in model.objects.all()}

--- a/web/impact/impact/v1/helpers/matching_criterion_helper.py
+++ b/web/impact/impact/v1/helpers/matching_criterion_helper.py
@@ -32,3 +32,7 @@ class MatchingCriterionHelper(CriterionHelper):
     def _check_cache(self, apps):
         if not self._app_ids_to_targets:
             self.calc_app_ids_to_targets(apps)
+
+    @classmethod
+    def cache_instances_by_name(cls, model):
+        return {instance.name: instance for instance in model.objects.all()}

--- a/web/impact/impact/v1/helpers/matching_industry_criterion_helper.py
+++ b/web/impact/impact/v1/helpers/matching_industry_criterion_helper.py
@@ -12,13 +12,20 @@ from impact.v1.helpers.matching_criterion_helper import MatchingCriterionHelper
 class MatchingIndustryCriterionHelper(MatchingCriterionHelper):
     application_field = "startup__primary_industry__id"
     judge_field = "expertprofile__primary_industry__name"
+    industries = None
 
     def __init__(self, subject):
         super().__init__(subject)
         self._top_level_id_cache = None
 
+    @classmethod
+    def _industry_map(cls):
+        if cls.industries is None:
+            cls.industries = cls.cache_instances_by_name(Industry)
+        return cls.industries
+
     def app_ids_for_feedbacks(self, feedbacks, option_name, applications):
-        target = Industry.objects.filter(name=option_name).first()
+        target = self.__class__._industry_map()[option_name]
         return self.find_app_ids(
             self.filter_by_judge_option(feedbacks, option_name),
             self.app_ids_to_targets(applications),
@@ -27,7 +34,8 @@ class MatchingIndustryCriterionHelper(MatchingCriterionHelper):
     def calc_app_ids_to_targets(self, applications):
         top_level_industry_map = {
             industry.id: (industry.parent_id, industry.parent.name)
-            for industry in Industry.objects.filter(parent_id__isnull=False)
+            for industry in Industry.objects.filter(
+                    parent_id__isnull=False).prefetch_related('parent')
         }
         top_level_industry_map.update({
             industry.id: (industry.id, industry.name)

--- a/web/impact/impact/v1/helpers/matching_industry_criterion_helper.py
+++ b/web/impact/impact/v1/helpers/matching_industry_criterion_helper.py
@@ -21,7 +21,7 @@ class MatchingIndustryCriterionHelper(MatchingCriterionHelper):
     @classmethod
     def _industry_map(cls):
         if cls.industries is None:
-            cls.industries = cls.cache_instances_by_name(Industry)
+            cls.industries = cls.instances_by_name(Industry)
         return cls.industries
 
     def app_ids_for_feedbacks(self, feedbacks, option_name, applications):

--- a/web/impact/impact/v1/helpers/matching_program_criterion_helper.py
+++ b/web/impact/impact/v1/helpers/matching_program_criterion_helper.py
@@ -12,13 +12,21 @@ from impact.v1.helpers.matching_criterion_helper import MatchingCriterionHelper
 class MatchingProgramCriterionHelper(MatchingCriterionHelper):
     application_field = "startup_id"
     judge_field = "expertprofile__home_program_family__name"
+    program_families = None
 
     def __init__(self, subject):
         super().__init__(subject)
         self._program_name_cache = None
 
+    @classmethod
+    def _program_family_map(cls):
+        if cls.program_families is None:
+            cls.program_families = cls.cache_instances_by_name(ProgramFamily)
+        return cls.program_families
+
     def app_ids_for_feedbacks(self, feedbacks, option_name, applications):
-        target = ProgramFamily.objects.filter(name=option_name).first()
+        target = self.__class__._program_family_map()[option_name]
+
         return self.find_app_ids(
             self.filter_by_judge_option(feedbacks, option_name),
             applications,

--- a/web/impact/impact/v1/helpers/matching_program_criterion_helper.py
+++ b/web/impact/impact/v1/helpers/matching_program_criterion_helper.py
@@ -19,13 +19,18 @@ class MatchingProgramCriterionHelper(MatchingCriterionHelper):
         self._program_name_cache = None
 
     @classmethod
-    def _program_family_map(cls):
+    def _program_family(cls, family_name):
         if cls.program_families is None:
-            cls.program_families = cls.cache_instances_by_name(ProgramFamily)
-        return cls.program_families
+            cls.program_families = cls.instances_by_name(ProgramFamily)
+
+        program_family = cls.program_families.get(family_name)
+        if program_family is None:
+            program_family = ProgramFamily.objects.get(name=family_name)
+            cls.program_families[family_name] = program_family
+        return program_family
 
     def app_ids_for_feedbacks(self, feedbacks, option_name, applications):
-        target = self.__class__._program_family_map()[option_name]
+        target = self._program_family(option_name)
 
         return self.find_app_ids(
             self.filter_by_judge_option(feedbacks, option_name),

--- a/web/impact/impact/v1/views/analyze_judging_round_view.py
+++ b/web/impact/impact/v1/views/analyze_judging_round_view.py
@@ -51,7 +51,8 @@ class AnalyzeJudgingRoundView(ImpactView):
     def get(self, request, pk):
         self.instance = self.model.objects.get(pk=pk)
         options = CriterionOptionSpec.objects.filter(
-            criterion__judging_round=self.instance)
+            criterion__judging_round=self.instance).prefetch_related(
+                'criterion')
         self.apps = Application.objects.filter(
             application_status="submitted",
             application_type=self.instance.application_type)

--- a/web/impact/impact/v1/views/analyze_judging_round_view.py
+++ b/web/impact/impact/v1/views/analyze_judging_round_view.py
@@ -57,8 +57,10 @@ class AnalyzeJudgingRoundView(ImpactView):
             application_status="submitted",
             application_type=self.instance.application_type)
         application_counts = self.judge_to_count()
+        app_ids = self.apps.values_list('id', flat=True)
         analyses = [OptionAnalysis(option,
                                    self.apps,
+                                   app_ids,
                                    self.instance,
                                    application_counts).analyses()
                     for option in options]

--- a/web/impact/impact/v1/views/analyze_judging_round_view.py
+++ b/web/impact/impact/v1/views/analyze_judging_round_view.py
@@ -1,11 +1,14 @@
 # MIT License
 # Copyright (c) 2017 MassChallenge, Inc.
 
+from django.db.models import Count
 from itertools import chain
 from accelerator.models import (
     Application,
     CriterionOptionSpec,
+    JudgePanelAssignment,
     JudgingRound,
+
 )
 from rest_framework.response import Response
 from impact.v1.views.impact_view import ImpactView
@@ -52,6 +55,21 @@ class AnalyzeJudgingRoundView(ImpactView):
         self.apps = Application.objects.filter(
             application_status="submitted",
             application_type=self.instance.application_type)
-        analyses = [OptionAnalysis(option, self.apps, self.instance).analyses()
+        application_counts = self.judge_to_count()
+        analyses = [OptionAnalysis(option,
+                                   self.apps,
+                                   self.instance,
+                                   application_counts).analyses()
                     for option in options]
         return Response({"results": list(chain.from_iterable(analyses))})
+
+    def judge_to_count(self):
+        assignments = JudgePanelAssignment.objects.filter(
+            scenario__judging_round=self.instance)
+        judge_assignment_counts = assignments.annotate(
+            assignment_count=Count("panel__applications")).values_list(
+                "judge_id", "assignment_count")
+        results = {}
+        for judge_id, assignment_count in judge_assignment_counts:
+            results[judge_id] = results.get(judge_id, 0) + assignment_count
+        return results


### PR DESCRIPTION
Plucked a bunch of low-hanging fruit, made follow-on tickets for the remaining (hard) work. 
AC-5981 and AC-5982 are the follow-ons

To test:
* check out development. 
* load clean db
* working as a user with correct permissions (v1 group, unless permissions PR has merged) hit http://localhost:8000/api/v1/analyze_judging_round/48/
* check out AC-5901
* hit the same endpoint in a new tab
* compare the two: results should be identical, and debug toolbar should show 153 queries on development and 82 on the branch. Load time,  CPU time, and DB time on the branch should be reduced relative to development. 
