### PR TITLE
AC-6537: Link Office Hours to New Mentor Profiles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ before_script:
 - docker build --no-cache -t masschallenge/front-end ../front-end
 - docker run -v $(pwd)/../front-end/dist:/usr/src/app/dist -t masschallenge/front-end
 - cp -r ../front-end/dist web/impact/static/front-end-dist
+- cp -r ../front-end/dist web/impact/static-compiled/front-end-dist
 - cp ../front-end/dist/index.html web/impact/templates/front-end.html
 - docker network create impact-api_default 
 - docker-compose -f docker-compose.travis.yml build --no-cache --build-arg DJANGO_ACCELERATOR_REVISION=$DJANGO_ACCELERATOR_REVISION

--- a/web/impact/impact/urls.py
+++ b/web/impact/impact/urls.py
@@ -114,7 +114,7 @@ urls = [
     url(r'^directory/(?:.*)$', TemplateView.as_view(
         template_name='front-end.html'),
         name="directory"),
-    url(r'^directory/people/(?:.*)$', TemplateView.as_view(
+    url(r'^directory/people/(.*)/$', TemplateView.as_view(
         template_name='front-end.html'),
         name="directory_people"),
     url(r'^allocator/(?:.*)$', TemplateView.as_view(

--- a/web/impact/impact/urls.py
+++ b/web/impact/impact/urls.py
@@ -114,6 +114,9 @@ urls = [
     url(r'^directory/(?:.*)$', TemplateView.as_view(
         template_name='front-end.html'),
         name="directory"),
+    url(r'^directory/people/(?:.*)$', TemplateView.as_view(
+        template_name='front-end.html'),
+        name="directory_people"),
     url(r'^allocator/(?:.*)$', TemplateView.as_view(
         template_name='front-end.html'),
         name="allocator"),


### PR DESCRIPTION
Changes introduced in [AC-6537](https://masschallenge.atlassian.net/browse/AC-6537)
- Added the `/directory/people/id` to the urls file.
- Made an edit to the travis.yml file to save the static files into the static-compiled file instead of the static file.

How to test:
- Masquarade as this [user](https://test3.masschallenge.org/admin/simpleuser/user/67468/masquerade/)
- Visit this [link](https://test3.masschallenge.org/mentors/60141) to view the mentor profile.
It redirects to the new mentor directory with this [link](https://test3.masschallenge.org/directory/people/60141)
