### PR TITLE
AC-6375: Rebuild person profile page using front-end directory repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -268,7 +268,7 @@ checkout:
 		echo; \
 	done
 
-watch-frontend stop-frontend: process-exists=$(shell ps -ef | egrep -h "./watch_frontend.sh|parcel watch" | grep -v "grep" | awk '{print $$2}')
+watch-frontend stop-frontend: process-exists=$(shell ps -ef | grep "./watch_frontend.sh" | grep -v "grep" | awk '{print $$2}')
 watch-frontend:
 	@if [ -z "$(process-exists)" ]; then \
 		cd $(DIRECTORY) && nohup bash -c "./watch_frontend.sh &" && cd $(IMPACT_API); \

--- a/Makefile
+++ b/Makefile
@@ -268,7 +268,7 @@ checkout:
 		echo; \
 	done
 
-watch-frontend stop-frontend: process-exists=$(shell ps -ef | grep "./watch_frontend.sh" | grep -v "grep" | awk '{print $$2}')
+watch-frontend stop-frontend: process-exists=$(shell ps -ef | egrep -h "./watch_frontend.sh|parcel watch" | grep -v "grep" | awk '{print $$2}')
 watch-frontend:
 	@if [ -z "$(process-exists)" ]; then \
 		cd $(DIRECTORY) && nohup bash -c "./watch_frontend.sh &" && cd $(IMPACT_API); \

--- a/web/impact/impact/graphql/query.py
+++ b/web/impact/impact/graphql/query.py
@@ -10,6 +10,7 @@ from accelerator.models import (
     StartupTeamMember,
 )
 from graphql import GraphQLError
+EXPERT_NOT_FOUND_MESSAGE = 'Expert matching the id does not exist.'
 
 
 class Query(graphene.ObjectType):
@@ -25,7 +26,7 @@ class Query(graphene.ObjectType):
             expert = ExpertProfile.objects.filter(user_id=user_id).first()
 
             if not expert:
-                return GraphQLError("Expert matching the id does not exist")
+                return GraphQLError(EXPERT_NOT_FOUND_MESSAGE)
 
             return expert
 

--- a/web/impact/impact/graphql/query.py
+++ b/web/impact/impact/graphql/query.py
@@ -23,27 +23,19 @@ class Query(graphene.ObjectType):
 
     def resolve_expert_profile(self, info, **kwargs):
         user_id = kwargs.get('id')
+        expert = ExpertProfile.objects.filter(user_id=user_id).first()
 
-        if user_id is not None:
-            expert = ExpertProfile.objects.filter(user_id=user_id).first()
+        if not expert:
+            return GraphQLError(EXPERT_NOT_FOUND_MESSAGE)
 
-            if not expert:
-                return GraphQLError(EXPERT_NOT_FOUND_MESSAGE)
-
-            return expert
-
-        return GraphQLError("Ensure url specifies an expert id")
+        return expert
 
     def resolve_entrepreneur_profile(self, info, **kwargs):
         team_member_id = kwargs.get('id')
+        team_member = StartupTeamMember.objects.filter(
+            id=team_member_id).first()
 
-        if team_member_id is not None:
-            team_member = StartupTeamMember.objects.filter(
-                id=team_member_id).first()
+        if not team_member:
+            return GraphQLError(TEAM_MEMBER_NOT_FOUND_MESSAGE)
 
-            if not team_member:
-                return GraphQLError(TEAM_MEMBER_NOT_FOUND_MESSAGE)
-
-            return team_member
-
-        return GraphQLError("Ensure url specifies a team member id")
+        return team_member

--- a/web/impact/impact/graphql/query.py
+++ b/web/impact/impact/graphql/query.py
@@ -1,23 +1,25 @@
 import graphene
 
-from impact.graphql.types.expert_profile_type import ExpertProfileType
-from impact.graphql.types.entrepreneur_profile_type import (
-    EntrepreneurProfileType
+from impact.graphql.types import (
+    ExpertProfileType,
+    StartupTeamMemberType,
 )
 from accelerator.models import (
     ExpertProfile,
-    EntrepreneurProfile,
     StartupTeamMember,
 )
 from graphql import GraphQLError
 EXPERT_NOT_FOUND_MESSAGE = 'Expert matching the id does not exist.'
+TEAM_MEMBER_NOT_FOUND_MESSAGE = (
+    'Startup Team Member matching id does not exist'
+)
 
 
 class Query(graphene.ObjectType):
     expert_profile = graphene.Field(
         ExpertProfileType, id=graphene.Int())
     entrepreneur_profile = graphene.Field(
-        EntrepreneurProfileType, id=graphene.Int())
+        StartupTeamMemberType, id=graphene.Int())
 
     def resolve_expert_profile(self, info, **kwargs):
         user_id = kwargs.get('id')
