### PR TITLE
AC-6023: Mentor Directory - Should only show confirmed Alumni Mentors to Alumni Entrepreneurs

### DIFF
--- a/web/impact/impact/tests/test_algolia_api_key_view.py
+++ b/web/impact/impact/tests/test_algolia_api_key_view.py
@@ -67,11 +67,10 @@ class TestAlgoliaApiKeyView(APITestCase):
 
     def test_finalist_user_gets_all_programs_in_program_group(self):
         named_group = NamedGroupFactory()
-        programs = []
-        for _ in range(5):
-            programs.append(ProgramFactory(
-                mentor_program_group=named_group,
-                program_status=ACTIVE_PROGRAM_STATUS))
+        programs = ProgramFactory.create_batch(
+            5,
+            mentor_program_group=named_group,
+            program_status=ACTIVE_PROGRAM_STATUS)
         other_program = ProgramFactory(program_status=ACTIVE_PROGRAM_STATUS)
         program = programs[0]
         user = self._create_user_with_role_grant(program, UserRole.FINALIST)
@@ -88,11 +87,10 @@ class TestAlgoliaApiKeyView(APITestCase):
 
     def test_finalist_user_gets_all_programs_in_past_or_present(self):
         named_group = NamedGroupFactory()
-        programs = []
-        for _ in range(5):
-            programs.append(ProgramFactory(
-                mentor_program_group=named_group,
-                program_status=ACTIVE_PROGRAM_STATUS))
+        programs = ProgramFactory.create_batch(
+            5,
+            mentor_program_group=named_group,
+            program_status=ACTIVE_PROGRAM_STATUS)
         other_program = ProgramFactory(program_status=UPCOMING_PROGRAM_STATUS,
                                        mentor_program_group=named_group)
         program = programs[0]
@@ -111,11 +109,10 @@ class TestAlgoliaApiKeyView(APITestCase):
     def test_alumni_user_only_sees_mentors_of_alumni_programs(self):
         named_group = NamedGroupFactory()
         named_alumni_group = NamedGroupFactory()
-        programs = []
-        for _ in range(5):
-            programs.append(ProgramFactory(
-                mentor_program_group=named_group,
-                program_status=ACTIVE_PROGRAM_STATUS))
+        programs = ProgramFactory.create_batch(
+            5,
+            mentor_program_group=named_group,
+            program_status=ACTIVE_PROGRAM_STATUS)
         other_program = ProgramFactory(program_status=ENDED_PROGRAM_STATUS,
                                        mentor_program_group=named_alumni_group)
 
@@ -137,11 +134,10 @@ class TestAlgoliaApiKeyView(APITestCase):
             self):
         named_group = NamedGroupFactory()
         named_alumni_group = NamedGroupFactory()
-        programs = []
-        for _ in range(5):
-            programs.append(ProgramFactory(
-                mentor_program_group=named_group,
-                program_status=ACTIVE_PROGRAM_STATUS))
+        programs = ProgramFactory.create_batch(
+            5,
+            mentor_program_group=named_group,
+            program_status=ACTIVE_PROGRAM_STATUS)
         other_program = ProgramFactory(program_status=ENDED_PROGRAM_STATUS,
                                        mentor_program_group=named_alumni_group)
 
@@ -165,11 +161,11 @@ class TestAlgoliaApiKeyView(APITestCase):
 
     def test_non_participant_user_sees_all_confirmed_mentors(self):
         named_group = NamedGroupFactory()
-        programs = []
-        for _ in range(5):
-            programs.append(ProgramFactory(
-                mentor_program_group=named_group,
-                program_status=ACTIVE_PROGRAM_STATUS))
+        programs = ProgramFactory.create_batch(
+            5,
+            mentor_program_group=named_group,
+            program_status=ACTIVE_PROGRAM_STATUS)
+
         program = programs[0]
         user = self._create_user_with_role_grant(program,
                                                  UserRole.DESIRED_MENTOR)

--- a/web/impact/impact/tests/test_algolia_api_key_view.py
+++ b/web/impact/impact/tests/test_algolia_api_key_view.py
@@ -13,10 +13,13 @@ from accelerator.tests.factories import (
     ProgramRoleFactory,
     ProgramRoleGrantFactory,
     UserRoleFactory,
+    BaseProfileFactory,
 )
 from accelerator_abstract.models import (
     ACTIVE_PROGRAM_STATUS,
     UPCOMING_PROGRAM_STATUS,
+    ENDED_PROGRAM_STATUS,
+    ENTREPRENEUR_USER_TYPE
 )
 from impact.tests.api_test_case import APITestCase
 from impact.tests.factories import UserFactory
