### PR TITLE
AC-5903: re-name 'directory' repo to 'front-end'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,7 +192,7 @@ db_cache/
 web/impact/schema.json
 web/impact/categories.json
 web/impact/confusables.json
-web/impact/templates/directory.html
+web/impact/templates/front-end.html
 /mysql_entrypoint/000*
 !/mysql_entrypoint/0001*
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
     - RELEASE_TAG=$(git tag -l --points-at HEAD | head -n1)
     - BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
     - DJANGO_ACCELERATOR_REVISION=`./infer_repository_revision.sh "$BRANCH" https://www.github.com/masschallenge/django-accelerator.git`
-    - MENTOR_DIRECTORY_REVISION=`./infer_repository_revision.sh "$BRANCH" https://$GITHUB_ACCESS_TOKEN@github.com/masschallenge/directory.git`
+    - FRONT_END_REVISION=`./infer_repository_revision.sh "$BRANCH" https://$GITHUB_ACCESS_TOKEN@github.com/masschallenge/front-end.git`
 
 before_install:
 - echo -e "machine github.com\n  login $GITHUB_ACCESS_TOKEN" >> ~/.netrc
@@ -36,13 +36,13 @@ before_script:
 - for key in $keys; do echo "$key=${!key}" >> .prod.env; echo "" >> .prod.env; done
 - echo "DATABASE_URL=mysql://${DATABASE_USER}:${DATABASE_PASSWORD}@${DATABASE_HOST}/${DATABASE_NAME}" >> .prod.env
 - echo "" >> .prod.env
-- git clone https://$GITHUB_ACCESS_TOKEN@github.com/masschallenge/directory -b $MENTOR_DIRECTORY_REVISION ../directory
-- cp .prod.env ../directory/.env
+- git clone https://$GITHUB_ACCESS_TOKEN@github.com/masschallenge/front-end -b $FRONT_END_REVISION ../front-end
+- cp .prod.env ../front-end/.env
 - cp .prod.env .env
-- docker build --no-cache -t masschallenge/mentor-directory ../directory
-- docker run -v $(pwd)/../directory/dist:/usr/src/app/dist -t masschallenge/mentor-directory
-- cp -r ../directory/dist web/impact/static/directory-dist
-- cp ../directory/dist/index.html web/impact/templates/directory.html
+- docker build --no-cache -t masschallenge/front-end ../front-end
+- docker run -v $(pwd)/../front-end/dist:/usr/src/app/dist -t masschallenge/front-end
+- cp -r ../front-end/dist web/impact/static/front-end-dist
+- cp ../front-end/dist/index.html web/impact/templates/front-end.html
 - docker network create impact-api_default 
 - docker-compose -f docker-compose.travis.yml build --no-cache --build-arg DJANGO_ACCELERATOR_REVISION=$DJANGO_ACCELERATOR_REVISION
 - docker-compose -f docker-compose.travis.yml up -d

--- a/Makefile
+++ b/Makefile
@@ -224,9 +224,9 @@ code-check:
 ACCELERATE = ../accelerate
 DJANGO_ACCELERATOR = ../django-accelerator
 IMPACT_API = ../impact-api
-DIRECTORY = ../directory
+FRONT_END = ../front-end
 SEMANTIC = ../semantic-ui-theme
-REPOS = $(ACCELERATE) $(DJANGO_ACCELERATOR) $(DIRECTORY) $(SEMANTIC) $(IMPACT_API) 
+REPOS = $(ACCELERATE) $(DJANGO_ACCELERATOR) $(FRONT_END) $(SEMANTIC) $(IMPACT_API) 
 
 # Database migration related targets
 
@@ -270,7 +270,7 @@ checkout:
 watch-frontend stop-frontend: process-exists=$(shell ps -ef | egrep -h "./watch_frontend.sh|parcel watch" | grep -v "grep" | awk '{print $$2}')
 watch-frontend:
 	@if [ -z "$(process-exists)" ]; then \
-		cd $(DIRECTORY) && nohup bash -c "./watch_frontend.sh &" && cd $(IMPACT_API); \
+		cd $(FRONT_END) && nohup bash -c "./watch_frontend.sh &" && cd $(IMPACT_API); \
 	fi;
 
 stop-frontend:

--- a/create_release.sh
+++ b/create_release.sh
@@ -21,5 +21,5 @@ cd ../django-accelerator && git tag "v${TAG}"
 git push --tags 
 cd ../accelerate && git tag "v${TAG}"
 git push --tags
-cd ../directory && git tag "v${TAG}"
+cd ../front-end && git tag "v${TAG}"
 git push --tags

--- a/docker-compose.travis.yml
+++ b/docker-compose.travis.yml
@@ -44,7 +44,7 @@ services:
     volumes:
       - ./web/impact:/wwwroot
       - ./db_cache:/db_cache
-      - ../directory/dist:/wwwroot/static/directory-dist
+      - ../front-end/dist:/wwwroot/static/front-end-dist
       - ./web/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
       - ./web/impact/media:/media:ro
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,13 +18,13 @@ services:
       - ./web/impact/sass:/gulp/sass:cached
       - ./web/impact/static/css:/gulp/css:cached
       - ./web/impact/static/js:/gulp/js:cached
-  mentor_directory:
+  front-end:
     build:
       dockerfile: dev.Dockerfile
-      context: ../directory
+      context: ../front-end
     volumes:
-      - ../directory/dist:/usr/src/app/dist
-      - ../directory/src:/usr/src/app/src
+      - ../front-end/dist:/usr/src/app/dist
+      - ../front-end/src:/usr/src/app/src
     ports:
       - "1234:1234"
   # Web python
