### PR TITLE
AC-6256: make release should work when some branches are on development branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ env:
   global:
     - DOCKER_COMPOSE_VERSION=1.20.1
       # get all the branches referencing this commit
-    - IS_RELEASE=$(git ls-remote origin | grep "$TRAVIS_COMMIT\s\+refs/heads/release$")
-    - RELEASE_TAG=$(git tag -l --points-at HEAD | head -n1)
     - BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
     - DJANGO_ACCELERATOR_REVISION=`./infer_repository_revision.sh "$BRANCH" https://www.github.com/masschallenge/django-accelerator.git`
     - FRONT_END_REVISION=`./infer_repository_revision.sh "$BRANCH" https://$MC_DEV_ADMIN_GH_TOKEN@github.com/masschallenge/front-end.git`
@@ -57,7 +55,7 @@ after_success:
 - sudo chmod +x /usr/local/bin/ecs-cli;
 - pip install awscli==1.15.3;
 - export PATH=$PATH:$HOME/.local/bin;
-- export TAG=$(if [ "$RELEASE_TAG" = "" ]; then echo "$BRANCH"; else echo "$RELEASE_TAG"; fi);
+- export TAG=$BRANCH;
 - export ECR_TOKEN=`aws ecr get-authorization-token --region us-east-1 --output text --query 'authorizationData[].authorizationToken' | base64 --decode | cut -d':' -f2`
 - export ECR_HOST=`aws ecr get-authorization-token --region us-east-1 --output text --query 'authorizationData[].proxyEndpoint'`
 - export DOCKER_USER=AWS


### PR DESCRIPTION
#### Changes introduced in [AC-6256](https://masschallenge.atlassian.net/browse/AC-6256)
- stop getting the tag on a commit manually, instead use
  travis env variables which use the tag that triggered a
  travis build

#### How to test
I recreated a common scenario with engineers who deploy a work in progress to an AWS stack often. What happens is an engineer will often start with a tag like `vTR-AC-XXXX`, then later create another like `vTR-AC-XXXX-deploy` and maybe even another `vTR-AC-XXXX-deploy-2`.

If these tags happen to be on the same commit on impact-api:

#### on development
* vTR-AC-XXXX - works correctly, and a docker image with that tag is pushed to AWS
* vTR-AC-XXXX-deploy - will push a docker image with the tag `vTR-AC-XXXX` instead of `vTR-AC-XXXX-deploy`
* vTR-AC-XXXX-deploy-2 - will push a docker image with the tag `vTR-AC-XXXX` instead of `vTR-AC-XXXX-deploy-2`

You can see this behaviour with 2 tags pushed to development
[vTR-AC-6256-3](https://travis-ci.org/masschallenge/impact-api/builds/563201967) - this tag was pushed first and therefore the image with the [correct tag](https://travis-ci.org/masschallenge/impact-api/builds/563201967#L3883) was pushed to AWS
[vTR-AC-6256-4](https://travis-ci.org/masschallenge/impact-api/builds/563202240) - this tag was pushed second and an the image with the [vTR-AC-6256-3](https://travis-ci.org/masschallenge/impact-api/builds/563202240#L3882) was wrongly pushed to AWS

#### while on this branch
* vTR-AC-XXXX - works correctly, and a docker image with that tag is pushed to AWS
* vTR-AC-XXXX-deploy - will push a docker image with the tag `vTR-AC-XXXX-deploy`
* vTR-AC-XXXX-deploy-2 - will push a docker image with the tag `vTR-AC-XXXX-deploy-2`

You can see this behaviour with 2 tags pushed to the AC-6256
[vTR-AC-6256](https://travis-ci.org/masschallenge/impact-api/builds/563123314) - this tag was pushed first and therefore the image with the [correct tag](https://travis-ci.org/masschallenge/impact-api/builds/563123314#L3883) i.e. vTR-AC-6256 was pushed to AWS
[vTR-AC-6256-2](https://travis-ci.org/masschallenge/impact-api/builds/563123490) - this tag was pushed second and an the image with the [correct tag](https://travis-ci.org/masschallenge/impact-api/builds/563123490#L3899) i.e. vTR-AC-6256-2 was pushed to AWS. Unlike the behaviour on development that would have used the initial tag.

#### Note
There's some context I left on the [ticket](https://masschallenge.atlassian.net/browse/AC-6256?focusedCommentId=41225&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-41225) that explains what this is solving for.
Previously (before this ticket), to ensure that the travis build of impact-api correctly tags the docker image it uploads to AWS an engineer had to create a commit with a trivial change and then tag that commit.
These changes get rid of that requirement, and should allow engineers create custom deploys with less hustle.