### PR TITLE
[AC-7072] Agenda view for single office hours holder availability

### DIFF
--- a/web/impact/impact/v1/helpers/mentor_program_office_hour_helper.py
+++ b/web/impact/impact/v1/helpers/mentor_program_office_hour_helper.py
@@ -14,6 +14,7 @@ OFFFICE_HOUR_FIELDS = {
     "id": PK_FIELD,
     "title": OPTIONAL_STRING_FIELD,
     "location": OPTIONAL_STRING_FIELD,
+    "timezone": OPTIONAL_STRING_FIELD,
     "start_date_time": OPTIONAL_STRING_FIELD,
     "end_date_time": OPTIONAL_STRING_FIELD,
     "mentor_id": OPTIONAL_INTEGER_FIELD,
@@ -64,3 +65,11 @@ class MentorProgramOfficeHourHelper(ModelHelper):
     @property
     def is_open(self):
         return self.subject.is_open()
+
+    @property
+    def location(self):
+        return self.field_element("location", "name")
+
+    @property
+    def timezone(self):
+        return self.field_element("location", "timezone")

--- a/web/impact/impact/v1/helpers/mentor_program_office_hour_helper.py
+++ b/web/impact/impact/v1/helpers/mentor_program_office_hour_helper.py
@@ -43,6 +43,10 @@ class MentorProgramOfficeHourHelper(ModelHelper):
         return self.field_element("location", "name")
 
     @property
+    def timezone(self):
+        return self.field_element("location", "timezone")
+
+    @property
     def mentor_id(self):
         return self.field_element("mentor", "id")
 
@@ -69,11 +73,3 @@ class MentorProgramOfficeHourHelper(ModelHelper):
     @property
     def is_open(self):
         return self.subject.is_open()
-
-    @property
-    def location(self):
-        return self.field_element("location", "name")
-
-    @property
-    def timezone(self):
-        return self.field_element("location", "timezone")

--- a/web/impact/impact/v1/views/mentor_program_office_hour_list_view.py
+++ b/web/impact/impact/v1/views/mentor_program_office_hour_list_view.py
@@ -3,6 +3,8 @@
 from django.db.models import Value as V
 from django.db.models.functions import Concat
 
+from accelerator.utils import localized_today_utc_date
+
 from impact.v1.views.base_list_view import BaseListView
 from impact.v1.helpers import (
     MentorProgramOfficeHourHelper,
@@ -20,6 +22,13 @@ class MentorProgramOfficeHourListView(BaseListView):
         qs = super().filter(qs)
         if not self.request.query_params.keys():
             return qs
+
+        if 'upcoming' in self.request.query_params.keys():
+            # Hardcoded to the boston timezone should replaced with
+            # user relevant timezone
+            timezone = "America/New_York"
+            today = localized_today_utc_date(timezone)
+            qs = qs.filter(start_date_time__gte=todayt)
 
         if self._has_mentor_or_finalist_filter(NAME_FIELDS):
             return self._filter_by_mentor_or_finalist_names(qs)

--- a/web/impact/impact/v1/views/mentor_program_office_hour_list_view.py
+++ b/web/impact/impact/v1/views/mentor_program_office_hour_list_view.py
@@ -28,7 +28,7 @@ class MentorProgramOfficeHourListView(BaseListView):
             # user relevant timezone
             timezone = "America/New_York"
             today = localized_today_utc_date(timezone)
-            qs = qs.filter(start_date_time__gte=todayt)
+            qs = qs.filter(start_date_time__gte=today)
 
         if self._has_mentor_or_finalist_filter(NAME_FIELDS):
             return self._filter_by_mentor_or_finalist_names(qs)

--- a/web/impact/impact/v1/views/mentor_program_office_hour_list_view.py
+++ b/web/impact/impact/v1/views/mentor_program_office_hour_list_view.py
@@ -1,14 +1,13 @@
 # MIT License
 # Copyright (c) 2019 MassChallenge, Inc.
+from datetime import datetime
 from django.db.models import Value as V
 from django.db.models.functions import Concat
 
-from accelerator.utils import localized_today_utc_date
-
-from impact.v1.views.base_list_view import BaseListView
 from impact.v1.helpers import (
     MentorProgramOfficeHourHelper,
 )
+from impact.v1.views.base_list_view import BaseListView
 
 ID_FIELDS = ['mentor_id', 'finalist_id']
 NAME_FIELDS = ['mentor_name', 'finalist_name']
@@ -24,10 +23,7 @@ class MentorProgramOfficeHourListView(BaseListView):
             return qs
 
         if 'upcoming' in self.request.query_params.keys():
-            # Hardcoded to the boston timezone should replaced with
-            # user relevant timezone
-            timezone = "America/New_York"
-            today = localized_today_utc_date(timezone)
+            today = datetime.utcnow()
             qs = qs.filter(start_date_time__gte=today)
 
         if self._has_mentor_or_finalist_filter(NAME_FIELDS):


### PR DESCRIPTION
**Changes Introduced in [AC-7072](https://masschallenge.atlassian.net/browse/AC-7072):**
- Update Office Hours api to enable return of upcoming office hours only

**Test:**

- The working front-end is sufficient.
- Alternatively, visit the api link below and see all the returned office hours are in the future
http://localhost:8000/api/v1/office_hours/?upcoming=true&mentor_id=56778&limit=10&offset=10