### PR TITLE
AC-1: Create an Algolia based Startup Directory on Accelerate for staff

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ before_script:
 - docker build --no-cache -t masschallenge/front-end ../front-end
 - docker run -v $(pwd)/../front-end/dist:/usr/src/app/dist -t masschallenge/front-end
 - cp -r ../front-end/dist web/impact/static/front-end-dist
+- cp -r ../front-end/dist web/impact/static-compiled/front-end-dist
 - cp ../front-end/dist/index.html web/impact/templates/front-end.html
 - docker network create impact-api_default 
 - docker-compose -f docker-compose.travis.yml build --no-cache --build-arg DJANGO_ACCELERATOR_REVISION=$DJANGO_ACCELERATOR_REVISION

--- a/web/impact/impact/urls.py
+++ b/web/impact/impact/urls.py
@@ -119,13 +119,13 @@ urls = [
         name="allocator"),
     url(r'^people/$', TemplateView.as_view(
         template_name='front-end.html'),
-        name="entreprenuer_profile"),
+        name="entreprenuer_directory"),
     url(r'^people/(.*)/$', TemplateView.as_view(
         template_name='front-end.html'),
         name="entreprenuer_profile"),
     url(r'^startups/$', TemplateView.as_view(
         template_name='front-end.html'),
-        name="startup_profile"),
+        name="startup_directory"),
     url(r'^openid/', include('oidc_provider.urls', namespace='oidc_provider')),
     url(r'^$', IndexView.as_view()),
 ]

--- a/web/impact/impact/urls.py
+++ b/web/impact/impact/urls.py
@@ -123,7 +123,7 @@ urls = [
     url(r'^people/(.*)/$', TemplateView.as_view(
         template_name='front-end.html'),
         name="entreprenuer_profile"),
-    url(r'^startup/$', TemplateView.as_view(
+    url(r'^startups/$', TemplateView.as_view(
         template_name='front-end.html'),
         name="startup_profile"),
     url(r'^openid/', include('oidc_provider.urls', namespace='oidc_provider')),

--- a/web/impact/impact/urls.py
+++ b/web/impact/impact/urls.py
@@ -123,6 +123,9 @@ urls = [
     url(r'^people/(.*)/$', TemplateView.as_view(
         template_name='front-end.html'),
         name="entreprenuer_profile"),
+    url(r'^startup/$', TemplateView.as_view(
+        template_name='front-end.html'),
+        name="startup_profile"),
     url(r'^openid/', include('oidc_provider.urls', namespace='oidc_provider')),
     url(r'^$', IndexView.as_view()),
 ]


### PR DESCRIPTION
#### Changes introduced in [AC-1](https://masschallenge.atlassian.net/browse/AC-1)
- add /startups url that redirects traffic to the front-end

#### How to test
- login as a staff user, our `+superuser` accounts should do for this
- visit https://test6.masschallenge.org/startups and see the new startup directory

#### Note
- This PR can be merged in as is i.e. it has no travis build dependencies