### PR TITLE
AC-6245: Semantic repo is not updated by make checkout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -225,7 +225,8 @@ ACCELERATE = ../accelerate
 DJANGO_ACCELERATOR = ../django-accelerator
 IMPACT_API = ../impact-api
 DIRECTORY = ../directory
-REPOS = $(ACCELERATE) $(DJANGO_ACCELERATOR) $(DIRECTORY) $(IMPACT_API)
+SEMANTIC = ../semantic-ui-theme
+REPOS = $(ACCELERATE) $(DJANGO_ACCELERATOR) $(DIRECTORY) $(SEMANTIC) $(IMPACT_API) 
 
 
 # Database migration related targets


### PR DESCRIPTION
**Changes introduced in [AC-6245](https://masschallenge.atlassian.net/browse/AC-6245)**
- ensure 'make checkout' also checks out the semantic repo

**How to test**
- checkout this branch on impact
- run a `make checkout development` and notice that your local semantic-ui-theme repo is also updated