### PR TITLE
AC-6086: Engineer is able to successfully load a dump of prod db locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -340,7 +340,7 @@ django-shell: .env
 DB_CACHE_DIR = db_cache/
 s3_key = $(db_name).sql.gz
 gz_file ?= $(DB_CACHE_DIR)$(s3_key)
-intermediary_file = sql_dump.sql
+intermediary_file = /tmp/sql_dump.sql
 
 load-db: $(DB_CACHE_DIR) $(gz_file) .env
 	@echo "Loading $(gz_file)"

--- a/Makefile
+++ b/Makefile
@@ -340,12 +340,17 @@ django-shell: .env
 DB_CACHE_DIR = db_cache/
 s3_key = $(db_name).sql.gz
 gz_file ?= $(DB_CACHE_DIR)$(s3_key)
+intermediary_file = sql_dump.sql
 
 load-db: $(DB_CACHE_DIR) $(gz_file) .env
 	@echo "Loading $(gz_file)"
-	@echo "drop database mc_dev; create database mc_dev;" | docker-compose run --rm web ./manage.py dbshell
-	@gzcat $(gz_file) | docker-compose run --rm web ./manage.py dbshell
-	@docker-compose run --rm web ./manage.py migrate
+	@echo "This will take a while, don't be alarmed if your console appears frozen."
+	@echo "drop database mc_dev; create database mc_dev; " > $(intermediary_file)
+	@gzcat $(gz_file) >> $(intermediary_file)
+	@sed -i "" "s|\`masschallenge\`|\`mc_dev\`|g" $(intermediary_file)
+	@cat $(intermediary_file) | docker-compose run --rm web ./manage.py dbshell
+	@rm -rf $(intermediary_file)
+	@docker-compose run --rm web ./manage.py migrate --noinput
 
 %.sql.gz:
 	@echo downloading db...


### PR DESCRIPTION
**Changes introduced in [AC-6086](https://masschallenge.atlassian.net/browse/AC-6086)**:
- change target db to `mc_dev` when loading a prod db locally

**How to test**:
- download a dump from [S3](https://s3.console.aws.amazon.com/s3/buckets/accelerate-db-backup/?region=us-east-1&tab=overview)
- unzip and gzip the sql file downloaded
- run `make load-db gz_file=<path-to-gz-file>`
- the dump should be successfully loaded locally

- on development this would throw errors since the dump was being loaded to a different database