### PR TITLE
[AC-6635] make release issue: tags on impact-api not getting pushed

### DIFF
--- a/create_release.sh
+++ b/create_release.sh
@@ -9,13 +9,13 @@ if [ ! -n "$tag" ]; then
 else
     echo "You passed in '$tag' as the custom tag"
     # TR == test release
-    echo "We're going to refactor the tag into 'TR-$tag' to avoid any conflicts."
-    TAG="TR-$tag"
-    git tag "v${TAG}"
+    echo "Renaming as 'TR-$tag' to avoid potential conflicts."
+    export TAG="TR-$tag"
 fi
 
 echo $TAG
 
+git tag "v${TAG}"
 git push --tags
 cd ../django-accelerator && git tag "v${TAG}"
 git push --tags 


### PR DESCRIPTION
#### Changes introduced in [AC-6635]()
- tag impact before pushing tags
- minor cleanup to custom tagging mechanism

#### How to test
To test this we could make a release and perform a deploy

--

OR

--

This could be tested locally (but in my opinion, with some hustle) by
- checking this branch out
- running `make release`
- note that a new tag is pushed to impact-api
- another user doing `git fetch` locally should be able to get this tag from the remote

To cleanup
- on accelerate run `make delete-tag tag=<the-tag-that-was-created>`, this will delete the new tag locally and on the remote
- users that tested this branch out should first do this