### PR TITLE
AC-6758 People Directory - Staff can search ALL people registered on our system in the people directory

### DIFF
--- a/web/impact/impact/tests/test_algolia_api_key_view.py
+++ b/web/impact/impact/tests/test_algolia_api_key_view.py
@@ -197,15 +197,14 @@ class TestAlgoliaApiKeyView(APITestCase):
 
         self.assertEqual(response_data["filters"], [])
 
-    def test_superuser_employee_sees_people_directory(self):
+    def test_superuser_employee_sees_people_directory_with_no_filters(self):
         user = _create_expert()
         user.is_superuser = True
         user.save()
         response_data = self._get_response_data(
             user, self._person_directory_url())
 
-        expected_filter = (IS_TEAM_MEMBER_FILTER + ' AND ' +
-                           HAS_FINALIST_ROLE_FILTER)
+        expected_filter = []
         self.assertEqual(response_data["filters"], expected_filter)
 
     def _create_user_with_role_grant(

--- a/web/impact/impact/views/algolia_api_key_view.py
+++ b/web/impact/impact/views/algolia_api_key_view.py
@@ -76,20 +76,17 @@ def _get_search_key(request):
 
 
 def _get_filters(request):
+    if is_employee(request.user):
+        return []
+
+
     if request.GET['index'] == 'people':
         if not base_accelerator_check(request.user):
             raise PermissionDenied()
-        if is_employee(request.user):
-            return _build_filter(
-                IS_TEAM_MEMBER_FILTER, HAS_FINALIST_ROLE_FILTER)
-        else:
-            return _build_filter(
-                IS_TEAM_MEMBER_FILTER,
-                HAS_FINALIST_ROLE_FILTER, IS_ACTIVE_FILTER)
+        return _build_filter(
+            IS_TEAM_MEMBER_FILTER,
+            HAS_FINALIST_ROLE_FILTER, IS_ACTIVE_FILTER)
 
-    # an empty filter i.e. [], means the user sees all mentors
-    if is_employee(request.user):
-        return []
 
     if request.GET['index'] == 'mentor':
         participant_roles = [UserRole.AIR, UserRole.STAFF, UserRole.MENTOR]


### PR DESCRIPTION
#### Changes introduced in [AC-6758](https://masschallenge.atlassian.net/browse/AC-6758)
- Staff can search ALL people registered on our system in the people directory

#### How to test
#####On localhost
- This PR has a sister PR on front-end [here](https://github.com/masschallenge/front-end/pull/168)
- Checkout this branch on both `impact` and `frontend`,
- With `impact-api` and `front-end` running,
- Navigate to this [url](http://localhost:1234/people)
- Notice that the people results returned are greater than 60000
#### How to reproduce
- Checkout to development and notice that the results are less than 10000