### PR TITLE
AC-6257: make release argument is in CAPS, inconsistent with other arguments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,9 +142,9 @@ target_help = \
   '\tRelease name defaults release-<version>.<number> where <version> is' \
   '\tthe first line of impact-api/VERSION and <number> is the next unused' \
   '\tnon-negative integer (0,1,2,...).' \
-  '\t$$(TAG) overrides the entire release name.' \
-  '\tThe TAG can be set by adding an optional TAG="custom-tag" to the command' \
-  '\te.g. make release TAG="XX-XXXX" ' \
+  '\t$$(tag) overrides the entire release name.' \
+  '\tThe tag can be set by adding an optional tag="custom-tag" to the command' \
+  '\te.g. make release tag="XX-XXXX" ' \
   'deploy - Deploy $$(release_name) to a $$(target).' \
   '\tValid targets include "staging" (the default), "production",' \
   '\t "test-1", and "test-2"' \

--- a/create_release.sh
+++ b/create_release.sh
@@ -1,14 +1,14 @@
 
 # if a tag hasn't been passed in as a parameter, create a semantic one
-if [ ! -n "$TAG" ]; then
+if [ ! -n "$tag" ]; then
     docker run --rm  -v"$(pwd)":/app  -ti semantic-release  -- semantic-release version
     export pwd=$(pwd)
     export TAG=$(docker run --tty=false --rm  -v$pwd:/app  -i semantic-release -- semantic-release version --noop | grep "Current version: " | cut -d ' ' -f 3 | sed -e "s/\r//")
 else
-    echo "You passed in '$TAG' as the custom tag"
+    echo "You passed in '$tag' as the custom tag"
     # TR == test release
-    echo "We're going to refactor the tag into 'TR-$TAG' to avoid any conflicts."
-    TAG="TR-$TAG"
+    echo "We're going to refactor the tag into 'TR-$tag' to avoid any conflicts."
+    TAG="TR-$tag"
     git tag "v${TAG}"
 fi
 


### PR DESCRIPTION
#### Changes introduced in [AC-6257](https://masschallenge.atlassian.net/browse/AC-6257)
- use lowercase rather than uppercase argument to the 'make release' command

#### How to test

> Before
- on development
- the `make release` command is used with an uppercase TAG argument when making test tags i.e. `make release TAG=<some-tag>`

> After

- checkout AC-6257 in impact
- try use the `make release` target with a lowercase argument e.g. `make release tag=<reviewer-name>` to confirm it works as expected