### PR TITLE
[AC-6077] Remove capacity update logic

### DIFF
--- a/web/impact/impact/tests/test_allocate_applications_view.py
+++ b/web/impact/impact/tests/test_allocate_applications_view.py
@@ -94,19 +94,6 @@ class TestAllocateApplicationsView(APITestCase):
             assert [NO_APP_LEFT_FOR_JUDGE.format(context.judge.email)
                     in response.data]
 
-    def test_get_adds_capacity_and_quota(self):
-        context = AnalyzeJudgingContext()
-        judging_round = context.judging_round
-        commitment = context.judges[0].judgeroundcommitment_set.first()
-        with self.login(email=self.basic_user().email):
-            url = reverse(AllocateApplicationsView.view_name,
-                          args=[judging_round.id, context.judge.id])
-            response = self.client.get(url)
-            assert response.status_code == 200
-            commitment.refresh_from_db()
-            assert commitment.capacity > 0
-            assert commitment.current_quota > 0
-
     def test_get_for_unknown_judge_fails(self):
         context = AnalyzeJudgingContext()
         judging_round = context.judging_round

--- a/web/impact/impact/v1/views/allocate_applications_view.py
+++ b/web/impact/impact/v1/views/allocate_applications_view.py
@@ -192,7 +192,6 @@ class AllocateApplicationsView(ImpactView):
             assignment_status=ASSIGNED_PANEL_ASSIGNMENT_STATUS)
 
     def _make_panel(self, choices):
-        self._enable_additional_assignments(len(choices))
         panel = Panel.objects.create(status=ACTIVE_PANEL_STATUS)
         JudgePanelAssignment.objects.create(
             judge=self.judge,
@@ -204,17 +203,6 @@ class AllocateApplicationsView(ImpactView):
                 application_id=choice,
                 panel=panel,
                 scenario=self.scenario)
-
-    def _enable_additional_assignments(self, desired):
-        goal = self._judge_assignment_count() + desired
-        commitment = self.judge.judgeroundcommitment_set.filter(
-            judging_round=self.judging_round).first()
-        if commitment.current_quota is None:
-            commitment.current_quota = 0
-        if commitment:
-            commitment.capacity = max(goal, commitment.capacity)
-            commitment.current_quota = max(goal, commitment.current_quota)
-            commitment.save()
 
     def _judge_assignment_count(self):
         scenarios = Scenario.objects.filter(


### PR DESCRIPTION
Per discussion with Jeff, determined that the correct thing is to simply remove the capacity update logic and associated tests, as it is not needed. 

Changed behavior: 
when a judge self-allocates in a dynamically-allocated round, their capacity is not changed even if they go above their originally stated capacity. 

Capacity is reflected on the user's /panels page, as in the screen shot. 

Testing hints: 
pick a judging round, say pk=48
set it to allow_dynamic_allocation
update is_active to True and end_date_time to > now 
pick a JudgeRoundCommitment for that round and update its capacity to zero
sign in as that judge and navigate to /panels and allocate yourself a panel
note that capacity does not change

![Screen Shot 2019-05-14 at 2 50 05 PM](https://user-images.githubusercontent.com/5283553/57723979-ce7c5d80-7657-11e9-9658-e909d58b1166.png)