@@ -35,7 +38,7 @@ class TestAlgoliaApiKeyView(APITestCase):
         with self.settings(
                 ALGOLIA_APPLICATION_ID='test',
                 ALGOLIA_API_KEY='test'):
-            with self.login(email=self.basic_user().email):
+            with self.login(email=self._create_user_with_base_profile().email):
                 response = self.client.get(self.url)
                 response_data = json.loads(response.content)
                 self.assertTrue('token' in response_data.keys())
@@ -105,6 +108,61 @@ class TestAlgoliaApiKeyView(APITestCase):
                     self.assertIn(program.name, response_data["filters"])
                 self.assertNotIn(other_program.name, response_data["filters"])
 
+    def test_alumni_user_only_sees_mentors_of_alumni_programs(self):
+        named_group = NamedGroupFactory()
+        named_alumni_group = NamedGroupFactory()
+        programs = []
+        for _ in range(5):
+            programs.append(ProgramFactory(
+                mentor_program_group=named_group,
+                program_status=ACTIVE_PROGRAM_STATUS))
+        other_program = ProgramFactory(program_status=ENDED_PROGRAM_STATUS,
+                                       mentor_program_group=named_alumni_group)
+
+        user = self._create_user_with_role_grant(
+            other_program, UserRole.ALUM)
+
+        with self.settings(
+                ALGOLIA_APPLICATION_ID='test',
+                ALGOLIA_API_KEY='test'):
+            with self.login(email=user.email):
+                response = self.client.get(self.url)
+                response_data = json.loads(response.content)
+
+                for program in programs:
+                    self.assertNotIn(program.name, response_data["filters"])
+                self.assertIn(other_program.name, response_data["filters"])
+
+    def test_alumni_user_who_is_also_finalist_sees_mentors_of_both_programs(
+            self):
+        named_group = NamedGroupFactory()
+        named_alumni_group = NamedGroupFactory()
+        programs = []
+        for _ in range(5):
+            programs.append(ProgramFactory(
+                mentor_program_group=named_group,
+                program_status=ACTIVE_PROGRAM_STATUS))
+        other_program = ProgramFactory(program_status=ENDED_PROGRAM_STATUS,
+                                       mentor_program_group=named_alumni_group)
+
+        finalist_program = programs[1]
+
+        user = self._create_user_with_role_grant(
+            other_program, UserRole.ALUM)
+        self._create_user_with_role_grant(
+            finalist_program, UserRole.FINALIST, user)
+
+        with self.settings(
+                ALGOLIA_APPLICATION_ID='test',
+                ALGOLIA_API_KEY='test'):
+            with self.login(email=user.email):
+                response = self.client.get(self.url)
+                response_data = json.loads(response.content)
+
+                for program in programs:
+                    self.assertIn(program.name, response_data["filters"])
+                self.assertIn(other_program.name, response_data["filters"])
+
     def test_non_participant_user_sees_all_confirmed_mentors(self):
         named_group = NamedGroupFactory()
         programs = []
@@ -125,12 +183,25 @@ class TestAlgoliaApiKeyView(APITestCase):
                 self.assertIn(IS_CONFIRMED_MENTOR_FILTER,
                               response_data["filters"])
 
-    def _create_user_with_role_grant(self, program, user_role_name):
+    def _create_user_with_base_profile(self, user_type=ENTREPRENEUR_USER_TYPE):
+        user = self.basic_user()
+        profile = BaseProfileFactory()
+        profile.user = user
+        profile.user_type = user_type
+        profile.save()
+
+        return user
+
+    def _create_user_with_role_grant(
+            self, program, user_role_name, user=False):
         user_role = UserRoleFactory(name=user_role_name)
         program_role = ProgramRoleFactory(
             user_role=user_role,
             program=program
         )
-        user = self.basic_user()
+
+        if not user:
+            user = self._create_user_with_base_profile()
+
         ProgramRoleGrantFactory(person=user, program_role=program_role)
         return user

