### PR TITLE
AC-6377: Build new people directory page in front-end repo (React + SUI)

### DIFF
--- a/web/impact/impact/permissions/directory_access_permissions.py
+++ b/web/impact/impact/permissions/directory_access_permissions.py
@@ -2,6 +2,9 @@ from impact.permissions import BasePermission
 from accelerator_abstract.models import ACTIVE_PROGRAM_STATUS
 from accelerator.models import UserRole
 from accelerator_abstract.models.base_user_utils import is_employee
+from accelerator_abstract.models.base_permission_checks import (
+    base_accelerator_check
+)
 
 
 class DirectoryAccessPermissions(BasePermission):
@@ -11,7 +14,11 @@ class DirectoryAccessPermissions(BasePermission):
         allowed_roles = UserRole.FINALIST_USER_ROLES + [
             UserRole.MENTOR, UserRole.ALUM
         ]
-        return request.user.programrolegrant_set.filter(
-            program_role__program__program_status=ACTIVE_PROGRAM_STATUS,
-            program_role__user_role__name__in=allowed_roles,
-        ).exists() or is_employee(request.user)
+        return (
+            request.user.programrolegrant_set.filter(
+                program_role__program__program_status=ACTIVE_PROGRAM_STATUS,
+                program_role__user_role__name__in=allowed_roles,
+            ).exists() or
+            is_employee(request.user) or
+            base_accelerator_check(request.user)
+        )

--- a/web/impact/impact/tests/test_algolia_api_key_view.py
+++ b/web/impact/impact/tests/test_algolia_api_key_view.py
@@ -19,13 +19,11 @@ from accelerator.tests.factories import (
 from accelerator_abstract.models import (
     ACTIVE_PROGRAM_STATUS,
     UPCOMING_PROGRAM_STATUS,
-    ENDED_PROGRAM_STATUS,
-    ENTREPRENEUR_USER_TYPE
+    ENDED_PROGRAM_STATUS
 )
 from impact.tests.api_test_case import APITestCase
 from impact.tests.factories import UserFactory
 from impact.views import AlgoliaApiKeyView
-from impact.views.algolia_api_key_view import IS_CONFIRMED_MENTOR_FILTER
 
 User = get_user_model()  # pylint: disable=invalid-name
 

--- a/web/impact/impact/tests/test_algolia_api_key_view.py
+++ b/web/impact/impact/tests/test_algolia_api_key_view.py
@@ -57,7 +57,7 @@ def _create_batch_program_and_named_group(status, batch_size):
 class TestAlgoliaApiKeyView(APITestCase):
     client_class = APIClient
     user_factory = UserFactory
-    url = reverse(AlgoliaApiKeyView.view_name)
+    url = "{}?index=mentor".format(reverse(AlgoliaApiKeyView.view_name))
 
     def test_logged_in_user_with_role_grants_in_ended_programs_gets_403(self):
         program = _create_batch_program_and_named_group(

--- a/web/impact/impact/views/algolia_api_key_view.py
+++ b/web/impact/impact/views/algolia_api_key_view.py
@@ -5,6 +5,8 @@ import time
 
 from algoliasearch import algoliasearch
 from django.conf import settings
+from django.core.exceptions import PermissionDenied
+
 from rest_framework import permissions
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -24,6 +26,10 @@ from accelerator_abstract.models import (
 from accelerator_abstract.models.base_user_utils import (
     is_entrepreneur,
     is_employee,
+)
+
+from accelerator_abstract.models.base_permission_checks import (
+    base_accelerator_check
 )
 
 from impact.permissions import DirectoryAccessPermissions
@@ -70,7 +76,10 @@ def _get_search_key(request):
 def _get_filters(request):
 
     if request.GET['index'] == 'people':
-        return IS_TEAM_MEMBER_FILTER
+        if base_accelerator_check(request.user):
+            return IS_TEAM_MEMBER_FILTER
+        else:
+            raise PermissionDenied()
 
     # an empty filter i.e. [], means the user sees all mentors
     if is_employee(request.user):

--- a/web/impact/impact/views/algolia_api_key_view.py
+++ b/web/impact/impact/views/algolia_api_key_view.py
@@ -19,19 +19,18 @@ from accelerator.models import (
 from accelerator_abstract.models import (
     ACTIVE_PROGRAM_STATUS,
     ENDED_PROGRAM_STATUS,
-    ENTREPRENEUR_USER_TYPE,
 )
 
 from accelerator_abstract.models.base_user_utils import (
     is_entrepreneur,
-    is_employee,   
+    is_employee,
 )
 
 from impact.permissions import DirectoryAccessPermissions
 
 IS_CONFIRMED_MENTOR_FILTER = "is_confirmed_mentor:true"
 CONFIRMED_MENTOR_IN_PROGRAM_FILTER = 'confirmed_mentor_programs:"{program}"'
-IS_TEAM_MEMBER_FILTER = 'is_team_member:true'
+IS_TEAM_MEMBER_FILTER = 'is_team_member:true AND has_a_finalist_role:true'
 
 
 class AlgoliaApiKeyView(APIView):
@@ -92,11 +91,12 @@ def _get_filters(request):
         )
 
         program_groups = Program.objects.filter(
-            programrole__in=user_program_roles_as_participant).values_list(
+            programrole__in=user_program_roles_as_participant
+        ).values_list(
             'mentor_program_group', flat=True).distinct()
         program_families = ProgramFamily.objects.filter(
-            programs__mentor_program_group__in=program_groups).prefetch_related(
-            'programs').distinct()
+            programs__mentor_program_group__in=program_groups
+        ).prefetch_related('programs').distinct()
         facet_filters = _facet_filters(program_families)
         if len(facet_filters) > 0:
             return " OR ".join(facet_filters)


### PR DESCRIPTION
#### Changes introduced in [AC-6377](https://masschallenge.atlassian.net/browse/AC-6377)
- alter filter based on which directory were getting from algolia

#### How to test
this is deployed on test2
- visit test2 and log in as staff
- now visit https://test2.masschallenge.org/people/ and behold the new people directory

if local testing is your thing
- checkout this branch on the directory and impact
- ensure to be logged in on accelerate
- visit localhost:1234/people and behold the new people directory

#### Note
- Tests on new filter logic missing, not blocking review though
- there are 3 related PRs ([accelerate](https://github.com/masschallenge/accelerate/pull/2117), [accelerator](https://github.com/masschallenge/django-accelerator/pull/163), [directory](https://github.com/masschallenge/directory/pull/136)). The accelerator PR should be merged in first, then the order of the merge is not important but it's important that a deploy is not done when changes have not been completely merged across all repos.