### PR TITLE
AC-6287: make checkout branch=AC-XXX does not check out development if AC-XXXX does not exist repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -256,14 +256,18 @@ status:
 
 checkout:
 	@for r in $(REPOS) ; do \
-	  cd $$r; \
-	  ((git -c 'color.ui=always' checkout $(branch) 2>&1 | \
-	   sed "s|^|$$r: |") || \
-	  (git -c 'color.ui=always' checkout $(DEFAULT_BRANCH) 2>&1 | \
-	   sed "s|^|$$r: |")) && \
-	  git pull | sed "s|^|$$r: |"; \
-	  echo; \
-	  done
+		cd $$r; \
+		git show-ref --verify --quiet refs/heads/$(branch); \
+		if [ $$? -eq 0 ]; then \
+			git -c 'color.ui=always' checkout $(branch) 2>&1 | sed "s|^|$$r: |"; \
+			git pull | sed "s|^|$$r: |"; \
+		else \
+			echo "$(branch) doesn't exist, checking out $(DEFAULT_BRANCH)..."; \
+			git -c 'color.ui=always' checkout $(DEFAULT_BRANCH) 2>&1 | sed "s|^|$$r: |"; \
+			git pull | sed "s|^|$(DEFAULT_BRANCH): |"; \
+		fi; \
+		echo; \
+	done
 
 # Server and Virtual Machine related targets
 debug ?= 1

--- a/Makefile
+++ b/Makefile
@@ -259,13 +259,12 @@ checkout:
 		cd $$r; \
 		git show-ref --verify --quiet refs/heads/$(branch); \
 		if [ $$? -eq 0 ]; then \
-			git -c 'color.ui=always' checkout $(branch) 2>&1 | sed "s|^|$$r: |"; \
-			git pull | sed "s|^|$$r: |"; \
+			git -c 'color.ui=always' checkout $(branch) > /tmp/gitoutput 2>&1; \
 		else \
 			echo "$(branch) doesn't exist, checking out $(DEFAULT_BRANCH)..."; \
-			git -c 'color.ui=always' checkout $(DEFAULT_BRANCH) 2>&1 | sed "s|^|$$r: |"; \
-			git pull | sed "s|^|$(DEFAULT_BRANCH): |"; \
+			git -c 'color.ui=always' checkout $(DEFAULT_BRANCH) > /tmp/gitoutput 2>&1; \
 		fi; \
+		{ cat /tmp/gitoutput & git pull; } | sed "s|^|$$r: |"; \
 		echo; \
 	done
 


### PR DESCRIPTION
Changes introduced in [AC-6287](https://masschallenge.atlassian.net/browse/AC-6287):
- ensure development is checked out if the branch does not exist

How to test:
- while on development, run `make checkout branch=develop`

- note that errors are thrown and no branch changes are made
---
- now checkout AC-6287
- run `git checkout master` on **accelerate** and/ or the **directory**
- run `make checkout branch=develop` and notice all repositories are checked out to development