### PR TITLE
[AC-6779] People Directory - Inactive users should not appear for community members (especially inactive staff)

### DIFF
--- a/web/impact/impact/views/algolia_api_key_view.py
+++ b/web/impact/impact/views/algolia_api_key_view.py
@@ -168,7 +168,4 @@ def _get_public_key(params, search_key):
 
 
 def _build_filter(*args):
-    overall_filter = args[0] if args else ''
-    for filter_part in args[1:]:
-        overall_filter += (' AND ' + filter_part)
-    return overall_filter
+    return " AND ".join(args)


### PR DESCRIPTION
### Changes introduced in [AC-6779](https://masschallenge.atlassian.net/browse/AC-6779):
- add the is_active field to the people index

### Dependency
This has a sibling PR here https://github.com/masschallenge/accelerate/pull/2209 that should merge first. The people indices for staging and prod should be reindexed once these have merged

### How to test
**On Test3**
- Logged in as a staff member e.g [staff](https://test3.masschallenge.org/admin/simpleuser/user/43639/masquerade/) go to the [people index on test3](https://test3.masschallenge.org/people). Search for an inactive account e.g John Harthorne's. You should be able to see the result.
- Repeat the above process with a non staff user e.g [user](https://test3.masschallenge.org/admin/simpleuser/user/11167/masquerade/). John Harthorne's profile should not appear in the results
- Other QA stuff

**Localhost**
- To test on localhost ensure you have checked out to the AC-6779 branch on impact and run impact with `make run-server`
- Run the frontend with `yarn clean; yarn start` and visit `http://localhost:1234/people`
- Follow the process above