### PR TITLE
[AC-6023-fix]: Only show confirmed Alumni Mentors to Alumni Entrepreneurs on Mentor Directory

### DIFF
--- a/web/impact/impact/tests/test_algolia_api_key_view.py
+++ b/web/impact/impact/tests/test_algolia_api_key_view.py
@@ -113,7 +113,7 @@ class TestAlgoliaApiKeyView(APITestCase):
             5,
             mentor_program_group=named_group,
             program_status=ACTIVE_PROGRAM_STATUS)
-        other_program = ProgramFactory(program_status=ENDED_PROGRAM_STATUS,
+        other_program = ProgramFactory(program_status=ACTIVE_PROGRAM_STATUS,
                                        mentor_program_group=named_alumni_group)
 
         user = self._create_user_with_role_grant(
@@ -138,7 +138,7 @@ class TestAlgoliaApiKeyView(APITestCase):
             5,
             mentor_program_group=named_group,
             program_status=ACTIVE_PROGRAM_STATUS)
-        other_program = ProgramFactory(program_status=ENDED_PROGRAM_STATUS,
+        other_program = ProgramFactory(program_status=ACTIVE_PROGRAM_STATUS,
                                        mentor_program_group=named_alumni_group)
 
         finalist_program = programs[1]

--- a/web/impact/impact/views/algolia_api_key_view.py
+++ b/web/impact/impact/views/algolia_api_key_view.py
@@ -109,7 +109,7 @@ def _entrepreneur_specific_finalist_filter(roles, request):
 def _entrepreneur_specific_alumni_filter(roles, request):
     if is_entrepreneur(request.user):
         has_current_alum_roles = ProgramRoleGrant.objects.filter(
-            program_role__program__program_status=ENDED_PROGRAM_STATUS,
+            program_role__program__program_status=ACTIVE_PROGRAM_STATUS,
             program_role__user_role__name=UserRole.ALUM,
             person=request.user
         ).exists()


### PR DESCRIPTION
**Changes introduced**:
- fix bug that assumes Alumni program will have a status of `ended`

**How to test**:
- On staging, mark the Alumni Program as `ended` and leaving `Alumni eligible program` **UNCHECKED**
- Masquerade as `bhaskar@ziroh.com` and visit the directory
- Notice he/she can only see 1 confirmed mentor of the Alumni program

This PR ensures we correctly assume the Alumni Program status is `ACTIVE` instead of ended.
**Post-test**:
- On staging, mark the Alumni Program as `active` and leaving `Alumni eligible program` **UNCHECKED**