### PR TITLE
AC-5831: Adding Open ID provider package to test integration with mobilize

### DIFF
--- a/web/impact/impact/oidc_provider_settings.py
+++ b/web/impact/impact/oidc_provider_settings.py
@@ -1,0 +1,9 @@
+
+
+def userinfo(claims, user):
+    # Populate claims dict.
+    claims['name'] = '{0} {1}'.format(user.first_name, user.last_name)
+    claims['given_name'] = user.first_name
+    claims['family_name'] = user.last_name
+    claims['email'] = user.email
+    return claims

--- a/web/impact/impact/settings.py
+++ b/web/impact/impact/settings.py
@@ -152,6 +152,7 @@ class Base(Configuration):
             },
         },
     ]
+    OIDC_USERINFO = 'impact.oidc_provider_settings.userinfo'
     CORS_ALLOW_CREDENTIALS = True
     CORS_ORIGIN_WHITELIST = (
         'localhost:1234',

--- a/web/impact/impact/settings.py
+++ b/web/impact/impact/settings.py
@@ -97,6 +97,7 @@ class Base(Configuration):
         'oauth2_provider',
         'rest_framework',
         'rest_framework.authtoken',
+        'oidc_provider',
         'rest_framework_swagger',
         'fluent_pages',
         'impact',

--- a/web/impact/impact/urls.py
+++ b/web/impact/impact/urls.py
@@ -110,6 +110,7 @@ urls = [
     url(r'^directory/(?:.*)$', TemplateView.as_view(
         template_name='directory.html'),
         name="directory"),
+    url(r'^openid/', include('oidc_provider.urls', namespace='oidc_provider')),
     url(r'^$', IndexView.as_view()),
 ]
 

--- a/web/impact/requirements/base.txt
+++ b/web/impact/requirements/base.txt
@@ -48,6 +48,7 @@ drf-schema-adapter
 drf-tracking
 graphene-django==2.1
 sorl-thumbnail==12.4.1
+django-oidc-provider
 
 
 # django-configurations from Git master (needed for Django 1.8 support)


### PR DESCRIPTION
In order to test out an integration with mobilize we need a configuration endpoint exposed under a domain with a valid certificate. 

The only real way to test this out without a lot of back-and-forth with mobilize is to integrate this package and push it to production to test the end-to-end workflow.

I'd like to get this merged and out as soon as possible.