### PR TITLE
[AC-6021] Fix dependencies breaking impact-api build (django-registration, graphene-django)

### DIFF
--- a/web/impact/requirements/base.txt
+++ b/web/impact/requirements/base.txt
@@ -37,7 +37,7 @@ django-oauth-toolkit<1.1
 django-paypal
 django-polymorphic==1.3
 django-redis-cache
-django-registration==2.5.2
+django-registration==2.4.1
 django-rest-framework-proxy
 django-rest-swagger
 django-storages==1.6.5
@@ -46,7 +46,7 @@ djangorestframework
 djangorestframework-jwt
 drf-schema-adapter
 drf-tracking
-graphene-django>=2.0
+graphene-django==2.1
 sorl-thumbnail==12.4.1
 
 


### PR DESCRIPTION
## [AC-6019](https://masschallenge.atlassian.net/browse/AC-6019)

The versions of **django-registration** and **graphene-django** that we were getting were not compatible with the version of Django that impact-api uses, v1.10.

graphene-django was formerly an unpinned dependency; it had a recent update that hadn't been noticed yet.

The too-new version of django-registration was an error from a previous ticket.

To test: run `make build` on this branch in impact-api and see that you do not get compatibility warnings of the type recorded on the ticket.