### PR TITLE
[AC-6593] Lower ASSIGNMENT_DISCOUNT to 0.45 in Application Allocator

### DIFF
--- a/web/impact/impact/v1/views/allocate_applications_view.py
+++ b/web/impact/impact/v1/views/allocate_applications_view.py
@@ -33,7 +33,7 @@ ALREADY_ASSIGNED_ERROR = "{judge} is already assigned to {count} applications"
 JUDGING_ROUND_INACTIVE_ERROR = "Judging round {} is not active"
 NO_APP_LEFT_FOR_JUDGE = "{} has provided feedback on all applications"
 NO_DATA_FOR_JUDGE = "Judging round {judging_round} has no data for {judge}"
-ASSIGNMENT_DISCOUNT = 0.85
+ASSIGNMENT_DISCOUNT = 0.45
 
 
 class AllocateApplicationsView(ImpactView):


### PR DESCRIPTION
[JIRA](https://masschallenge.atlassian.net/browse/AC-6593)

Changes in AC-6593:
- ASSIGNMENT_DISCOUNT is a constant that allocator uses to determine if a judge need be assigned another application. It is currently too high and this is resulting in an in-optimal allocation of applications. We've decided to lower it to improve this problem. 

To test:
 - TBD