### PR TITLE
[AC-7176] Fix available office hours URL on mentor profile

### DIFF
--- a/web/impact/impact/graphql/types/expert_profile_type.py
+++ b/web/impact/impact/graphql/types/expert_profile_type.py
@@ -85,9 +85,9 @@ class ExpertProfileType(DjangoObjectType):
                 slugs = _get_slugs(self, mentor_program, latest_mentor_program)
                 return "/officehours/list/{family_slug}/{program_slug}/".format(
                     family_slug=slugs[0],
-                    program_slug=slugs[1] + (
-                    '/?mentor_id={mentor_id}'.format(
-                        mentor_id=self.user.id)))
+                    program_slug=slugs[1]) + (
+                    '?mentor_id={mentor_id}'.format(
+                        mentor_id=self.user.id))
 
     def resolve_current_mentees(self, info, **kwargs):
         return _get_mentees(self.user, ACTIVE_PROGRAM_STATUS)

--- a/web/impact/impact/tests/test_graphql.py
+++ b/web/impact/impact/tests/test_graphql.py
@@ -218,7 +218,7 @@ class TestGraphQL(APITestCase):
                         .format(
                             family_slug=family_slug,
                             program_slug=program_slug) + (
-                            '?mentor_id={mentor_id}/'.format(
+                            '?mentor_id={mentor_id}'.format(
                                 mentor_id=confirmed.id)))
 
         query = """


### PR DESCRIPTION
**Changes introduced on [AC-7176](https://masschallenge.atlassian.net/browse/AC-7176):**

- Fixed the available office hours link.

**How to test:**
**On development:**

- Visit the [link](http://localhost:1234/directory/people/4600)
- Click on the available for office hours link.
- Get a 500 server error.

**On this branch:**

- Follow the above instructions.
- Notice that you are redirected to the office hours page.