### PR TITLE
AC-6754: Prevent the AC-6678 branch from automatically deploying to pre-staging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -466,7 +466,7 @@ endif
 
 
 deploy:
-	@if [ "$$IMAGE_TAG" != "development" ] && [ "$$IMAGE_TAG" != "AC-6678" ]; then exit 1; fi;
+	@if [ "$$IMAGE_TAG" != "development" ]; then exit 1; fi;
 	@pip install --upgrade certifi pyopenssl requests[security] ndg-httpsclient pyasn1 pip botocore
 	@curl -s https://raw.githubusercontent.com/silinternational/ecs-deploy/master/ecs-deploy | sudo tee /usr/bin/ecs-deploy
 	@sudo chmod +x /usr/bin/ecs-deploy


### PR DESCRIPTION
#### Changes introduced in [AC-6754](https://masschallenge.atlassian.net/browse/AC-6754)
ensure AC-6678 branch does not lead to auto-deployment

#### How to test
- A passing travis build and code change review should be enough to call this done.

#### Context
- this is a cleanup task from the [AC-6678](https://masschallenge.atlassian.net/browse/AC-6678) ticket