### PR TITLE
AC-6522: `make release` fails if impact-api is on development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -427,8 +427,6 @@ release-list:
 
 
 release:
-	@git commit --allow-empty -m "generating a new release"
-	@git push
 	@bash create_release.sh
 
 

--- a/create_release.sh
+++ b/create_release.sh
@@ -1,6 +1,8 @@
 
 # if a tag hasn't been passed in as a parameter, create a semantic one
 if [ ! -n "$tag" ]; then
+    git commit --allow-empty -m "generating a new release"
+    git push
     docker run --rm  -v"$(pwd)":/app  -ti semantic-release  -- semantic-release version
     export pwd=$(pwd)
     export TAG=$(docker run --tty=false --rm  -v$pwd:/app  -i semantic-release -- semantic-release version --noop | grep "Current version: " | cut -d ' ' -f 3 | sed -e "s/\r//")
@@ -14,7 +16,6 @@ fi
 
 echo $TAG
 
-git push
 git push --tags
 cd ../django-accelerator && git tag "v${TAG}"
 git push --tags 


### PR DESCRIPTION
#### Changes introduced in [AC-6522](https://masschallenge.atlassian.net/browse/AC-6522)
- only create phantom commit when releasing the master branch

#### How to test
**Do not checkout this branch**
while on impact
- run `git fetch` to get the upstream changes
- be sure to be on development
- cherry-pick the change in this commit with `git cherry-pick ebbd9c3`
- run `make release tag=AC-6522-<your-name>`

Notice all the repos are tagged with no error despite impact being on development.

#### To undo the cherry-pick
- per review suggestion you can use `git reset --hard origin/development`

and below you can see my blunt instrument for undoing the cherrypick :)
- run `git reset --hard $(git log --oneline -2 | awk '{print $1}' | tail -1)` to undo the cherry-picked commit