### PR TITLE
[AC-6262] Address pathological performance of AllocateApplicationsView when criteria are engaged

### DIFF
--- a/web/impact/impact/tests/test_criterion_helper.py
+++ b/web/impact/impact/tests/test_criterion_helper.py
@@ -2,9 +2,10 @@ from impact.tests.api_test_case import APITestCase
 from impact.tests.factories import CriterionOptionSpecFactory
 from impact.v1.helpers import CriterionHelper
 
+
 class TestCriterionHelper(APITestCase):
     def test_find_helper_caches_by_criterion(self):
-        
+
         criterion = CriterionOptionSpecFactory().criterion
         helper_instance = CriterionHelper.find_helper(criterion)
         assert CriterionHelper.find_helper(criterion) == helper_instance

--- a/web/impact/impact/tests/test_criterion_helper.py
+++ b/web/impact/impact/tests/test_criterion_helper.py
@@ -1,0 +1,10 @@
+from impact.tests.api_test_case import APITestCase
+from impact.tests.factories import CriterionOptionSpecFactory
+from impact.v1.helpers import CriterionHelper
+
+class TestCriterionHelper(APITestCase):
+    def test_find_helper_caches_by_criterion(self):
+        
+        criterion = CriterionOptionSpecFactory().criterion
+        helper_instance = CriterionHelper.find_helper(criterion)
+        assert CriterionHelper.find_helper(criterion) == helper_instance

--- a/web/impact/impact/v1/helpers/criterion_helper.py
+++ b/web/impact/impact/v1/helpers/criterion_helper.py
@@ -40,12 +40,16 @@ class CriterionHelper(ModelHelper):
 
     @classmethod
     def find_helper(cls, criterion):
-        helper = cls.helper_instances.get(criterion.name)
+        helper = cls.helper_instances.get((criterion.name))
         if helper is None:
             helper = cls.specific_helpers.get((criterion.type, criterion.name),
                                               cls)(criterion)
-            cls.helper_instances[criterion.name] = helper
+            cls.helper_instances[(criterion.name)] = helper
         return helper
+
+    @classmethod
+    def clear_cache(cls):
+        cls.helper_instances = {}
 
     def options(self, spec, apps):
         return [spec.option]

--- a/web/impact/impact/v1/helpers/criterion_helper.py
+++ b/web/impact/impact/v1/helpers/criterion_helper.py
@@ -40,11 +40,11 @@ class CriterionHelper(ModelHelper):
 
     @classmethod
     def find_helper(cls, criterion):
-        helper = cls.helper_instances.get(criterion)
+        helper = cls.helper_instances.get(criterion.name)
         if helper is None:
             helper = cls.specific_helpers.get((criterion.type, criterion.name),
                                               cls)(criterion)
-            cls.helper_instances[criterion] = helper
+            cls.helper_instances[criterion.name] = helper
         return helper
 
     def options(self, spec, apps):

--- a/web/impact/impact/v1/helpers/criterion_helper.py
+++ b/web/impact/impact/v1/helpers/criterion_helper.py
@@ -32,6 +32,7 @@ class CriterionHelper(ModelHelper):
     INPUT_KEYS = ALL_KEYS
 
     specific_helpers = {}
+    helper_instances = {}
 
     @classmethod
     def register_helper(cls, klass, type, name):
@@ -39,8 +40,12 @@ class CriterionHelper(ModelHelper):
 
     @classmethod
     def find_helper(cls, criterion):
-        return cls.specific_helpers.get((criterion.type, criterion.name),
-                                        cls)(criterion)
+        helper = cls.helper_instances.get(criterion)
+        if helper is None:
+            helper = cls.specific_helpers.get((criterion.type, criterion.name),
+                                              cls)(criterion)
+            cls.helper_instances[criterion] = helper
+        return helper
 
     def options(self, spec, apps):
         return [spec.option]

--- a/web/impact/impact/v1/views/allocate_applications_view.py
+++ b/web/impact/impact/v1/views/allocate_applications_view.py
@@ -54,6 +54,7 @@ class AllocateApplicationsView(ImpactView):
         applications = self._allocate()
         if self.errors:
             return self._failure()
+        CriterionHelper.clear_cache()
         return Response(applications)
 
     def _initialize(self, round_id, judge_id):

--- a/web/impact/impact/v1/views/analyze_judging_round_view.py
+++ b/web/impact/impact/v1/views/analyze_judging_round_view.py
@@ -19,6 +19,7 @@ from impact.v1.helpers.model_helper import (
     READ_ONLY_OBJECT_FIELD,
     READ_ONLY_STRING_FIELD,
 )
+from impact.v1.helpers import CriterionHelper
 from impact.permissions import global_operations_manager_check
 
 ANALYZE_JUDGING_ROUND_FIELDS = {
@@ -69,6 +70,7 @@ class AnalyzeJudgingRoundView(ImpactView):
                                    self.instance,
                                    application_counts).analyses()
                     for option in options]
+        CriterionHelper.clear_cache()
         return Response({"results": list(chain.from_iterable(analyses))})
 
     def judge_to_count(self):


### PR DESCRIPTION
https://masschallenge.atlassian.net/browse/AC-6262

To review: 
- on clean db, find an online JudgingRound and modify it so that 
 -- round is active
 -- end date is in the future
 -- allow_dynamic_allocation is True

- count the number of active Applications for that round: `Application.objects.filter(cycle=judging_round.program.cycle, application_status="submitted").count()`
- find a Criterion whose `type` is industry, set its judging_round_id to point to your chosen JudgingRound

- Find a confirmed judge for that round, delete all of their JudgePanelAssignments, and become that user

hit the allocate applications endpoint on impact:
http://localhost:8000/api/v1/allocate_applications/[JUDGING ROUND ID]/[USER ID]/

On development branch, this will take a while. On the feature branch, this will be much faster

Note the SQL tab in the debug toolbar. On the development branch, you will see (among others) 5 queries for each Application - one query for each top-level industry. On the feature branch, those will be gone. 

You can also test for the other criteria using a similar technique. I found it useful to reduce the number of active applications:
```
ids = list(Application.objects.filter(cycle=judging_round.program.cycle, application_status="submitted").values_list('id', flat=True))
Application.objects.filter(cycle=judging_round.program.cycle, application_status="submitted", id__in=ids[50:]).update(application_status="discarded")
```
This will ensure that you're down to 50 applications, which should be more manageable. 

The feature branch should load with reasonable performance and db usage with all criteria engaged for your judging round. ("reasonable db usage": there are still some duplicated queries, but no N+1 performance)

Note: for repeated testing, you can clear out existing assignments like so:
```
panel = JudgePanelAssignment.objects.filter(judge_id=YOUR_JUDGE_ID).panel
panel.applicationpanelassignment_set.all().delete()
panel.judgepanelassignment_set.all().delete()
```
