### PR TITLE
AC-6399: Frontend process that watches for changes not being correctly killed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -268,7 +268,7 @@ checkout:
 		echo; \
 	done
 
-watch-frontend stop-frontend: process-exists=$(shell ps -ef | grep "./watch_frontend.sh" | grep -v "grep" | awk '{print $$2}')
+watch-frontend stop-frontend: process-exists=$(shell ps -ef | egrep -h "./watch_frontend.sh|parcel watch" | grep -v "grep" | awk '{print $$2}')
 watch-frontend:
 	@if [ -z "$(process-exists)" ]; then \
 		cd $(DIRECTORY) && nohup bash -c "./watch_frontend.sh &" && cd $(IMPACT_API); \


### PR DESCRIPTION
#### Changes introduced in [AC-6399](https://masschallenge.atlassian.net/browse/AC-6399)
- ensure processes that watch for frontend changes are killed correctly

#### How to test
- while on development and with impact running
- on your terminal, run `ps -ef | grep 'parcel watch' | wc -l` to give you the number of processes watching your front-end
- now run `make stop-frontend` and run `ps -ef | grep 'parcel watch' | wc -l` to see if the process was killed (the number should have stayed the same)

- now check out AC-6399
- run `make stop-frontend` and then `ps -ef | grep 'parcel watch' | wc -l`
- note that you only get `1` process running (the grep command)

#### Note
- remember to run `make watch-frontend` after reviewing this to make sure your frontend is watching for changes