### PR TITLE
[AC-6167] enable employees to have api_v1 permissions

### DIFF
--- a/web/impact/impact/permissions/v1_api_permissions.py
+++ b/web/impact/impact/permissions/v1_api_permissions.py
@@ -1,3 +1,4 @@
+from accelerator_abstract.models.base_user_utils import is_employee
 from impact.permissions import (
     settings,
     BasePermission)
@@ -8,4 +9,4 @@ class V1APIPermissions(BasePermission):
 
     def has_permission(self, request, view):
         return request.user.groups.filter(
-            name=settings.V1_API_GROUP).exists()
+            name=settings.V1_API_GROUP).exists() or is_employee(request.user)

--- a/web/impact/impact/tests/api_test_case.py
+++ b/web/impact/impact/tests/api_test_case.py
@@ -10,11 +10,13 @@ from django.conf import settings
 from django.contrib.auth.models import Group
 from django.urls import reverse
 
+from accelerator.models import UserRole
 from accelerator_abstract.models.base_clearance import (
     CLEARANCE_LEVEL_GLOBAL_MANAGER,
 )
 from impact.tests.factories import (
     ClearanceFactory,
+    ProgramRoleGrantFactory,
     UserFactory,
 )
 
@@ -45,8 +47,15 @@ class APITestCase(TestCase):
         user.save()
         return user
 
+    def staff_user(self):
+        user = self.make_user('basic_user@test.com')
+        staff_grant = ProgramRoleGrantFactory(
+            program_role__user_role__name=UserRole.STAFF,
+            person=user)
+        return staff_grant.person
+
     def global_operations_manager(self, program_family):
-        user = self.basic_user()
+        user = self.staff_user()
         ClearanceFactory(user=user,
                          level=CLEARANCE_LEVEL_GLOBAL_MANAGER,
                          program_family=program_family)

--- a/web/impact/impact/tests/test_judging_round_detail_view.py
+++ b/web/impact/impact/tests/test_judging_round_detail_view.py
@@ -54,3 +54,15 @@ class TestJudgingRoundDetailView(APITestCase):
             schema = options_response.data["actions"]["GET"]
             validator = Draft4Validator(schema)
             assert validator.is_valid(json.loads(get_response.content))
+
+    def test_staff_user_can_view(self):
+        judging_round = JudgingRoundFactory()
+        email = self.staff_user().email
+        with self.login(email=email):
+            url = reverse(JudgingRoundDetailView.view_name,
+                          args=[judging_round.id])
+            response = self.client.get(url)
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.data["name"], judging_round.name)
+            self.assertEqual(response.data["program_id"],
+                             judging_round.program_id)

--- a/web/impact/impact/tests/test_judging_round_list_view.py
+++ b/web/impact/impact/tests/test_judging_round_list_view.py
@@ -149,6 +149,13 @@ class TestJudgingRoundListView(APITestCase):
             round_ids = [item["id"] for item in results]
             self.assertTrue(the_round.id in round_ids)
 
+    def test_staff_user_can_view(self):
+        email = self.staff_user().email
+        with self.login(email=email):
+            url = reverse(JudgingRoundListView.view_name)
+            response = self.client.get(url)
+            self.assertEqual(response.status_code, 200)
+
 
 def _add_clearance(user, judging_round):
     ClearanceFactory(level=CLEARANCE_LEVEL_GLOBAL_MANAGER,

--- a/web/impact/impact/tests/test_judging_round_list_view.py
+++ b/web/impact/impact/tests/test_judging_round_list_view.py
@@ -149,12 +149,18 @@ class TestJudgingRoundListView(APITestCase):
             round_ids = [item["id"] for item in results]
             self.assertTrue(the_round.id in round_ids)
 
-    def test_staff_user_can_view(self):
-        email = self.staff_user().email
-        with self.login(email=email):
-            url = reverse(JudgingRoundListView.view_name)
-            response = self.client.get(url)
-            self.assertEqual(response.status_code, 200)
+    def test_global_operations_manager_can_view(self):
+        count = 5
+        judging_rounds = JudgingRoundFactory.create_batch(count)
+        user = self.staff_user()
+        for judging_round in judging_rounds:
+            _add_clearance(user, judging_round)
+        with self.login(email=user.email):
+            response = self.client.get(self.url)
+            assert response.data["count"] == count
+            assert all([JudgingRoundListView.serialize(judging_round)
+                        in response.data["results"]
+                        for judging_round in judging_rounds])
 
 
 def _add_clearance(user, judging_round):


### PR DESCRIPTION
#### Changes introduced in [AC-6167](https://masschallenge.atlassian.net/browse/AC-6167):
- Grant V1APIPermissions to staff users so that they can access the allocator

#### How to test
- Run impact locally on this branch and masquarade as a staff user with global operations manager clearance who does not have the v1_client group
-- 4697-user@example.com has the correct clearance, run `user.groups.all().delete()` in the django shell to ensure they do not have the v1_client group. (or use the django admin)
- Run the directory with `yarn clean; yarn start` and go to the route http://localhost:1234/allocator
- You should be able to see the allocator without getting a 403