### PR TITLE
[AC-6370] running make build-all results in failing build for semantic-version dockerfile

### DIFF
--- a/Dockerfile.semantic-release
+++ b/Dockerfile.semantic-release
@@ -3,7 +3,7 @@ RUN apk update
 RUN apk add --no-cache bash git
 RUN /entrypoint.sh \
     -a git \
-    -p python-semantic-release \
+    -p python-semantic-release==3.11.2 \
     && echo
 RUN apk add pcre git
 RUN git config --global user.email semantic-release@masschallenge.org


### PR DESCRIPTION
to test:

1. checkout development and run:
`docker image rm semantic-release`
`docker build  -f Dockerfile.semantic-release -t semantic-release .`

2. note that this fails

3. checkout this branch and re-run commands in step 1 and note that it succeeds 