@@ -36,12 +38,12 @@ class Query(graphene.ObjectType):
         team_member_id = kwargs.get('id')
 
         if team_member_id is not None:
-            user_id = StartupTeamMember.objects.filter(
-                id=team_member_id).values_list("user_id", flat=True)
+            team_member = StartupTeamMember.objects.filter(
+                id=team_member_id).first()
 
-            if not user_id:
-                return GraphQLError("Startup Team Member does not exist")
+            if not team_member:
+                return GraphQLError(TEAM_MEMBER_NOT_FOUND_MESSAGE)
 
-            return EntrepreneurProfile.objects.filter(user_id=user_id).first()
+            return team_member
 
         return GraphQLError("Ensure url specifies a team member id")

--- a/web/impact/impact/graphql/types/__init__.py
+++ b/web/impact/impact/graphql/types/__init__.py
@@ -11,9 +11,7 @@ from impact.graphql.types.entrepreneur_profile_type import (
 from impact.graphql.types.functional_expertise_type import (
     FunctionalExpertiseType
 )
-from impact.graphql.types.entrepreneur_profile_type import (
-    EntrepreneurProfileType
-)
 from impact.graphql.types.startup_mentor_relationship_type import (
     StartupMentorRelationshipType
 )
+from impact.graphql.types.expert_profile_type import ExpertProfileType

--- a/web/impact/impact/graphql/types/__init__.py
+++ b/web/impact/impact/graphql/types/__init__.py
@@ -1,0 +1,19 @@
+from impact.graphql.types.user_type import UserType
+from impact.graphql.types.program_type import ProgramType
+from impact.graphql.types.startup_type import StartupType
+from impact.graphql.types.industry_type import IndustryType
+from impact.graphql.types.program_family_type import ProgramFamilyType
+from impact.graphql.types.interest_category_type import InterestCategoryType
+from impact.graphql.types.startup_team_member_type import StartupTeamMemberType
+from impact.graphql.types.entrepreneur_profile_type import (
+    EntrepreneurProfileType
+)
+from impact.graphql.types.functional_expertise_type import (
+    FunctionalExpertiseType
+)
+from impact.graphql.types.entrepreneur_profile_type import (
+    EntrepreneurProfileType
+)
+from impact.graphql.types.startup_mentor_relationship_type import (
+    StartupMentorRelationshipType
+)

--- a/web/impact/impact/graphql/types/__init__.py
+++ b/web/impact/impact/graphql/types/__init__.py
@@ -15,3 +15,9 @@ from impact.graphql.types.startup_mentor_relationship_type import (
     StartupMentorRelationshipType
 )
 from impact.graphql.types.expert_profile_type import ExpertProfileType
+from impact.graphql.types.entrepreneur_startup_type import (
+    EntrepreneurStartupType
+)
+from impact.graphql.types.expert_startup_type import (
+    ExpertStartupType
+)

--- a/web/impact/impact/graphql/types/entrepreneur_profile_type.py
+++ b/web/impact/impact/graphql/types/entrepreneur_profile_type.py
@@ -1,0 +1,48 @@
+import graphene
+from graphene_django import DjangoObjectType
+from accelerator.models import (
+    EntrepreneurProfile,
+    StartupTeamMember,
+    Startup,
+)
+from impact.graphql.types import (
+    StartupType
+)
+
+
+class EntrepreneurProfileType(DjangoObjectType):
+    startups = graphene.List(StartupType)
+    image_url = graphene.String()
+    title = graphene.String()
+    current_program = graphene.String()
+
+    class Meta:
+        model = EntrepreneurProfile
+        only_fields = (
+            'facebook_url',
+            'linked_in_url',
+            'personal_website_url',
+            'phone',
+            'twitter_handle',
+            'user',
+        )
+
+    def resolve_image_url(self, info, **kwargs):
+        return self.image and self.image.url
+
+    def resolve_startups(self, info, **kwargs):
+        ids = _startup_team_members(self.user).values_list(
+            'startup', flat=True).distinct()
+        startups = Startup.objects.filter(id__in=ids)
+        return [startup for startup in startups]
+
+    def resolve_title(self, info, **kwargs):
+        return _startup_team_members(self.user).values_list(
+            'title', flat=True).distinct()[0]
+
+    def resolve_current_program(self, info, **kwargs):
+        return self.current_program.name
+
+
+def _startup_team_members(user):
+    return StartupTeamMember.objects.filter(user=user)

--- a/web/impact/impact/graphql/types/entrepreneur_profile_type.py
+++ b/web/impact/impact/graphql/types/entrepreneur_profile_type.py
@@ -1,19 +1,10 @@
 import graphene
 from graphene_django import DjangoObjectType
-from accelerator.models import (
-    EntrepreneurProfile,
-    StartupTeamMember,
-    Startup,
-)
-from impact.graphql.types import (
-    StartupType
-)
+from accelerator.models import EntrepreneurProfile
 
 
 class EntrepreneurProfileType(DjangoObjectType):
-    startups = graphene.List(StartupType)
     image_url = graphene.String()
-    title = graphene.String()
     current_program = graphene.String()
 
     class Meta:
@@ -24,25 +15,10 @@ class EntrepreneurProfileType(DjangoObjectType):
             'personal_website_url',
             'phone',
             'twitter_handle',
-            'user',
         )
 
     def resolve_image_url(self, info, **kwargs):
         return self.image and self.image.url
 
