### PR TITLE
AC-6277: make run-all-servers does not start directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -265,13 +265,12 @@ checkout:
 	  echo; \
 	  done
 
-watch-frontend: process-exists=$(shell ps -ef | grep "yarn.js watch" | grep -v "grep" | awk '{print $$2}')
+watch-frontend stop-frontend: process-exists=$(shell ps -ef | grep "./watch_frontend.sh" | grep -v "grep" | awk '{print $$2}')
 watch-frontend:
 	@if [ -z "$(process-exists)" ]; then \
-		cd $(DIRECTORY) && nohup bash -c "yarn watch &" && cd $(IMPACT_API); \
+		cd $(DIRECTORY) && nohup bash -c "./watch_frontend.sh &" && cd $(IMPACT_API); \
 	fi;
 
-stop-frontend: process-exists=$(shell ps -ef | grep 'yarn.js watch' | grep -v 'grep' | awk '{print $$2}')
 stop-frontend:
 	@if [ -n "$(process-exists)" ]; then \
 		kill $(process-exists); \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,9 +31,14 @@ services:
       - ./web/impact/static/css:/gulp/css
       - ./web/impact/static/js:/gulp/js
   mentor_directory:
-    build: ../directory
+    build:
+      dockerfile: dev.Dockerfile
+      context: ../directory
     volumes:
       - ../directory/dist:/usr/src/app/dist
+      - ../directory/src:/usr/src/app/src
+    ports:
+      - "1234:1234"
   # Web python
   web:
     build: ./web

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,7 @@ services:
       - ./db_cache:/db_cache
       - ./web/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
       - ./web/impact/media:/media:ro
+      - ./web/scripts/mysqlwait.sh:/usr/bin/mysqlwait.sh
     depends_on:
       - mysql
       - mentor_directory
@@ -79,6 +80,10 @@ services:
     command: >
       /bin/bash -c "
       until $$(curl --output /dev/null --silent --head --fail http://web:8000); do
-        echo \"BUILDING...\"
+        echo \"BUILDING WEB...\"
         sleep 5
-      done; echo \"BUILD COMPLETE - visit http://localhost:8000 in a browser\";"
+      done; echo \"WEB BUILD COMPLETE - visit http://localhost:8000 in a browser\";
+      until $$(curl --output /dev/null --silent --head --fail http://mentor_directory:1234); do
+        echo \"BUILDING FRONTEND...\"
+        sleep 5
+      done; echo \"FRONTEND BUILD COMPLETE - visit http://localhost:1234 in a browser\";"

--- a/web/scripts/mysqlwait.sh
+++ b/web/scripts/mysqlwait.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
-until `curl --output /dev/null --silent --head --fail http://web:8000`; do \
-    echo "Waiting for web:8000. This might take a while..."; \
-    sleep 5; \
+until `curl --output /dev/null --silent --head --fail http://web:8000`; do
+    echo "Waiting for web:8000. This might take a while..."
+    sleep 5
 done
+echo "WEB BUILD COMPLETE - visit http://localhost:8000 in a browser"
+
+until `curl --output /dev/null --silent --head --fail http://mentor_directory:1234`; do
+    echo "BUILDING FRONTEND..."
+    sleep 5
+done
+echo "FRONTEND BUILD COMPLETE - visit http://localhost:1234 in a browser"


### PR DESCRIPTION
**Changes introduced in [AC-6277](urlhttps://masschallenge.atlassian.net/browse/AC-6277)**:
- create make targets for starting and stopping our frontend
- expose our frontend to port 1234 automatically

**How to test**:
1 - run `make stop-all-servers`
2 - run `docker ps -a | grep mentor_directory` and get the container_id of `impact-api_mentor_directory` and do `docker rm <id>`
3 - run `docker images | grep mentor_directory` and do `docker rmi <image-id>`

- now checkout AC-6277 on both impact and the directory
- while on impact, run `make run-server`
- wait for the text "FRONTEND BUILD COMPLETE - visit http://localhost:1234 in a browser"
- a this point the directory should be available on localhost:1234 and should reload on code change

@masschallenge/dev-team please note that when the AC-6277 PRs are merged, we will all need to do steps 1 - 3 to ensure you're using these changes.

Steps 1 - 3 can also be used to switch context (i.e. reverse the changes of this PR) after testing this PR.