### PR TITLE
[AC-7039] add finalists programs in response for finalist users

### DIFF
--- a/web/impact/impact/tests/test_algolia_api_key_view.py
+++ b/web/impact/impact/tests/test_algolia_api_key_view.py
@@ -27,9 +27,7 @@ from impact.tests.api_test_case import APITestCase
 from impact.tests.factories import UserFactory
 from impact.views import AlgoliaApiKeyView
 from impact.views.algolia_api_key_view import (
-    HAS_FINALIST_ROLE_FILTER,
     IS_ACTIVE_FILTER,
-    IS_TEAM_MEMBER_FILTER,
 )
 
 User = get_user_model()  # pylint: disable=invalid-name
@@ -118,6 +116,19 @@ class TestAlgoliaApiKeyView(APITestCase):
         response_data = self._get_response_data(
             user, self._person_directory_url())
         self.assertIn(IS_ACTIVE_FILTER, response_data["filters"])
+
+    def test_finalist_user_response_has_programs_finalist_in(self):
+        program = ProgramFactory(program_status=ACTIVE_PROGRAM_STATUS)
+        user = self._create_user_with_role_grant(program, UserRole.FINALIST)
+        response_data = self._get_response_data(
+            user, self._mentor_directory_url())
+        self.assertIn(program.name, response_data["finalist_programs"])
+
+    def test_staff_user_response_has_no_programs_finalist_in_field(self):
+        user = self.staff_user()
+        response_data = self._get_response_data(
+            user, self._person_directory_url())
+        self.assertNotIn("finalist_programs", response_data.keys())
 
     def test_finalist_user_gets_all_programs_in_program_group(
             self):

--- a/web/impact/impact/tests/test_algolia_api_key_view.py
+++ b/web/impact/impact/tests/test_algolia_api_key_view.py
@@ -124,11 +124,11 @@ class TestAlgoliaApiKeyView(APITestCase):
             user, self._mentor_directory_url())
         self.assertIn(program.name, response_data["finalist_programs"])
 
-    def test_staff_user_response_has_no_programs_finalist_in_field(self):
+    def test_non_finalists_have_no_finalist_programs(self):
         user = self.staff_user()
         response_data = self._get_response_data(
             user, self._person_directory_url())
-        self.assertNotIn("finalist_programs", response_data.keys())
+        self.assertEqual(response_data["finalist_programs"], [])
 
     def test_finalist_user_gets_all_programs_in_program_group(
             self):

--- a/web/impact/impact/views/algolia_api_key_view.py
+++ b/web/impact/impact/views/algolia_api_key_view.py
@@ -59,19 +59,17 @@ class AlgoliaApiKeyView(APIView):
             'validUntil': int(time.time()) + 3600,
             'userToken': request.user.id,
         }
-        programs_finalist_in = _get_finalist_program_role_grants(
+        finalist_programs = _get_finalist_program_role_grants(
             request.user).values_list('program_role__program__name', flat=True)
         if filters:
             params['filters'] = filters
         public_key = _get_public_key(params, search_key)
-        response_data = {
+        return Response({
             'token': public_key,
             'index_prefix': settings.ALGOLIA_INDEX_PREFIX,
             'filters': filters,
-        }
-        if programs_finalist_in.exists():
-            response_data['finalist_programs'] = programs_finalist_in
-        return Response(response_data)
+            'finalist_programs': finalist_programs
+        })
 
 
 def _get_search_key(request):


### PR DESCRIPTION
### Changes introduced in [AC-7039](https://masschallenge.atlassian.net/browse/AC-7039):
- add finalists programs in response for finalist users in algolia token request

### How to test
- Run `make checkout branch=AC-7039` to checkout to this branch
- Login into accelerate and masquerade as a finalist in a current program e.g. [44670](http://localhost:8181/admin/simpleuser/user/59402/masquerade/)
- Visit `http://localhost:8000/api/algolia/api_key/?index=mentor` on your browser and notice that the response data contains `finalist_programs` for the user

**Note**
- This has sibling PRs on [accelerate](https://github.com/masschallenge/accelerate/pull/2351) and the [front-end](https://github.com/masschallenge/front-end/pull/177)
- This should merge before the front-end PR