-    def resolve_startups(self, info, **kwargs):
-        ids = _startup_team_members(self.user).values_list(
-            'startup', flat=True).distinct()
-        startups = Startup.objects.filter(id__in=ids)
-        return [startup for startup in startups]
-
-    def resolve_title(self, info, **kwargs):
-        return _startup_team_members(self.user).values_list(
-            'title', flat=True).distinct()[0]
-
     def resolve_current_program(self, info, **kwargs):
         return self.current_program.name
-
-
-def _startup_team_members(user):
-    return StartupTeamMember.objects.filter(user=user)

--- a/web/impact/impact/graphql/types/entrepreneur_startup_type.py
+++ b/web/impact/impact/graphql/types/entrepreneur_startup_type.py
@@ -1,0 +1,29 @@
+import graphene
+
+from accelerator.models import (
+    StartupStatus,
+    Startup,
+)
+from impact.graphql.types import (
+    StartupType,
+    ProgramType,
+)
+
+
+class EntrepreneurStartupType(StartupType):
+    program = graphene.Field(ProgramType)
+
+    class Meta:
+        model = Startup
+        only_fields = (
+            'id',
+            'short_pitch',
+        )
+
+    def resolve_program(self, info, **kwargs):
+        status = StartupStatus.objects.filter(
+            startup=self,
+            program_startup_status__startup_list_tab_id='finalists'
+        ).order_by('-created_at').first()
+        if status:
+            return status.program_startup_status.program

--- a/web/impact/impact/graphql/types/expert_profile_type.py
+++ b/web/impact/impact/graphql/types/expert_profile_type.py
@@ -12,14 +12,7 @@ from accelerator_abstract.models import (
     ACTIVE_PROGRAM_STATUS,
     ENDED_PROGRAM_STATUS,
 )
-from impact.graphql.types.industry_type import IndustryType  # noqa: F401
-from impact.graphql.types.startup_mentor_relationship_type import (
-    StartupMentorRelationshipType,
-)
-from impact.graphql.types.program_family_type import ProgramFamilyType  # noqa: F401, E501
-from impact.graphql.types.user_type import UserType  # noqa: F401
-from impact.graphql.types.functional_expertise_type import FunctionalExpertiseType  # noqa: F401, E501
-from impact.graphql.types.interest_category_type import InterestCategoryType  # noqa: F401, E501
+from impact.graphql.types import StartupMentorRelationshipType
 from django.db.models import Q
 
 from impact.utils import compose_filter

--- a/web/impact/impact/graphql/types/expert_startup_type.py
+++ b/web/impact/impact/graphql/types/expert_startup_type.py
@@ -1,0 +1,26 @@
+import graphene
+
+from accelerator.models import (
+    Startup,
+    StartupMentorRelationship,
+)
+from impact.graphql.types import (
+    StartupType,
+    ProgramType,
+)
+
+
+class ExpertStartupType(StartupType):
+    program = graphene.Field(ProgramType)
+
+    class Meta:
+        model = Startup
+        only_fields = (
+            'id',
+            'short_pitch',
+        )
+
+    def resolve_program(self, info, **kwargs):
+        smr_id = info.variable_values["startup_mentor_relationship_id"]
+        smr = StartupMentorRelationship.objects.filter(id=smr_id).first()
+        return smr and smr.startup_mentor_tracking.program

--- a/web/impact/impact/graphql/types/interest_category_type.py
+++ b/web/impact/impact/graphql/types/interest_category_type.py
@@ -2,8 +2,6 @@ from graphene_django import DjangoObjectType
 
 from accelerator.models import InterestCategory
 
-from impact.graphql.types.program_type import ProgramType  # noqa: F401
-
 
 class InterestCategoryType(DjangoObjectType):
     class Meta:

--- a/web/impact/impact/graphql/types/program_type.py
+++ b/web/impact/impact/graphql/types/program_type.py
@@ -1,9 +1,25 @@
+import graphene
+
 from graphene_django import DjangoObjectType
 
 from accelerator.models import Program
-from impact.graphql.types.program_family_type import ProgramFamilyType  # noqa: F401, E501
 
 
 class ProgramType(DjangoObjectType):
+    year = graphene.String()
+    family = graphene.String()
+
     class Meta:
         model = Program
