### PR TITLE
AC-6139: Command "make code-check" runs successfully in dockerized environment

### DIFF
--- a/Dockerfile.fpdiff
+++ b/Dockerfile.fpdiff
@@ -5,7 +5,7 @@ RUN pip install --upgrade pip
 COPY web/scripts/fpdiff.sh /usr/bin
 
 RUN pip3 install \
-    flake8 \
+    "flake8<3.6" \
     "pycodestyle<2.4"
 
 WORKDIR /code


### PR DESCRIPTION
**Changes introduced in [AC-6139](https://masschallenge.atlassian.net/browse/AC-6139)**:
- ensure we download correct version of flake8

**How to test**
- in impact
- run `docker build -t masschallenge/fpdiff -f Dockerfile.fpdiff .`
- then run `make code-check`, it will correctly return changes that violate our code styles