### PR TITLE
[AC-6438] Put Program Family Interest on the User Calls in the API

### DIFF
--- a/web/impact/impact/tests/contexts/user_context.py
+++ b/web/impact/impact/tests/contexts/user_context.py
@@ -19,12 +19,16 @@ class UserContext(object):
                  user_type="ENTREPRENEUR",
                  primary_industry=None,
                  additional_industries=None,
-                 functional_expertise=None):
+                 functional_expertise=None,
+                 program_families=[]):
         user = UserFactory(date_joined=(timezone.now() + timedelta(-10)))
         self.user = user
+        self.program_families = program_families
         self.baseprofile = BaseProfileFactory(user=user, user_type=user_type)
         if user_type == "ENTREPRENEUR":
-            self.profile = EntrepreneurProfileFactory(user=user)
+            self.profile = EntrepreneurProfileFactory(
+                user=user,
+                program_families=self.program_families)
             user.entrepreneurprofile = self.profile
         elif user_type == "EXPERT":
             self.primary_industry = primary_industry or IndustryFactory()
@@ -34,7 +38,8 @@ class UserContext(object):
                 user=self.user,
                 primary_industry=self.primary_industry,
                 additional_industries=self.additional_industries,
-                functional_expertise=self.functional_expertise)
+                functional_expertise=self.functional_expertise,
+                program_families=self.program_families)
             user.expertprofile = self.profile
         elif user_type == "MEMBER":
             self.profile = MemberProfileFactory(user=self.user)

--- a/web/impact/impact/tests/test_user_detail_view.py
+++ b/web/impact/impact/tests/test_user_detail_view.py
@@ -166,6 +166,32 @@ class TestUserDetailView(APITestCase):
             assert all([expertise.id in functional_expertise_ids
                         for expertise in functional_expertise])
 
+    def test_get_expert_with_program_family_interests(self):
+        program_families = ProgramFamilyFactory.create_batch(2)
+        context = UserContext(user_type=EXPERT_USER_TYPE,
+                              program_families=program_families)
+        user = context.user
+        with self.login(email=self.basic_user().email):
+            url = reverse(UserDetailView.view_name, args=[user.id])
+            response = self.client.get(url)
+            program_family_ids = [
+                datum["id"] for datum in response.data["program_families"]]
+            assert all([program_family.id in program_family_ids
+                        for program_family in program_families])
+
+    def test_get_entrepreneur_with_program_family_interests(self):
+        program_families = ProgramFamilyFactory.create_batch(2)
+        context = UserContext(user_type=ENTREPRENEUR_USER_TYPE,
+                              program_families=program_families)
+        user = context.user
+        with self.login(email=self.basic_user().email):
+            url = reverse(UserDetailView.view_name, args=[user.id])
+            response = self.client.get(url)
+            program_family_ids = [
+                datum["id"] for datum in response.data["program_families"]]
+            assert all([program_family.id in program_family_ids
+                        for program_family in program_families])
+
     def test_get_with_no_profile(self):
         context = UserContext(user_type=ENTREPRENEUR_USER_TYPE)
         user = context.user