+        only_fields = (
+            'name',
+        )
+
+    def resolve_year(self, info, **kwargs):
+        if self.start_date:
+            return self.start_date.year
+
+        return ''
+
+    def resolve_family(self, info, **kwargs):
+        return self.program_family.name

--- a/web/impact/impact/graphql/types/program_type.py
+++ b/web/impact/impact/graphql/types/program_type.py
@@ -19,7 +19,5 @@ class ProgramType(DjangoObjectType):
         if self.start_date:
             return self.start_date.year
 
-        return ''
-
     def resolve_family(self, info, **kwargs):
         return self.program_family.name

--- a/web/impact/impact/graphql/types/startup_mentor_relationship_type.py
+++ b/web/impact/impact/graphql/types/startup_mentor_relationship_type.py
@@ -2,45 +2,20 @@ import graphene
 from graphene_django import DjangoObjectType
 
 from accelerator.models import StartupMentorRelationship
+from impact.graphql.types.expert_startup_type import ExpertStartupType
 
 
 class StartupMentorRelationshipType(DjangoObjectType):
-    program_location = graphene.String()
+    startup = graphene.Field(ExpertStartupType)
     program_status = graphene.String()
-    program_year = graphene.String()
-    startup_id = graphene.String()
-    startup_name = graphene.String()
-    startup_high_resolution_logo = graphene.String()
-    startup_short_pitch = graphene.String()
 
     class Meta:
         model = StartupMentorRelationship
-
-    def resolve_program_location(self, info, **kwargs):
-        program = self.startup_mentor_tracking.program
-        return program and program.program_family.name
-
-    def resolve_program_year(self, info, **kwargs):
-        program = self.startup_mentor_tracking.program
-        return program and program.start_date.year
 
     def resolve_program_status(self, info, **kwargs):
         program = self.startup_mentor_tracking.program
         return program and program.program_status
 
-    def resolve_startup_id(self, info, **kwargs):
-        startup = self.startup_mentor_tracking.startup
-        return startup and startup.id
-
-    def resolve_startup_name(self, info, **kwargs):
-        startup = self.startup_mentor_tracking.startup
-        return startup and startup.name
-
-    def resolve_startup_high_resolution_logo(self, info, **kwargs):
-        startup = self.startup_mentor_tracking.startup
-        return (startup and startup.high_resolution_logo and
-                startup.high_resolution_logo.url)
-
-    def resolve_startup_short_pitch(self, info, **kwargs):
-        startup = self.startup_mentor_tracking.startup
-        return startup and startup.short_pitch
+    def resolve_startup(self, info, **kwargs):
+        info.variable_values["startup_mentor_relationship_id"] = self.id
+        return self.startup_mentor_tracking.startup

--- a/web/impact/impact/graphql/types/startup_team_member_type.py
+++ b/web/impact/impact/graphql/types/startup_team_member_type.py
@@ -23,14 +23,9 @@ class StartupTeamMemberType(DjangoObjectType):
         )
 
     def resolve_startups(self, info, **kwargs):
