### PR TITLE
AC-6909 integrate code climate coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,6 @@ before_script:
 - docker-compose -f docker-compose.travis.yml up -d
 
 script:
-- make test
 - make coverage
 - make coverage-xml-report
 
@@ -72,4 +71,4 @@ after_success:
 - make deploy IMAGE_TAG=$TAG;
 
 after_script:
-- ./cc-test-reporter after-build -t coverage.py --exit-code $TRAVIS_TEST_RESULT
+- ./cc-test-reporter after-build --prefix $TRAVIS_BUILD_DIR/web/impact/ -t coverage.py --exit-code $TRAVIS_TEST_RESULT

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,4 +71,4 @@ after_success:
 - make deploy IMAGE_TAG=$TAG;
 
 after_script:
-- cd web/impact/ && ../../../cc-test-reporter after-build -t coverage.py --exit-code $TRAVIS_TEST_RESULT
+- cd web/impact/ && ../../cc-test-reporter after-build -t coverage.py --exit-code $TRAVIS_TEST_RESULT

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,9 @@ before_install:
 - docker-compose --version
 
 before_script:
+- curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+- chmod +x ./cc-test-reporter
+- ./cc-test-reporter before-build
 - if [ -z $TRAVIS_TAG ]; then git remote set-branches origin $BRANCH; fi
 - git fetch
 - git checkout $BRANCH
@@ -50,6 +53,8 @@ before_script:
 
 script:
 - make test
+- make coverage
+- make coverage-xml-report
 
 after_success:
 - if [ "$DEPLOY_ENVIRONMENT" = "" ]; then export DEPLOY_ENVIRONMENT=$(if [ "$BRANCH" = "master" ]; then echo "production"; else echo "staging"; fi); fi;
@@ -65,3 +70,6 @@ after_success:
 - echo $DOCKER_PASSWORD | docker login -u $DOCKER_USER --password-stdin $ECR_HOST
 - make travis-release AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY ENVIRONMENT=$DEPLOY_ENVIRONMENT DOCKER_REGISTRY=$DOCKER_REGISTRY IMAGE_TAG=$TAG;
 - make deploy IMAGE_TAG=$TAG;
+
+after_script:
+- ./cc-test-reporter after-build -t coverage.py --exit-code $TRAVIS_TEST_RESULT

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,5 +71,4 @@ after_success:
 - make deploy IMAGE_TAG=$TAG;
 
 after_script:
-- mv web/impact/coverage.xml .
-- ./cc-test-reporter after-build -t coverage.py --exit-code $TRAVIS_TEST_RESULT
+- cd web/impact/ && ../../../cc-test-reporter after-build -t coverage.py --exit-code $TRAVIS_TEST_RESULT

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,4 +71,5 @@ after_success:
 - make deploy IMAGE_TAG=$TAG;
 
 after_script:
+- mv web/impact/coverage.xml .
 - ./cc-test-reporter after-build --prefix $TRAVIS_BUILD_DIR/web/impact/ -t coverage.py --exit-code $TRAVIS_TEST_RESULT

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,4 +72,4 @@ after_success:
 
 after_script:
 - mv web/impact/coverage.xml .
-- ./cc-test-reporter after-build --prefix $TRAVIS_BUILD_DIR/web/impact/ -t coverage.py --exit-code $TRAVIS_TEST_RESULT
+- ./cc-test-reporter after-build -t coverage.py --exit-code $TRAVIS_TEST_RESULT

--- a/Makefile
+++ b/Makefile
@@ -207,6 +207,9 @@ coverage-report: .env
 coverage-html-report: .env
 	@docker-compose run --rm web coverage html --omit="*/tests/*"
 
+coverage-xml-report: .env
+  @docker-compose run --rm web coverage xml --omit="*/tests/*"
+
 coverage-html: coverage
 	@open web/impact/htmlcov/index.html
 

--- a/Makefile
+++ b/Makefile
@@ -208,7 +208,7 @@ coverage-html-report: .env
 	@docker-compose run --rm web coverage html --omit="*/tests/*"
 
 coverage-xml-report: .env
-  @docker-compose run --rm web coverage xml --omit="*/tests/*"
+	@docker-compose run --rm web coverage xml -i  --omit="*/tests/*"
 
 coverage-html: coverage
 	@open web/impact/htmlcov/index.html

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ _Copyright (c) 2017 MassChallenge, Inc._
 
  [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Build Status](https://travis-ci.org/masschallenge/impact-api.svg?branch=development)](https://travis-ci.org/masschallenge/impact-api)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/919b52c7bf78bfc67bb6/test_coverage)](https://codeclimate.com/github/masschallenge/impact-api/test_coverage)
 <a href="https://codeclimate.com/github/masschallenge/impact-api/maintainability">
   <img src="https://api.codeclimate.com/v1/badges/919b52c7bf78bfc67bb6/maintainability" />
 </a>


### PR DESCRIPTION
This PR adds coverage reports to code climate. 

to test:

- re-run the latest AC-6909 branch in travis: https://travis-ci.org/masschallenge/impact-api/builds/563717117

- visit the test coverage page and see that there is a new report generated (at bottom of page) https://codeclimate.com/repos/59f22f001def2a02b1007388/settings/test_reporter