### PR TITLE
AC-6428: Break our local environment into logical pieces working together

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ before_script:
 - docker run -v $(pwd)/../directory/dist:/usr/src/app/dist -t masschallenge/mentor-directory
 - cp -r ../directory/dist web/impact/static/directory-dist
 - cp ../directory/dist/index.html web/impact/templates/directory.html
+- docker network create impact-api_default 
 - docker-compose -f docker-compose.travis.yml build --no-cache --build-arg DJANGO_ACCELERATOR_REVISION=$DJANGO_ACCELERATOR_REVISION
 - docker-compose -f docker-compose.travis.yml up -d
 

--- a/Makefile
+++ b/Makefile
@@ -228,7 +228,6 @@ DIRECTORY = ../directory
 SEMANTIC = ../semantic-ui-theme
 REPOS = $(ACCELERATE) $(DJANGO_ACCELERATOR) $(DIRECTORY) $(SEMANTIC) $(IMPACT_API) 
 
-
 # Database migration related targets
 
 data-migration migrations: .env
@@ -282,16 +281,16 @@ stop-frontend:
 # Server and Virtual Machine related targets
 debug ?= 1
 
-run-server: run-server-$(debug) watch-frontend
+run-server: run-server-$(debug)
 
-run-server-0: .env initial-db-setup watch-frontend
+run-server-0: .env initial-db-setup watch-frontend kill-exited-containers ensure-mysql
 	@docker-compose up
 
-run-detached-server: .env initial-db-setup watch-frontend
+run-detached-server: .env initial-db-setup watch-frontend ensure-mysql kill-exited-containers
 	@docker-compose up -d
 	@docker-compose run --rm web /usr/bin/mysqlwait.sh
 
-run-server-1: run-detached-server watch-frontend
+run-server-1: run-detached-server watch-frontend ensure-mysql kill-exited-containers
 	@docker-compose exec web /bin/bash /usr/bin/start-nodaemon.sh
 
 dev: run-server-0
@@ -307,11 +306,9 @@ initial-db-setup:
 
 stop-server: .env stop-frontend
 	@docker-compose stop
-	-@killall -9 docker-compose || true
 
 shutdown-vms: .env stop-frontend
 	@docker-compose down
-	@rm -rf ./mysql/data
 	@rm -rf ./redis
 
 REMOVE_IMAGES = no
@@ -344,13 +341,13 @@ build-all: build
 
 # Interactive shell Targets
 
-bash-shell: .env
+bash-shell: .env kill-exited-containers ensure-mysql
 	@docker-compose exec web /bin/bash || docker-compose run --rm web /bin/bash
 
-db-shell: .env
+db-shell: .env kill-exited-containers ensure-mysql
 	@docker-compose run --rm web ./manage.py dbshell
 
-django-shell: .env
+django-shell: .env kill-exited-containers ensure-mysql
 	@docker-compose run --rm web ./manage.py shell
 
 
@@ -361,7 +358,7 @@ s3_key = $(db_name).sql.gz
 gz_file ?= $(DB_CACHE_DIR)$(s3_key)
 intermediary_file = /tmp/sql_dump.sql
 
-load-db: $(DB_CACHE_DIR) $(gz_file) .env
+load-db: $(DB_CACHE_DIR) $(gz_file) .env kill-exited-containers ensure-mysql
 	@echo "Loading $(gz_file)"
 	@echo "This will take a while, don't be alarmed if your console appears frozen."
 	@echo "drop database mc_dev; create database mc_dev; use mc_dev;" > $(intermediary_file)
@@ -381,7 +378,7 @@ ${DB_CACHE_DIR}:
 clean-db-cache:
 	@rm -f $(gz_file)
 
-load-remote-db: clean-db-cache
+load-remote-db: clean-db-cache ensure-mysql
 	$(MAKE) load-db gz_file=$(gz_file)
 
 mysql-container: run-detached-server
@@ -492,5 +489,16 @@ comp-messages: .env
 messages: .env
 	@docker-compose exec web python manage.py makemessages -a
 
-lint: .env
+lint: .env ensure-mysql
 	@docker-compose run --rm web pylint impact
+
+ensure-mysql: kill-exited-containers
+	@$(ACCELERATE_MAKE) ensure-mysql
+
+kill-exited-containers: containers-to-kill=$(shell docker ps -a -q --filter status=exited --filter name=impact)
+kill-exited-containers:
+	-@if [ -n "$(containers-to-kill)" ]; then \
+		echo "Removing unused impact docker containers..."; \
+		docker rm -f $(containers-to-kill); \
+		echo "Done removing containers."; \
+	fi;

--- a/Makefile
+++ b/Makefile
@@ -278,19 +278,20 @@ stop-frontend:
 		kill $(process-exists); \
 	fi;
 
+
 # Server and Virtual Machine related targets
 debug ?= 1
 
 run-server: run-server-$(debug)
 
-run-server-0: .env initial-db-setup watch-frontend kill-exited-containers ensure-mysql
+run-server-0: .env initial-db-setup watch-frontend ensure-mysql
 	@docker-compose up
 
-run-detached-server: .env initial-db-setup watch-frontend ensure-mysql kill-exited-containers
+run-detached-server: .env initial-db-setup watch-frontend ensure-mysql
 	@docker-compose up -d
 	@docker-compose run --rm web /usr/bin/mysqlwait.sh
 