--- a/web/impact/impact/tests/test_algolia_api_key_view.py
+++ b/web/impact/impact/tests/test_algolia_api_key_view.py
@@ -13,7 +13,7 @@ from accelerator.tests.factories import (
     ProgramRoleFactory,
     ProgramRoleGrantFactory,
     UserRoleFactory,
-    BaseProfileFactory,
+    EntrepreneurFactory,
 )
 from accelerator_abstract.models import (
     ACTIVE_PROGRAM_STATUS,
@@ -38,7 +38,7 @@ class TestAlgoliaApiKeyView(APITestCase):
         with self.settings(
                 ALGOLIA_APPLICATION_ID='test',
                 ALGOLIA_API_KEY='test'):
-            with self.login(email=self._create_user_with_base_profile().email):
+            with self.login(email=self._create_entrepreneur().email):
                 response = self.client.get(self.url)
                 response_data = json.loads(response.content)
                 self.assertTrue('token' in response_data.keys())
@@ -179,14 +179,11 @@ class TestAlgoliaApiKeyView(APITestCase):
                 self.assertIn(IS_CONFIRMED_MENTOR_FILTER,
                               response_data["filters"])
 
-    def _create_user_with_base_profile(self, user_type=ENTREPRENEUR_USER_TYPE):
-        user = self.basic_user()
-        profile = BaseProfileFactory()
-        profile.user = user
-        profile.user_type = user_type
-        profile.save()
-
-        return user
+    def _create_entrepreneur(self):
+        ent_user = EntrepreneurFactory()
+        ent_user.set_password("password")
+        ent_user.save()
+        return ent_user
 
     def _create_user_with_role_grant(
             self, program, user_role_name, user=False):
@@ -197,7 +194,7 @@ class TestAlgoliaApiKeyView(APITestCase):
         )
 
         if not user:
-            user = self._create_user_with_base_profile()
+            user = self._create_entrepreneur()
 
         ProgramRoleGrantFactory(person=user, program_role=program_role)
         return user

--- a/web/impact/impact/views/algolia_api_key_view.py
+++ b/web/impact/impact/views/algolia_api_key_view.py
@@ -62,6 +62,7 @@ def _get_filters(request):
         return []
     participant_roles = UserRole.FINALIST_USER_ROLES
     participant_roles.append(UserRole.MENTOR)
+    participant_roles.append(UserRole.ALUM)
     user_program_roles_as_participant = ProgramRole.objects.filter(
         programrolegrant__person=request.user,
         user_role__name__in=participant_roles

--- a/web/impact/impact/views/algolia_api_key_view.py
+++ b/web/impact/impact/views/algolia_api_key_view.py
@@ -66,10 +66,12 @@ def _get_search_key(request):
 def _get_filters(request):
     if request.user.is_staff:
         return []
-    participant_roles = UserRole.FINALIST_USER_ROLES + [
-        UserRole.MENTOR, UserRole.ALUM]
+    participant_roles = [UserRole.AIR, UserRole.STAFF, UserRole.MENTOR]
 
     participant_roles = _entrepreneur_specific_alumni_filter(
+        participant_roles, request)
+
+    participant_roles = _entrepreneur_specific_finalist_filter(
         participant_roles, request)
 
     user_program_roles_as_participant = ProgramRole.objects.filter(
@@ -90,7 +92,7 @@ def _get_filters(request):
         return IS_CONFIRMED_MENTOR_FILTER
 
 
-def _entrepreneur_specific_alumni_filter(roles, request):
+def _entrepreneur_specific_finalist_filter(roles, request):
     if is_entrepreneur(request.user):
         has_current_finalist_roles = ProgramRoleGrant.objects.filter(
             program_role__program__program_status=ACTIVE_PROGRAM_STATUS,
@@ -98,8 +100,22 @@ def _entrepreneur_specific_alumni_filter(roles, request):
             person=request.user
         ).exists()
 
-        if not has_current_finalist_roles:
-            roles.remove(UserRole.FINALIST)
+        if has_current_finalist_roles:
+            roles.append(UserRole.FINALIST)
+
+    return roles
+
+
+def _entrepreneur_specific_alumni_filter(roles, request):
+    if is_entrepreneur(request.user):
+        has_current_alum_roles = ProgramRoleGrant.objects.filter(
+            program_role__program__program_status=ENDED_PROGRAM_STATUS,
+            program_role__user_role__name=UserRole.ALUM,
+            person=request.user
+        ).exists()
+
+        if has_current_alum_roles:
+            roles.append(UserRole.ALUM)
 
     return roles
 


### PR DESCRIPTION
**Changes introduced in AC-6023**:
- ensure algolia filters respect alumni status

**How to Test**:
- visit [test 4](https://test4.masschallenge.org) and masquerade as `001@livemile.com`  who has been given ProgramRoleGrants to the Alum Program, if you visit the directory you will notice that `001@livemile.com` only sees `Ted William Regan` who is the only confirmed mentor in the `Global Almuni Program`. 

Feel free to poke around the directory in different use-cases
- as staff
- as an Enterpreneur who is not a finalist and is not an alumni either
- as an Enterpreneur who is both a finalist an alumni

- **Currently**, Enterpreneurs of an ended program still see the mentors of those programs on the directory 