### PR TITLE
AC-6166: Application allocator is not visible at /allocator

### DIFF
--- a/web/impact/impact/urls.py
+++ b/web/impact/impact/urls.py
@@ -110,6 +110,9 @@ urls = [
     url(r'^directory/(?:.*)$', TemplateView.as_view(
         template_name='directory.html'),
         name="directory"),
+    url(r'^allocator/(?:.*)$', TemplateView.as_view(
+        template_name='directory.html'),
+        name="allocator"),
     url(r'^openid/', include('oidc_provider.urls', namespace='oidc_provider')),
     url(r'^$', IndexView.as_view()),
 ]


### PR DESCRIPTION
**Changes introduced in [AC-6166](https://masschallenge.atlassian.net/browse/AC-6166)**
- add impact url to direct `/allocator` urls to the directory html file

**How to test**
- this is deployed on [test5](https://test5.masschallenge.org/allocator)
- this interface will redirect you to the allocator