@@ -40,13 +40,13 @@ services:
     volumes:
       - ./web/impact:/wwwroot:cached
       - ../django-accelerator:/packages/src/django-accelerator:cached
-      - ../directory/dist:/wwwroot/static/directory-dist:cached
+      - ../front-end/dist:/wwwroot/static/front-end-dist:cached
       - ./db_cache:/db_cache:cached
       - ./web/nginx/nginx.conf:/etc/nginx/nginx.conf:cached
       - ./web/impact/media:/media:cached
       - ./web/scripts/mysqlwait.sh:/usr/bin/mysqlwait.sh:cached
     depends_on:
-      - mentor_directory
+      - front-end
       - assets
     links:
       - redis
@@ -67,7 +67,7 @@ services:
         echo \"BUILDING WEB...\"
         sleep 5
       done; echo \"WEB BUILD COMPLETE - visit http://localhost:8000 in a browser\";
-      until $$(curl --output /dev/null --silent --head --fail http://mentor_directory:1234); do
+      until $$(curl --output /dev/null --silent --head --fail http://front-end:1234); do
         echo \"BUILDING FRONTEND...\"
         sleep 5
       done; echo \"FRONTEND BUILD COMPLETE - visit http://localhost:1234 in a browser\";"

--- a/infer_repository_revision.sh
+++ b/infer_repository_revision.sh
@@ -9,9 +9,9 @@ if [[  (! -z $DJANGO_ACCELERATOR_REVISION) && $REPO_URL == *"django-accelerator"
   echo $DJANGO_ACCELERATOR_REVISION
   exit
 fi
-# allow for an override, if DIRECTORY_REVISION is already set in env.
-if [[ (! -z $DIRECTORY_REVISION) && $REPO_URL == *"directory"* ]];then
-  echo $DIRECTORY_REVISION
+# allow for an override, if FRONT_END_REVISION is already set in env.
+if [[ (! -z $FRONT_END_REVISION) && $REPO_URL == *"front-end"* ]];then
+  echo $FRONT_END_REVISION
   exit
 fi
 

--- a/web/impact/impact/urls.py
+++ b/web/impact/impact/urls.py
@@ -112,16 +112,16 @@ urls = [
         include('oauth2_provider.urls', namespace='oauth2_provider')),
     url(r'^schema/$', schema_view, name='schema'),
     url(r'^directory/(?:.*)$', TemplateView.as_view(
-        template_name='directory.html'),
+        template_name='front-end.html'),
         name="directory"),
     url(r'^allocator/(?:.*)$', TemplateView.as_view(
-        template_name='directory.html'),
+        template_name='front-end.html'),
         name="allocator"),
     url(r'^people/$', TemplateView.as_view(
-        template_name='directory.html'),
+        template_name='front-end.html'),
         name="entreprenuer_profile"),
     url(r'^people/(.*)/$', TemplateView.as_view(
-        template_name='directory.html'),
+        template_name='front-end.html'),
         name="entreprenuer_profile"),
     url(r'^openid/', include('oidc_provider.urls', namespace='oidc_provider')),
     url(r'^$', IndexView.as_view()),

--- a/web/scripts/mysqlwait.sh
+++ b/web/scripts/mysqlwait.sh
@@ -5,7 +5,7 @@ until `curl --output /dev/null --silent --head --fail http://web:8000`; do
 done
 echo "WEB BUILD COMPLETE - visit http://localhost:8000 in a browser"
 
-until `curl --output /dev/null --silent --head --fail http://mentor_directory:1234`; do
+until `curl --output /dev/null --silent --head --fail http://front-end:1234`; do
     echo "BUILDING FRONTEND..."
     sleep 5
 done

--- a/web/scripts/start.sh
+++ b/web/scripts/start.sh
@@ -8,9 +8,9 @@ if [ "${DJANGO_CONFIGURATION}" == "Dev" ]; then
   done
 fi
 
-if [ -e "/wwwroot/static/directory-dist/index.html" ]
+if [ -e "/wwwroot/static/front-end-dist/index.html" ]
 then
-	cp /wwwroot/static/directory-dist/index.html templates/directory.html
+	cp /wwwroot/static/front-end-dist/index.html templates/front-end.html
 fi
 
 python3 manage.py migrate --noinput


### PR DESCRIPTION
#### Changes introduced in [AC-5903](https://masschallenge.atlassian.net/browse/AC-5903)
- replace all occurences of directory (in reference to our repository) to front-end

#### How to test
On the local
- stop your impact
- rename your `directory` repo to `front-end`
- checkout AC-5903 in the front-end, accelerate and impact repos
- run `make delete-vms` to ensure your frontend is not already running
- run your impact, notice that all runs smoothly

On a test machine
I also deployed these changes to make sure our release process has not been damaged. This can be seen on test4, feel free to look around and do the needed QA.

#### Once merged
Every engineer will need to
- rename their `directory` repo to `front-end`
- change the origin of their front-end repo i.e. `git remote remove origin; git remove add origin git@github.com:masschallenge/front-end.git`

#### Note
There are 2 sibling PRs on [accelerate](https://github.com/masschallenge/accelerate/pull/2132) and the [front-end](https://github.com/masschallenge/directory/pull/142)
Once this is ready to merge, we should
- delete the current [`front-end`](https://github.com/masschallenge/front-end) repo that is being used for testing purposes
- change the name of the [`directory`](https://github.com/masschallenge/directory) repo to `front-end` on GitHub