### PR TITLE
AC-6642: Lock down algoliasearch dependency on impact-api

### DIFF
--- a/web/impact/requirements/base.txt
+++ b/web/impact/requirements/base.txt
@@ -8,7 +8,7 @@ hiredis==0.2.0
 markdown==2.6.11
 mysqlclient==1.3.14
 oauthlib
-algoliasearch
+algoliasearch<2.0.0
 newrelic
 
 # Misc


### PR DESCRIPTION
#### Changes introduced in [AC-6642](https://masschallenge.atlassian.net/browse/AC-6642)
- lock algoliaseatch version to < 2.0.0

#### How to test
- a green travis build here should be enough