### PR TITLE
AC-6332: "make checkout branch" command fails if branch has not been checked out locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,6 +163,8 @@ no_release_error_msg = RELEASE must be set.  E.g., 'make deploy RELEASE=1.2.3.4'
 
 .PHONY: $(targets) $(deprecated_targets)
 
+YELLOW=\033[0;33m
+NO_COLOR=\033[0m
 
 .env:
 	@touch .env
@@ -256,11 +258,17 @@ status:
 checkout:
 	@for r in $(REPOS) ; do \
 		cd $$r; \
-		git show-ref --verify --quiet refs/heads/$(branch); \
+		git fetch 2>/dev/null; \
+		if [ $$? -ne 0 ]; then \
+			echo "$(YELLOW)Fetching the latest from the remote failed, you may not be able to checkout an existing remote branch.$(NO_COLOR)"; \
+			echo "$(YELLOW)Check your internet connection if the checkout fails.$(NO_COLOR)"; \
+			echo ""; \
+		fi; \
+		git branch -a | egrep $(branch) > /dev/null; \
 		if [ $$? -eq 0 ]; then \
 			git -c 'color.ui=always' checkout $(branch) > /tmp/gitoutput 2>&1; \
 		else \
-			echo "$(branch) doesn't exist, checking out $(DEFAULT_BRANCH)..."; \
+			echo "$(YELLOW)$(branch) doesn't exist, checking out $(DEFAULT_BRANCH)...$(NO_COLOR)"; \
 			git -c 'color.ui=always' checkout $(DEFAULT_BRANCH) > /tmp/gitoutput 2>&1; \
 		fi; \
 		{ cat /tmp/gitoutput & git pull; } | sed "s|^|$$r: |"; \

--- a/Makefile
+++ b/Makefile
@@ -163,8 +163,6 @@ no_release_error_msg = RELEASE must be set.  E.g., 'make deploy RELEASE=1.2.3.4'
 
 .PHONY: $(targets) $(deprecated_targets)
 
-YELLOW=\033[0;33m
-NO_COLOR=\033[0m
 
 .env:
 	@touch .env
@@ -260,15 +258,15 @@ checkout:
 		cd $$r; \
 		git fetch 2>/dev/null; \
 		if [ $$? -ne 0 ]; then \
-			echo "$(YELLOW)Fetching the latest from the remote failed, you may not be able to checkout an existing remote branch.$(NO_COLOR)"; \
-			echo "$(YELLOW)Check your internet connection if the checkout fails.$(NO_COLOR)"; \
+			echo "Fetching the latest from the remote failed, you may not be able to checkout an existing remote branch."; \
+			echo "Check your internet connection if the checkout fails."; \
 			echo ""; \
 		fi; \
 		git branch -a | egrep $(branch) > /dev/null; \
 		if [ $$? -eq 0 ]; then \
 			git -c 'color.ui=always' checkout $(branch) > /tmp/gitoutput 2>&1; \
 		else \
-			echo "$(YELLOW)$(branch) doesn't exist, checking out $(DEFAULT_BRANCH)...$(NO_COLOR)"; \
+			echo "$(branch) doesn't exist, checking out $(DEFAULT_BRANCH)..."; \
 			git -c 'color.ui=always' checkout $(DEFAULT_BRANCH) > /tmp/gitoutput 2>&1; \
 		fi; \
 		{ cat /tmp/gitoutput & git pull; } | sed "s|^|$$r: |"; \


### PR DESCRIPTION
#### Changes introduced in [AC-6332](https://masschallenge.atlassian.net/browse/AC-6332)
- ensure remote branches can be checked out by 'make checkout'
- add syntax highlighting to catch users attention on important text

#### How to test
There is currently a **AC-6332** branch on the accelerate and impact remote
- while on the development branch on impact
- run `make checkout branch=AC-6332`, note that it fails to checkout the branch on accelerate (and impact)
- now checkout this branch on impact
- try and run `make checkout branch=AC-6332` again and notice we have now checked out the AC-6332 branch on accelerate which was not previously possible.

As a bonus, text colour has been added to catch a users attention on important text.

#### Note
Whoever does the merge of this PR, please cleanup the AC-6332 remote on accelerate i.e. run `git push --delete origin AC-6332` on accelerate.