### PR TITLE
[AC-6483] Handle case where no submitted applications of a judging rounds application type exist

### DIFF
--- a/web/impact/impact/tests/test_analyze_judging_round_view.py
+++ b/web/impact/impact/tests/test_analyze_judging_round_view.py
@@ -210,6 +210,18 @@ class TestAnalyzeJudgingRoundView(APITestCase):
                     assert commitment.capacity - 1 == result[
                         'remaining_capacity']
 
+    def test_get_when_no_applications_for_round(self):
+        context = AnalyzeJudgingContext(add_application=False)
+        judging_round_id = context.criterion.judging_round.id
+        email = self.global_operations_manager(program_family).email
+        with self.login(email=email):
+            url = reverse(AnalyzeJudgingRoundView.view_name,
+                          args=[judging_round_id])
+            response = self.client.get(url)
+            results = response.data["results"]
+            for result in results:
+                assert result["needy_applications"] == 0    
+
 
 def _industry_options(context):
     return [app.startup.primary_industry.name

--- a/web/impact/impact/tests/test_analyze_judging_round_view.py
+++ b/web/impact/impact/tests/test_analyze_judging_round_view.py
@@ -213,6 +213,7 @@ class TestAnalyzeJudgingRoundView(APITestCase):
     def test_get_when_no_applications_for_round(self):
         context = AnalyzeJudgingContext(add_application=False)
         judging_round_id = context.criterion.judging_round.id
+        program_family = context.program.program_family
         email = self.global_operations_manager(program_family).email
         with self.login(email=email):
             url = reverse(AnalyzeJudgingRoundView.view_name,

--- a/web/impact/impact/tests/test_analyze_judging_round_view.py
+++ b/web/impact/impact/tests/test_analyze_judging_round_view.py
@@ -221,7 +221,7 @@ class TestAnalyzeJudgingRoundView(APITestCase):
             response = self.client.get(url)
             results = response.data["results"]
             for result in results:
-                assert result["needy_applications"] == 0    
+                assert result["needy_apps"] == 0    
 
 
 def _industry_options(context):

--- a/web/impact/impact/v1/helpers/matching_criterion_helper.py
+++ b/web/impact/impact/v1/helpers/matching_criterion_helper.py
@@ -29,6 +29,8 @@ class MatchingCriterionHelper(CriterionHelper):
     def _check_cache(self, apps):
         if not self._app_ids_to_targets and apps.count() > 0:
             self.calc_app_ids_to_targets(apps)
+        else:
+            self._app_ids_to_targets = {}
 
     def judge_matches_option(self, judge_data, option):
         return option == judge_data.get(self.judge_field)

--- a/web/impact/impact/v1/helpers/matching_criterion_helper.py
+++ b/web/impact/impact/v1/helpers/matching_criterion_helper.py
@@ -27,7 +27,7 @@ class MatchingCriterionHelper(CriterionHelper):
         return self._target_counts
 
     def _check_cache(self, apps):
-        if not self._app_ids_to_targets:
+        if not self._app_ids_to_targets and apps.count() > 0:
             self.calc_app_ids_to_targets(apps)
 
     def judge_matches_option(self, judge_data, option):

--- a/web/impact/impact/v1/helpers/matching_program_criterion_helper.py
+++ b/web/impact/impact/v1/helpers/matching_program_criterion_helper.py
@@ -72,9 +72,9 @@ class MatchingProgramCriterionHelper(MatchingCriterionHelper):
     def analysis_annotate_fields(self):
         return {"program": F(self.judge_field)}
 
-    def analysis_tally(self, app_id, db_value, cache, **kwargs):
-        if not self._app_ids_to_pf_name:
-            self.calc_app_ids_to_targets(kwargs["apps"])
+    def analysis_tally(self, app_id, db_value, cache, apps):
+        if not self._app_ids_to_pf_name and apps.count() > 0:
+            self.calc_app_ids_to_targets(apps)
 
         program_family = self._app_ids_to_pf_name.get(app_id)
         judge_program = db_value["program"]

--- a/web/impact/impact/v1/helpers/matching_program_criterion_helper.py
+++ b/web/impact/impact/v1/helpers/matching_program_criterion_helper.py
@@ -77,7 +77,7 @@ class MatchingProgramCriterionHelper(MatchingCriterionHelper):
         if not self._app_ids_to_pf_name and apps.count() > 0:
             self.calc_app_ids_to_targets(apps)
         else:
-            self._app_ids_to_pf_name = {}
+            self._app_ids_to_targets = {}
 
         program_family = self._app_ids_to_pf_name.get(app_id)
         judge_program = db_value["program"]

--- a/web/impact/impact/v1/helpers/matching_program_criterion_helper.py
+++ b/web/impact/impact/v1/helpers/matching_program_criterion_helper.py
@@ -72,9 +72,12 @@ class MatchingProgramCriterionHelper(MatchingCriterionHelper):
     def analysis_annotate_fields(self):
         return {"program": F(self.judge_field)}
 
-    def analysis_tally(self, app_id, db_value, cache, apps):
+    def analysis_tally(self, app_id, db_value, cache, **kwargs):
+        apps = kwargs.get("apps")
         if not self._app_ids_to_pf_name and apps.count() > 0:
             self.calc_app_ids_to_targets(apps)
+        else:
+            self._app_ids_to_pf_name = {}
 
         program_family = self._app_ids_to_pf_name.get(app_id)
         judge_program = db_value["program"]


### PR DESCRIPTION
[JIRA](https://masschallenge.atlassian.net/browse/AC-6483)

to test
* load a clean db with `make load-db`
* login with demo admin, give yourself exec/md clearance for all program families using the following in django-shell
```python
from accelerator.models import *
d = User.objects.get(email__startswith="demoadmin")
for pf in ProgramFamily.objects.all():
    Clearance.objects.create(user=d, level=CLEARANCE_LEVEL_EXEC_MD, program_family=pf)
```
* check out `development`
* judging round 48 has existing criteria, so it's a good test case on clean db. run the following in the django-shell to set the applications to the state that causes the error
* first, hit the following endpoint, it should return useful data, note that the 'needy_apps' field in each result is a nonzero number
http://localhost/api/v1/analyze_judging_round/48
* next, unsubmit the existing applications for that round
```
jr = JudgingRound.objects.get(pk="48")
Application.objects.filter(application_type=jr.application_type).filter(application_status="SUBMITTED").update(application_status='hidden')
```
* hit the analyze endpoint again, it should 500 
http://localhost/api/v1/analyze_judging_round/48
* check out this branch and refresh
* the api should respond without error, the 'needy_apps' field on each result should be '0'
* finally, reverse the unsubmit and see that the view still works:
```
Application.objects.filter(application_type=jr.application_type).filter(application_status='hidden').update(application_status='SUBMITTED')
```

There is a [Django Accelerator PR here](https://github.com/masschallenge/django-accelerator/pull/150) to support the unit test