### PR TITLE
AC-5994 - Allocator judging round selector needs to be optionally aware of user's clearance

### DIFF
--- a/web/impact/impact/tests/test_judging_round_list_view.py
+++ b/web/impact/impact/tests/test_judging_round_list_view.py
@@ -130,6 +130,19 @@ class TestJudgingRoundListView(APITestCase):
             round_ids = [item["id"] for item in results]
             self.assertTrue(the_round.id in round_ids)
 
+    def test_ignore_clearance_request_param_works(self):
+        the_round = JudgingRoundFactory.create(
+            round_type=ONLINE_JUDGING_ROUND_TYPE)
+        url = self.url + "?round_type={}&ignore_clearance=true".format(
+            ONLINE_JUDGING_ROUND_TYPE)
+        user = self.basic_user()
+        # The user doesn't have clearance, but PF should be displayed anyway
+        with self.login(email=user.email):
+            response = self.client.get(url)
+            results = response.data["results"]
+            round_ids = [item["id"] for item in results]
+            self.assertTrue(the_round.id in round_ids)
+
 
 def _add_clearance(user, judging_round):
     ClearanceFactory(level=CLEARANCE_LEVEL_GLOBAL_MANAGER,

--- a/web/impact/impact/v1/views/judging_round_list_view.py
+++ b/web/impact/impact/v1/views/judging_round_list_view.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2017 MassChallenge, Inc.
 
 from accelerator.models import (
+    Clearance,
     IN_PERSON_JUDGING_ROUND_TYPE,
     ONLINE_JUDGING_ROUND_TYPE,
 )
@@ -30,7 +31,12 @@ class JudgingRoundListView(BaseListView):
                 self.errors.append(INVALID_ROUND_TYPE_ERROR.format(round_type))
 
     def filter(self, qs):
-        return self._filter_by_round_type(super().filter(qs))
+        by_round = self._filter_by_round_type(super().filter(qs))
+        user = self.request.user
+        clearances = Clearance.objects.filter(user=user)
+        program_families = [c.program_family for c in clearances]
+        by_pf = by_round.filter(program__program_family__in=program_families)
+        return by_pf
 
     def _filter_by_round_type(self, qs):
         round_type = self.request.query_params.get("round_type", None)


### PR DESCRIPTION
## [AC-5994](https://masschallenge.atlassian.net/browse/AC-5994)

This code changes the `JudgingRoundListView.filter` method to, by default, filter its returned values according to the user's clearances. 

(The control for this is a request parameter, so the user _could_ get the list of all program families -- including the ones they're not cleared for -- by manually adding that parameter to a request. This does not seem like a security hole to me, given that the exposed data is only program family names and IDs, but I thought it worth mentioning.)

**To test:** 
1. In **impact-api**, `make run-server`, log in as demoadmin
1. Add demoadmin to **v1_clients** group
1. Give demoadmin clearance for BOS ProgramFamily (see below)
1. In **application-allocator**, `yarn && yarn start`
1. go to http://localhost:1234/app-allocator-setup
1. Look at the choices in the judging round menu
1. Via admin or console, give demoadmin clearance for MX (see below)
1. Refresh the page, check the menu, and confirm that the ProgramFamily you added .a clearance for now appears. (You can also directly check the [output of the API call](http://localhost/api/v1/judging_round/?round_type=Online) used to build the menu)

```python
# To add demoadmin to v1_clients group
from accelerator.models import User
from django.contrib.auth.models import Group
Group.objects.get(name='v1_clients').user_set.add(User.objects.get(email__startswith="demoadmin"))

# To give demoadmin user a new clearance
from accelerator.models import *
Clearance.objects.create(
    user=User.objects.get(email__startswith="demoadmin"), 
    level=CLEARANCE_LEVEL_EXEC_MD, 
    program_family=ProgramFamily.objects.get(pk=1)) # BOS: 1; MX: 5
```