-        ids = _startup_team_members({"user": self.user}).values_list(
+        ids = StartupTeamMember.objects.filter(user=self.user).values_list(
             'startup', flat=True).distinct()
-        startups = Startup.objects.filter(id__in=ids)
-        return startups
+        return Startup.objects.filter(id__in=ids)
 
     def resolve_profile(self, info, **kwargs):
         return EntrepreneurProfile.objects.filter(user=self.user).first()
-
-
-def _startup_team_members(filters):
-    return StartupTeamMember.objects.filter(**filters)

--- a/web/impact/impact/graphql/types/startup_team_member_type.py
+++ b/web/impact/impact/graphql/types/startup_team_member_type.py
@@ -1,11 +1,36 @@
+import graphene
 from graphene_django import DjangoObjectType
 
-from accelerator.models import StartupTeamMember
+from accelerator.models import StartupTeamMember, Startup, EntrepreneurProfile
+
+from impact.graphql.types import (
+    StartupType,
+)
+from impact.graphql.types.entrepreneur_profile_type import (
+    EntrepreneurProfileType
+)
 
 
 class StartupTeamMemberType(DjangoObjectType):
+    startups = graphene.List(StartupType)
+    profile = graphene.List(EntrepreneurProfileType)
+
     class Meta:
         model = StartupTeamMember
         only_fields = (
             'title',
+            'user',
         )
+
+    def resolve_startups(self, info, **kwargs):
+        ids = _startup_team_members({"user": self.user}).values_list(
+            'startup', flat=True).distinct()
+        startups = Startup.objects.filter(id__in=ids)
+        return [startup for startup in startups]
+
+    def resolve_profile(self, info, **kwargs):
+        return [EntrepreneurProfile.objects.filter(user=self.user).first()]
+
+
+def _startup_team_members(filters):
+    return StartupTeamMember.objects.filter(**filters)

--- a/web/impact/impact/graphql/types/startup_team_member_type.py
+++ b/web/impact/impact/graphql/types/startup_team_member_type.py
@@ -26,7 +26,7 @@ class StartupTeamMemberType(DjangoObjectType):
         ids = _startup_team_members({"user": self.user}).values_list(
             'startup', flat=True).distinct()
         startups = Startup.objects.filter(id__in=ids)
-        return [startup for startup in startups]
+        return startups
 
     def resolve_profile(self, info, **kwargs):
         return [EntrepreneurProfile.objects.filter(user=self.user).first()]

--- a/web/impact/impact/graphql/types/startup_team_member_type.py
+++ b/web/impact/impact/graphql/types/startup_team_member_type.py
@@ -3,8 +3,8 @@ from graphene_django import DjangoObjectType
 
 from accelerator.models import StartupTeamMember, Startup, EntrepreneurProfile
 
-from impact.graphql.types import (
-    StartupType,
+from impact.graphql.types.entrepreneur_startup_type import (
+    EntrepreneurStartupType,
 )
 from impact.graphql.types.entrepreneur_profile_type import (
     EntrepreneurProfileType
@@ -12,7 +12,7 @@ from impact.graphql.types.entrepreneur_profile_type import (
 
 
 class StartupTeamMemberType(DjangoObjectType):
-    startups = graphene.List(StartupType)
+    startups = graphene.List(EntrepreneurStartupType)
     profile = graphene.Field(EntrepreneurProfileType)
 
     class Meta:

--- a/web/impact/impact/graphql/types/startup_team_member_type.py
+++ b/web/impact/impact/graphql/types/startup_team_member_type.py
@@ -1,0 +1,11 @@
+from graphene_django import DjangoObjectType
+
+from accelerator.models import StartupTeamMember
+
+
+class StartupTeamMemberType(DjangoObjectType):
+    class Meta:
+        model = StartupTeamMember
+        only_fields = (
+            'title',
+        )

--- a/web/impact/impact/graphql/types/startup_team_member_type.py
+++ b/web/impact/impact/graphql/types/startup_team_member_type.py
@@ -13,7 +13,7 @@ from impact.graphql.types.entrepreneur_profile_type import (
 
 class StartupTeamMemberType(DjangoObjectType):
     startups = graphene.List(StartupType)
-    profile = graphene.List(EntrepreneurProfileType)
+    profile = graphene.Field(EntrepreneurProfileType)
 
     class Meta:
         model = StartupTeamMember
@@ -29,7 +29,7 @@ class StartupTeamMemberType(DjangoObjectType):
         return startups
 
     def resolve_profile(self, info, **kwargs):
-        return [EntrepreneurProfile.objects.filter(user=self.user).first()]
+        return EntrepreneurProfile.objects.filter(user=self.user).first()
 
 
 def _startup_team_members(filters):

--- a/web/impact/impact/graphql/types/startup_type.py
+++ b/web/impact/impact/graphql/types/startup_type.py
@@ -3,12 +3,18 @@ from graphene_django import DjangoObjectType
 
 from accelerator.models import (
     Startup,
+    Program,
+    Application,
+)
+from impact.graphql.types import (
+    ProgramType
 )
 
 
 class StartupType(DjangoObjectType):
     name = graphene.String()
     high_resolution_logo = graphene.String()
+    program = graphene.List(ProgramType)
 
     class Meta:
         model = Startup
@@ -25,3 +31,10 @@ class StartupType(DjangoObjectType):
             return self.high_resolution_logo.url
 
         return None
+
+    def resolve_program(self, info, **kwargs):
+        cycles = Application.objects.filter(
+            startup=self).values_list("cycle", flat=True)
+        return [
+            program
+            for program in Program.objects.filter(cycle_id__in=cycles)]

--- a/web/impact/impact/graphql/types/startup_type.py
+++ b/web/impact/impact/graphql/types/startup_type.py
@@ -3,8 +3,7 @@ from graphene_django import DjangoObjectType
 
 from accelerator.models import (
     Startup,
-    Program,
-    Application,
+    StartupStatus,
 )
 from impact.graphql.types import (
     ProgramType
@@ -33,8 +32,13 @@ class StartupType(DjangoObjectType):
         return None
 
     def resolve_program(self, info, **kwargs):
-        cycles = Application.objects.filter(
-            startup=self).values_list("cycle", flat=True)
-        return [
-            program
-            for program in Program.objects.filter(cycle_id__in=cycles)]
+
+        status = StartupStatus.objects.filter(
+            startup=self,
+            program_startup_status__startup_list_tab_id='finalists'
+        ).first()
+
+        if status:
+            return [status.program_startup_status.program]
+
+        return []

--- a/web/impact/impact/graphql/types/startup_type.py
+++ b/web/impact/impact/graphql/types/startup_type.py
@@ -1,9 +1,27 @@
+import graphene
 from graphene_django import DjangoObjectType
 
-from accelerator.models.startup import Startup
+from accelerator.models import (
+    Startup,
+)
 
 
 class StartupType(DjangoObjectType):
+    name = graphene.String()
+    high_resolution_logo = graphene.String()
+
     class Meta:
         model = Startup
-        only_fields = ('short_pitch',)
+        only_fields = (
+            'id',
+            'short_pitch',
+        )
+
+    def resolve_name(self, info, **kwargs):
+        return self.name
+
+    def resolve_high_resolution_logo(self, info, **kwargs):
+        if self.high_resolution_logo:
+            return self.high_resolution_logo.url
+
+        return None

--- a/web/impact/impact/graphql/types/startup_type.py
+++ b/web/impact/impact/graphql/types/startup_type.py
@@ -3,7 +3,6 @@ from graphene_django import DjangoObjectType
 
 from accelerator.models import (
     Startup,
-    StartupStatus,
 )
 from impact.graphql.types import (
     ProgramType
@@ -13,7 +12,7 @@ from impact.graphql.types import (
 class StartupType(DjangoObjectType):
     name = graphene.String()
     high_resolution_logo = graphene.String()
-    program = graphene.List(ProgramType)
+    program = graphene.Field(ProgramType)
 
     class Meta:
         model = Startup
@@ -28,12 +27,3 @@ class StartupType(DjangoObjectType):
     def resolve_high_resolution_logo(self, info, **kwargs):
         if self.high_resolution_logo:
             return self.high_resolution_logo.url
-
-    def resolve_program(self, info, **kwargs):
-        status = StartupStatus.objects.filter(
-            startup=self,
-            program_startup_status__startup_list_tab_id='finalists'
-        ).order_by('-created_at').first()
-        if status:
-            return [status.program_startup_status.program]
-        return []

--- a/web/impact/impact/graphql/types/startup_type.py
+++ b/web/impact/impact/graphql/types/startup_type.py
@@ -29,16 +29,11 @@ class StartupType(DjangoObjectType):
         if self.high_resolution_logo:
             return self.high_resolution_logo.url
 
-        return None
-
     def resolve_program(self, info, **kwargs):
-
         status = StartupStatus.objects.filter(
             startup=self,
             program_startup_status__startup_list_tab_id='finalists'
         ).order_by('-created_at').first()
-
         if status:
             return [status.program_startup_status.program]
-
         return []

--- a/web/impact/impact/graphql/types/startup_type.py
+++ b/web/impact/impact/graphql/types/startup_type.py
@@ -36,7 +36,7 @@ class StartupType(DjangoObjectType):
         status = StartupStatus.objects.filter(
             startup=self,
             program_startup_status__startup_list_tab_id='finalists'
-        ).order_by('-created_date').first()
+        ).order_by('-created_at').first()
 
         if status:
             return [status.program_startup_status.program]

--- a/web/impact/impact/graphql/types/startup_type.py
+++ b/web/impact/impact/graphql/types/startup_type.py
@@ -36,7 +36,7 @@ class StartupType(DjangoObjectType):
         status = StartupStatus.objects.filter(
             startup=self,
             program_startup_status__startup_list_tab_id='finalists'
-        ).first()
+        ).order_by('-created_date').first()
 
         if status:
             return [status.program_startup_status.program]

--- a/web/impact/impact/tests/test_graphql.py
+++ b/web/impact/impact/tests/test_graphql.py
@@ -158,7 +158,7 @@ class TestGraphQL(APITestCase):
 
             self.assertEqual(ent_profile["title"], member.title)
 
-            profile_response = ent_profile["profile"][0]
+            profile_response = ent_profile["profile"]
             self.assertEqual(
                 profile_response["imageUrl"],
                 profile.image.url if profile.image else "")

--- a/web/impact/impact/tests/test_graphql.py
+++ b/web/impact/impact/tests/test_graphql.py
@@ -17,6 +17,8 @@ from impact.tests.factories import (
     StartupMentorRelationshipFactory,
     UserRoleFactory,
     ApplicationFactory,
+    ProgramStartupStatusFactory,
+    StartupStatusFactory,
 )
 from impact.tests.utils import capture_stderr
 from impact.graphql.query import (
@@ -103,11 +105,19 @@ class TestGraphQL(APITestCase):
         with self.login(email=self.basic_user().email):
             context = StartupTeamMemberContext(primary_contact=False)
             startup = context.startup
+            program = context.program
 
             ApplicationFactory(cycle=context.cycle, startup=startup)
+            ps = ProgramStartupStatusFactory(
+                program=program,
+                startup_list_tab_id='finalists')
+            StartupStatusFactory(
+                startup=startup,
+                program_startup_status=ps
+            )
+
             user = context.user
             profile = user.entrepreneurprofile
-            program = context.program
             member = context.member
 
             query = """

--- a/web/impact/impact/tests/test_graphql.py
+++ b/web/impact/impact/tests/test_graphql.py
@@ -1,5 +1,6 @@
 # MIT License
 # Copyright (c) 2017 MassChallenge, Inc.
+import json
 from django.urls import reverse
 
 from accelerator.models import (
@@ -17,7 +18,11 @@ from impact.tests.factories import (
     UserRoleFactory,
 )
 from impact.tests.utils import capture_stderr
-from impact.graphql.query import EXPERT_NOT_FOUND_MESSAGE
+from impact.graphql.query import (
+    EXPERT_NOT_FOUND_MESSAGE,
+    TEAM_MEMBER_NOT_FOUND_MESSAGE
+)
+from accelerator.tests.contexts import StartupTeamMemberContext
 
 MENTEE_FIELDS = """
     startupId
@@ -92,6 +97,86 @@ class TestGraphQL(APITestCase):
                     }
                 }
             )
+
+    def test_query_with_entrepreneur(self):
+        with self.login(email=self.basic_user().email):
+            context = StartupTeamMemberContext(primary_contact=False)
+            user = context.user
+            profile = user.entrepreneurprofile
+            startup = context.startup
+            member = context.member
+
+            query = """
+                query {{
+                    entrepreneurProfile(id: {id}) {{
+                        title
+                        profile {{
+                            twitterHandle
+                            currentProgram
+                            imageUrl
+                            linkedInUrl
+                            facebookUrl
+                            personalWebsiteUrl
+                            phone
+                        }}
+                        user {{
+                            id
+                            email
+                            firstName
+                            lastName
+                        }}
+                        startups {{
+                            id
+                            name
+                            shortPitch
+                            highResolutionLogo
+                            program {{
+                                year
+                                family
+                            }}
+                        }}
+                    }}
+                }}
+            """.format(id=member.id)
+            response = self.client.post(self.url, data={'query': query})
+            data = json.loads(response.content.decode("utf-8"))["data"]
+            ent_profile = data["entrepreneurProfile"]
+
+            self.assertEqual(ent_profile["title"], member.title)
+
+            profile_response = ent_profile["profile"][0]
+            self.assertEqual(
+                profile_response["imageUrl"],
+                profile.image.url if profile.image else "")
+            self.assertEqual(
+                profile_response["linkedInUrl"], profile.linked_in_url)
+            self.assertEqual(
+                profile_response["personalWebsiteUrl"],
+                profile.personal_website_url)
+            self.assertEqual(profile_response["phone"], profile.phone)
+            self.assertEqual(
+                profile_response["facebookUrl"], profile.facebook_url)
+            self.assertEqual(
+                profile_response["twitterHandle"], profile.twitter_handle)
+            self.assertEqual(
+                profile_response["currentProgram"],
+                profile.current_program.name)
+
+            user_resp = ent_profile["user"]
+            self.assertEqual(user_resp["id"], str(user.id))
+            self.assertEqual(user_resp["email"], user.email)
+            self.assertEqual(user_resp["firstName"], user.first_name)
+            self.assertEqual(user_resp["lastName"], user.last_name)
+
+            startup_response = ent_profile["startups"][0]
+            self.assertEqual(startup_response["id"], str(startup.id))
+            self.assertEqual(startup_response["name"], startup.name)
+            self.assertEqual(
+                startup_response["shortPitch"], startup.short_pitch)
+            self.assertEqual(
+                startup_response["highResolutionLogo"],
+                startup.high_resolution_logo.url
+                if startup.high_resolution_logo else None)
 
     def test_office_url_field_returns_correct_value(self):
         program = ProgramFactory()
@@ -206,11 +291,11 @@ class TestGraphQL(APITestCase):
                 None
             )
 
-    def test_query_with_non_existent_user_id(self):
+    def test_query_with_non_existent_startup_team_member_id(self):
         with self.login(email=self.basic_user().email):
             query = """
                 query {{
-                    expertProfile(id: {id}) {{
+                    entrepreneurProfile(id: {id}) {{
                         user {{ firstName }}
                     }}
                 }}
@@ -222,8 +307,8 @@ class TestGraphQL(APITestCase):
                 error_messages = [x['message'] for x in
                                   response.json()['errors']]
 
-            self.assertIn(EXPERT_NOT_FOUND_MESSAGE, error_messages)
+            self.assertIn(TEAM_MEMBER_NOT_FOUND_MESSAGE, error_messages)
             self.assertEqual(
-                response.json()['data']['expertProfile'],
+                response.json()['data']['entrepreneurProfile'],
                 None
             )

--- a/web/impact/impact/tests/test_graphql.py
+++ b/web/impact/impact/tests/test_graphql.py
@@ -16,6 +16,7 @@ from impact.tests.factories import (
     ProgramRoleFactory,
     StartupMentorRelationshipFactory,
     UserRoleFactory,
+    ApplicationFactory,
 )
 from impact.tests.utils import capture_stderr
 from impact.graphql.query import (
@@ -101,9 +102,12 @@ class TestGraphQL(APITestCase):
     def test_query_with_entrepreneur(self):
         with self.login(email=self.basic_user().email):
             context = StartupTeamMemberContext(primary_contact=False)
+            startup = context.startup
+
+            ApplicationFactory(cycle=context.cycle, startup=startup)
             user = context.user
             profile = user.entrepreneurprofile
-            startup = context.startup
+            program = context.program
             member = context.member
 
             query = """
@@ -177,6 +181,13 @@ class TestGraphQL(APITestCase):
                 startup_response["highResolutionLogo"],
                 startup.high_resolution_logo.url
                 if startup.high_resolution_logo else None)
+
+            program_resp = startup_response["program"][0]
+            self.assertEqual(
+                program_resp["family"], str(program.program_family.name))
+            self.assertEqual(
+                program_resp["year"],
+                str(program.start_date.year) if program.start_date else '')
 
     def test_office_url_field_returns_correct_value(self):
         program = ProgramFactory()

--- a/web/impact/impact/tests/test_graphql.py
+++ b/web/impact/impact/tests/test_graphql.py
@@ -17,6 +17,7 @@ from impact.tests.factories import (
     UserRoleFactory,
 )
 from impact.tests.utils import capture_stderr
+from impact.graphql.query import EXPERT_NOT_FOUND_MESSAGE
 
 MENTEE_FIELDS = """
     startupId
@@ -27,8 +28,6 @@ MENTEE_FIELDS = """
     programYear
     programStatus
 """
-
-EXPERT_NOT_FOUND_MESSAGE = 'ExpertProfile matching query does not exist.'
 
 
 class TestGraphQL(APITestCase):

--- a/web/impact/impact/tests/test_graphql.py
+++ b/web/impact/impact/tests/test_graphql.py
@@ -197,7 +197,7 @@ class TestGraphQL(APITestCase):
                 program_resp["family"], str(program.program_family.name))
             self.assertEqual(
                 program_resp["year"],
-                str(program.start_date.year) if program.start_date else '')
+                str(program.start_date.year) if program.start_date else None)
 
     def test_office_url_field_returns_correct_value(self):
         program = ProgramFactory()

--- a/web/impact/impact/urls.py
+++ b/web/impact/impact/urls.py
@@ -120,7 +120,7 @@ urls = [
     url(r'^people/$', TemplateView.as_view(
         template_name='directory.html'),
         name="entreprenuer_profile"),
-    url(r'^people/(?P<pk>[0-9]+)/$', TemplateView.as_view(
+    url(r'^people/(.*)/$', TemplateView.as_view(
         template_name='directory.html'),
         name="entreprenuer_profile"),
     url(r'^openid/', include('oidc_provider.urls', namespace='oidc_provider')),

--- a/web/impact/impact/urls.py
+++ b/web/impact/impact/urls.py
@@ -117,6 +117,9 @@ urls = [
     url(r'^allocator/(?:.*)$', TemplateView.as_view(
         template_name='directory.html'),
         name="allocator"),
+    url(r'^people/$', TemplateView.as_view(
+        template_name='directory.html'),
+        name="entreprenuer_profile"),
     url(r'^people/(?P<pk>[0-9]+)/$', TemplateView.as_view(
         template_name='directory.html'),
         name="entreprenuer_profile"),

--- a/web/impact/impact/urls.py
+++ b/web/impact/impact/urls.py
@@ -117,6 +117,9 @@ urls = [
     url(r'^allocator/(?:.*)$', TemplateView.as_view(
         template_name='directory.html'),
         name="allocator"),
+    url(r'^people/(?P<pk>[0-9]+)/$', TemplateView.as_view(
+        template_name='directory.html'),
+        name="entreprenuer_profile"),
     url(r'^openid/', include('oidc_provider.urls', namespace='oidc_provider')),
     url(r'^$', IndexView.as_view()),
 ]


### PR DESCRIPTION
#### Changes introduced in [AC-6375](https://masschallenge.atlassian.net/browse/AC-6375)
- add graphql types and logic to allow us get information about an entrepreneur

#### How to test
- checkout this branch
- run impact
- visit `localhost/graphql`
- enter this in the query field (top left)
```
query getEntrepreneurProfile($id: Int!) {
  entrepreneurProfile(id: $id) {
    title
    user {
      id
      firstName
      lastName
      email
    }
    startups {
      id
      name
      shortPitch
      highResolutionLogo
      program {
        family
        year
      }
    }
    profile {
      phone
      linkedInUrl
      facebookUrl
      twitterHandle
      personalWebsiteUrl
      imageUrl
    }
    profile {
      currentProgram
    }
    
  }
}
```

- now enter the following in the bottom left with a startup team member id and see results on the right column
```
{"id": <startup-team-member-id>}
```