### PR TITLE
AC-6811: Impact-api has tests that use a UserRole to give staff permissions

### DIFF
--- a/web/impact/impact/tests/api_test_case.py
+++ b/web/impact/impact/tests/api_test_case.py
@@ -10,13 +10,12 @@ from django.conf import settings
 from django.contrib.auth.models import Group
 from django.urls import reverse
 
-from accelerator.models import UserRole
 from accelerator_abstract.models.base_clearance import (
     CLEARANCE_LEVEL_GLOBAL_MANAGER,
+    CLEARANCE_LEVEL_STAFF
 )
 from impact.tests.factories import (
     ClearanceFactory,
-    ProgramRoleGrantFactory,
     UserFactory,
 )
 
@@ -49,10 +48,11 @@ class APITestCase(TestCase):
 
     def staff_user(self):
         user = self.make_user('basic_user@test.com')
-        staff_grant = ProgramRoleGrantFactory(
-            program_role__user_role__name=UserRole.STAFF,
-            person=user)
-        return staff_grant.person
+        clearance = ClearanceFactory(
+        level=CLEARANCE_LEVEL_STAFF,
+        user=user 
+    )
+        return clearance.user
 
     def global_operations_manager(self, program_family):
         user = self.staff_user()

--- a/web/impact/impact/tests/api_test_case.py
+++ b/web/impact/impact/tests/api_test_case.py
@@ -49,9 +49,8 @@ class APITestCase(TestCase):
     def staff_user(self):
         user = self.make_user('basic_user@test.com')
         clearance = ClearanceFactory(
-        level=CLEARANCE_LEVEL_STAFF,
-        user=user 
-    )
+            level=CLEARANCE_LEVEL_STAFF,
+            user=user)
         return clearance.user
 
     def global_operations_manager(self, program_family):

--- a/web/impact/impact/tests/test_algolia_api_key_view.py
+++ b/web/impact/impact/tests/test_algolia_api_key_view.py
@@ -101,18 +101,18 @@ class TestAlgoliaApiKeyView(APITestCase):
             self.assertTrue(response.status_code, 403)
 
     def test_user_with_staff_role_grant_sees_all_mentors(self):
-        user = self.basic_user()
+        user = self.staff_user()
         program = _create_batch_program_and_named_group(
                         ACTIVE_PROGRAM_STATUS, 1)
-        self._create_user_with_role_grant(program[0], UserRole.STAFF, user)
+        self._create_user_with_role_grant(program[0], user)
         response_data = self._get_response_data(
             user, self._mentor_directory_url())
         self.assertEqual(response_data["filters"], [])
 
     def test_staff_user_does_not_have_is_active_filter(self):
-        user = self.basic_user()
+        user = self.staff_user()
         program = ProgramFactory(program_status=ACTIVE_PROGRAM_STATUS)
-        self._create_user_with_role_grant(program, UserRole.STAFF, user)
+        self._create_user_with_role_grant(program, user)
         response_data = self._get_response_data(
             user, self._person_directory_url())
         self.assertNotIn(IS_ACTIVE_FILTER, response_data["filters"])

--- a/web/impact/impact/tests/test_algolia_api_key_view.py
+++ b/web/impact/impact/tests/test_algolia_api_key_view.py
@@ -102,17 +102,12 @@ class TestAlgoliaApiKeyView(APITestCase):
 
     def test_user_with_staff_role_grant_sees_all_mentors(self):
         user = self.staff_user()
-        program = _create_batch_program_and_named_group(
-                        ACTIVE_PROGRAM_STATUS, 1)
-        self._create_user_with_role_grant(program[0], user)
         response_data = self._get_response_data(
             user, self._mentor_directory_url())
         self.assertEqual(response_data["filters"], [])
 
     def test_staff_user_does_not_have_is_active_filter(self):
         user = self.staff_user()
-        program = ProgramFactory(program_status=ACTIVE_PROGRAM_STATUS)
-        self._create_user_with_role_grant(program, user)
         response_data = self._get_response_data(
             user, self._person_directory_url())
         self.assertNotIn(IS_ACTIVE_FILTER, response_data["filters"])


### PR DESCRIPTION
**Changes introduced in AC-6811**
Make the tests pass that are affiliated to the updated to give staff permissions with clearances

**How to test**

**On development:**
Run the tests using the `make test` and notice that the 3 tests fail.

**Checkout to this branch:**
Run the tests using the `make test` and notice that the 3 tests pass.