--- a/web/impact/impact/v1/helpers/__init__.py
+++ b/web/impact/impact/v1/helpers/__init__.py
@@ -21,19 +21,27 @@ from impact.v1.helpers.model_helper import (
     OPTIONAL_INTEGER_FIELD,
     OPTIONAL_STRING_FIELD,
     OPTIONAL_URL_FIELD,
+    PHONE_FIELD,
+    PHONE_REGEX,
     PK_FIELD,
     REQUIRED_STRING_FIELD,
+    TWITTER_REGEX,
     json_array,
     json_list_wrapper,
     json_object,
     json_simple_list,
+    merge_fields,
+    serialize_list_field,
+    ModelHelper,
 )
 from impact.v1.helpers.validators import (
     INVALID_INTEGER_ERROR,
+    INVALID_URL_ERROR,
     validate_boolean,
     validate_choices,
     validate_regex,
     validate_string,
+    validate_url,
 )
 from impact.v1.helpers.organization_helper import (
     COULD_BE_STARTUP_CHECK,
@@ -41,6 +49,10 @@ from impact.v1.helpers.organization_helper import (
     ORGANIZATION_FIELDS,
     ORGANIZATION_USER_FIELDS,
     OrganizationHelper,
+)
+from impact.v1.helpers.program_family_helper import (
+    PROGRAM_FAMILY_FIELDS,
+    ProgramFamilyHelper,
 )
 from impact.v1.helpers.profile_helper import (
     COULD_BE_EXPERT_CHECK,
@@ -68,10 +80,6 @@ from impact.v1.helpers.program_helper import (
 from impact.v1.helpers.program_cycle_helper import (
     PROGRAM_CYCLE_FIELDS,
     ProgramCycleHelper,
-)
-from impact.v1.helpers.program_family_helper import (
-    PROGRAM_FAMILY_FIELDS,
-    ProgramFamilyHelper,
 )
 from impact.v1.helpers.credit_code_helper import (
     CREDIT_CODE_FIELDS,

--- a/web/impact/impact/v1/helpers/profile_helper.py
+++ b/web/impact/impact/v1/helpers/profile_helper.py
@@ -15,13 +15,10 @@ from accelerator.models import (
     ProgramFamily,
 )
 
-from impact.v1.helpers.functional_expertise_helper import (
-    FunctionalExpertiseHelper,
-)
-from impact.v1.helpers.industry_helper import IndustryHelper
-from impact.v1.helpers.model_helper import (
+from impact.v1.helpers import (
     BOOLEAN_FIELD,
-    ModelHelper,
+    INVALID_URL_ERROR,
+    MPTT_TYPE,
     PHONE_FIELD,
     PHONE_REGEX,
     OPTIONAL_STRING_FIELD,
@@ -29,16 +26,16 @@ from impact.v1.helpers.model_helper import (
     json_array,
     merge_fields,
     serialize_list_field,
-)
-from impact.v1.helpers.validators import (
-    INVALID_URL_ERROR,
     validate_boolean,
     validate_choices,
     validate_regex,
     validate_string,
     validate_url,
+    FunctionalExpertiseHelper,
+    IndustryHelper,
+    ModelHelper,
+    ProgramFamilyHelper,
 )
-from impact.v1.helpers.mptt_model_helper import MPTT_TYPE
 
 COULD_BE_EXPERT_CHECK = "could_be_expert"
 COULD_BE_NON_MEMBER_CHECK = "could_be_non_member"
@@ -414,6 +411,12 @@ class ProfileHelper(ModelHelper):
         return serialize_list_field(self.subject,
                                     "functional_expertise",
                                     FunctionalExpertiseHelper)
+
+    @property
+    def program_families(self):
+        return serialize_list_field(self.subject,
+                                    "program_families",
+                                    ProgramFamilyHelper)
 
     @property
     def expert_category(self):

--- a/web/impact/impact/v1/helpers/user_helper.py
+++ b/web/impact/impact/v1/helpers/user_helper.py
@@ -75,6 +75,7 @@ USER_FIELDS = {
     "linked_in_url": OPTIONAL_URL_FIELD,
     "personal_website_url": PERSONAL_WEBSITE_URL_FIELD,
     "functional_expertise": MPTT_ARRAY_FIELD,
+    "program_families": MPTT_ARRAY_FIELD,
 }
 
 


### PR DESCRIPTION
### Changes introduced in [AC-6438](https://masschallenge.atlassian.net/browse/AC-6438):
- Add program families to user payload

### How to test
- Checkout to this branch and run impact locally
- Make a request to `http://localhost:8000/api/v1/user/?limit=5` **Note** this view may result in a 502 if limit is not set
- Notice that user objects include the program_families field with objects if they exist or an empty list
- Make a request using user id to get user details for a specific user e.g `http://localhost:8000/api/v1/user/15/`. Notice that user objects include the program_families field with objects if they exist or an empty list