### PR TITLE
AC-6715: Silence logging when running tests on impact-api

### DIFF
--- a/web/impact/impact/settings.py
+++ b/web/impact/impact/settings.py
@@ -319,8 +319,7 @@ class Test(Base):
     DATABASE_ROUTERS = []
     DEBUG = False
     LANGUAGE_CODE = 'en'
-
-    logging.disable(logging.CRITICAL)
+    logging.disable(logging.INFO)
 
 
 class Prod(Base):

--- a/web/impact/impact/settings.py
+++ b/web/impact/impact/settings.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2017 MassChallenge, Inc.
 
 import os
-
+import logging
 import datetime
 from configurations import (
     Configuration,
@@ -319,6 +319,8 @@ class Test(Base):
     DATABASE_ROUTERS = []
     DEBUG = False
     LANGUAGE_CODE = 'en'
+
+    logging.disable(logging.CRITICAL)
 
 
 class Prod(Base):


### PR DESCRIPTION
#### Changes introduced in [AC-6715](https://masschallenge.atlassian.net/browse/AC-6715)
- stop verbose logging when running tests

#### How to test
- while on development
- run `make test` in impact and notice the logging that drowns out basically everything
- now checkout AC-6715
- run `make test` again and see our tests are back to cleanliness 🏆 
