### PR TITLE
AC-6533: Add 'keepdb' option to Makefile test targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,8 +188,9 @@ build: shutdown-vms delete-vms setup
 
 tests ?= $(TESTS)  # Backwards compatibility
 test: setup
-	@docker-compose run --rm web \
-		python3 manage.py test --configuration=Test $(tests)
+	@@if [ -z $$keepdb ]; then keepdb="--keepdb"; else keepdb=""; fi; \
+	docker-compose run --rm web \
+		python3 manage.py test $$keepdb --configuration=Test $(tests)
 
 coverage: coverage-run coverage-report coverage-html-report
 

--- a/Makefile
+++ b/Makefile
@@ -69,8 +69,9 @@ lower_target_help = \
 target_help = \
   'help - Prints this help message.' \
   ' ' \
-  'test - Run tests with no coverage. Run just those specified in $$(tests)' \
-  '\tif provided.  E.g.:' \
+  'test - Run tests with no coverage and while preserving the test database.' \
+	'\tIf you do not want to preserve the database add the keepdb=no flag E.g. make test keepdb=no' \
+	'\tRun just those specified in $$(tests)' \
   '\tmake test tests="impact.tests.test_file1 impact.tests.test_file2"' \
   'coverage - Run tests with coverage summary in terminal.' \
   'coverage-html - Run tests with coverage and open report in browser.' \


### PR DESCRIPTION
#### Changes introduced in [AC-6533](https://masschallenge.atlassian.net/browse/AC-6533)
- add keepdb option to 'make test' to allow a user opt out of keeping the db while running tests

#### How to test
- checkout this branch
- run `time make test tests=impact.tests.test_authentication_views` twice, and notice the second time, the test db is not recreated (the first time, the db is actually created)
- now run `time make test tests=impact.tests.test_authentication_views keepdb=no` and notice a prompt appears asking you to destroy the existing db.