-run-server-1: run-detached-server watch-frontend ensure-mysql kill-exited-containers
+run-server-1: run-detached-server watch-frontend ensure-mysql
 	@docker-compose exec web /bin/bash /usr/bin/start-nodaemon.sh
 
 dev: run-server-0
@@ -341,13 +342,13 @@ build-all: build
 
 # Interactive shell Targets
 
-bash-shell: .env kill-exited-containers ensure-mysql
+bash-shell: .env ensure-mysql
 	@docker-compose exec web /bin/bash || docker-compose run --rm web /bin/bash
 
-db-shell: .env kill-exited-containers ensure-mysql
+db-shell: .env ensure-mysql
 	@docker-compose run --rm web ./manage.py dbshell
 
-django-shell: .env kill-exited-containers ensure-mysql
+django-shell: .env ensure-mysql
 	@docker-compose run --rm web ./manage.py shell
 
 
@@ -358,7 +359,7 @@ s3_key = $(db_name).sql.gz
 gz_file ?= $(DB_CACHE_DIR)$(s3_key)
 intermediary_file = /tmp/sql_dump.sql
 
-load-db: $(DB_CACHE_DIR) $(gz_file) .env kill-exited-containers ensure-mysql
+load-db: $(DB_CACHE_DIR) $(gz_file) .env ensure-mysql
 	@echo "Loading $(gz_file)"
 	@echo "This will take a while, don't be alarmed if your console appears frozen."
 	@echo "drop database mc_dev; create database mc_dev; use mc_dev;" > $(intermediary_file)
@@ -378,7 +379,7 @@ ${DB_CACHE_DIR}:
 clean-db-cache:
 	@rm -f $(gz_file)
 
-load-remote-db: clean-db-cache ensure-mysql
+load-remote-db: clean-db-cache
 	$(MAKE) load-db gz_file=$(gz_file)
 
 mysql-container: run-detached-server

--- a/docker-compose.mysql.yml
+++ b/docker-compose.mysql.yml
@@ -1,0 +1,13 @@
+version: '3'
+services:
+  mysql:
+    container_name: mc-mysql
+    image: mysql:5.7.21
+    ports:
+      - "3307:3306"
+    volumes:
+      - ./mysql/conf.d/my.cnf:/etc/mysql/conf.d/my.cnf
+      - ./mysql_entrypoint:/docker-entrypoint-initdb.d
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: mc_dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,5 @@
-version: '2.3'
+version: '3'
 services:
-  mysql:
-    image: mysql:5.7.21
-    ports:
-      - "3307:3306"
-    volumes:
-      - ./mysql/conf.d/my.cnf:/etc/mysql/conf.d/my.cnf
-      - ./mysql/data:/var/lib/mysql
-      - ./mysql_entrypoint:/docker-entrypoint-initdb.d
-      - ./mysql/connection/:/var/run/mysqld/
-    environment:
-      MYSQL_ROOT_PASSWORD: root
-      MYSQL_DATABASE: mc_dev
   # Redis
   redis:
     build:
@@ -58,11 +46,9 @@ services:
       - ./web/impact/media:/media:ro
       - ./web/scripts/mysqlwait.sh:/usr/bin/mysqlwait.sh
     depends_on:
-      - mysql
       - mentor_directory
       - assets
     links:
-      - mysql
       - redis
     env_file:
       - .env
@@ -72,9 +58,7 @@ services:
     image: "python:3.6"
     depends_on:
       - web
-      - mysql
     links:
-      - mysql
       - redis
       - web
     command: >
@@ -87,3 +71,9 @@ services:
         echo \"BUILDING FRONTEND...\"
         sleep 5
       done; echo \"FRONTEND BUILD COMPLETE - visit http://localhost:1234 in a browser\";"
+
+
+networks:
+  default:
+    external:
+      name: impact-api_default


### PR DESCRIPTION
#### Changes introduced in [AC-6428](https://masschallenge.atlassian.net/browse/AC-6428)
- create mysql docker-compose file
- remove mysql service from impact docker-compose file
- use v3 in old docker-compose file
- connect old docker-compose file to impact-api_default network
- remove .gitkeep from dir we dont use anymore
- add ensure-mysql and kill-exited-containers target to makefile
- ensure targets run services that they depend on

#### How to test
to do a more targeted test
- while on development
- run `make shutdown--all-vms`
- checkout this branch on impact and accelerate
- run `make run-all-servers`
- now run tests and see improved test times

to do more general testing, this may be a bit tedious but may be the best way to test env changes i.e. using the changes in your daily workflow
- while on development
- run `make shutdown--all-vms`
- checkout this branch on impact and accelerate
- run `git reset --soft HEAD~1; git reset HEAD .` on both impact and accelerate
   - the above will allow you to keep the changes in this branch as you do your daily work
- now when doing your own work, you will have to 
   - `git stash`
   - `git checkout <the-branch-you-want-to>`
   - `git stash pop`
- also you will have to be a lot more selective when adding changes to commit i.e. you can't do `git add .` since this will also add changes from this branch.

Feel free to choose the approach that works best for you


#### Note
This PR and its [sibling](https://github.com/masschallenge/accelerate/pull/2072) are tightly coupled, merge only when both have been approved