### PR TITLE
AC-7025 - Clear Django 2 deprecation warnings in impact-api

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,7 +191,7 @@ tests ?= $(TESTS)  # Backwards compatibility
 test: setup
 	@@if [ -z $$keepdb ]; then keepdb="--keepdb"; else keepdb=""; fi; \
 	docker-compose run --rm web \
-		python3 manage.py test $$keepdb --configuration=Test $(tests)
+		python3 -Wa manage.py test $$keepdb --configuration=Test $(tests)
 
 coverage: coverage-run coverage-report coverage-html-report
 

--- a/web/impact/impact/graphql/auth/middleware.py
+++ b/web/impact/impact/graphql/auth/middleware.py
@@ -1,12 +1,14 @@
-from django.contrib.auth import authenticate
-from django.http import JsonResponse
 from graphql_jwt.exceptions import GraphQLJWTError
 from graphql_jwt.middleware import JSONWebTokenMiddleware
+
+from django.contrib.auth import authenticate
+from django.http import JsonResponse
+from django.utils.deprecation import MiddlewareMixin
 
 from impact.graphql.auth.utils import get_jwt_cookie
 
 
-class CookieJSONWebTokenMiddleware(JSONWebTokenMiddleware):
+class CookieJSONWebTokenMiddleware(JSONWebTokenMiddleware, MiddlewareMixin):
 
     def process_request(self, request):
         if get_jwt_cookie(request) is None:

--- a/web/impact/impact/graphql/middleware.py
+++ b/web/impact/impact/graphql/middleware.py
@@ -1,8 +1,12 @@
+from django.utils.deprecation import MiddlewareMixin
+
 from impact.graphql.utils.response_error import ResponseError
+
+
 NOT_LOGGED_IN_MSG = 'User Not Logged in!'
 
 
-class IsAuthenticatedMiddleware(object):
+class IsAuthenticatedMiddleware(MiddlewareMixin):
     def resolve(self, next, root, info, **args):
         if not info.context.user.is_authenticated():
             raise ResponseError(message=NOT_LOGGED_IN_MSG, code="401")

--- a/web/impact/impact/graphql/middleware.py
+++ b/web/impact/impact/graphql/middleware.py
@@ -8,6 +8,6 @@ NOT_LOGGED_IN_MSG = 'User Not Logged in!'
 
 class IsAuthenticatedMiddleware(MiddlewareMixin):
     def resolve(self, next, root, info, **args):
-        if not info.context.user.is_authenticated():
+        if not info.context.user.is_authenticated:
             raise ResponseError(message=NOT_LOGGED_IN_MSG, code="401")
         return next(root, info, **args)

--- a/web/impact/impact/middleware/method_override_middleware.py
+++ b/web/impact/impact/middleware/method_override_middleware.py
@@ -1,10 +1,11 @@
 # MIT License
 # Copyright (c) 2017 MassChallenge, Inc.
+from django.utils.deprecation import MiddlewareMixin
 
 METHOD_OVERRIDE_HEADER = 'HTTP_X_HTTP_METHOD_OVERRIDE'
 
 
-class MethodOverrideMiddleware(object):
+class MethodOverrideMiddleware(MiddlewareMixin):
     def process_request(self, request):
         if request.method != 'POST':
             return

--- a/web/impact/impact/middleware/track_api_calls.py
+++ b/web/impact/impact/middleware/track_api_calls.py
@@ -1,9 +1,11 @@
 import logging
 
+from django.utils.deprecation import MiddlewareMixin
+
 logger = logging.getLogger()
 
 
-class TrackAPICalls(object):
+class TrackAPICalls(MiddlewareMixin):
     def process_request(self, request):
         user = getattr(request, 'user', None)
 

--- a/web/impact/impact/settings.py
+++ b/web/impact/impact/settings.py
@@ -112,7 +112,7 @@ class Base(Configuration):
 
     AUTH_USER_MODEL = 'simpleuser.User'
 
-    MIDDLEWARE_CLASSES = [
+    MIDDLEWARE = [
         'django.contrib.sessions.middleware.SessionMiddleware',
         'django.middleware.common.CommonMiddleware',
         'django.middleware.csrf.CsrfViewMiddleware',
@@ -371,9 +371,9 @@ class Dev(Base):
         '*'
     ]
 
-    MIDDLEWARE_CLASSES = [
-                             'debug_toolbar.middleware.DebugToolbarMiddleware',
-                         ] + Base.MIDDLEWARE_CLASSES
+    MIDDLEWARE = [
+        'debug_toolbar.middleware.DebugToolbarMiddleware',
+    ] + Base.MIDDLEWARE
 
     INSTALLED_APPS = Base.INSTALLED_APPS + [
         'debug_toolbar',

--- a/web/impact/impact/settings.py
+++ b/web/impact/impact/settings.py
@@ -1,18 +1,25 @@
 # MIT License
 # Copyright (c) 2017 MassChallenge, Inc.
 
-import os
 import datetime
+import os
+import warnings
+
 from configurations import (
     Configuration,
     values,
 )
-from django.urls import reverse_lazy
 from unipath import Path
 
+from django.urls import reverse_lazy
+from django.utils.deprecation import RemovedInDjango20Warning
 
 LOG_FORMAT = 'host: localhost  %(name)s[%(process)d]: ' \
                 '%(levelname)s %(message)s'
+
+# Squelch Test DB complaining about timezone support
+warnings.filterwarnings("ignore", category=RemovedInDjango20Warning, 
+    module='django.db.backends.sqlite3.base', lineno=53)
 
 
 class Base(Configuration):

--- a/web/impact/impact/urls.py
+++ b/web/impact/impact/urls.py
@@ -96,7 +96,7 @@ urls = [
     url(r'^api/simpleuser/', include(simpleuser_router.urls)),
     url(r'^api/accelerator/', include(schema_router.urls),
         name='api-root'),
-    url(r'^sso/', include(sso_urlpatterns, namespace="sso")),
+    url(r'^sso/', include(sso_urlpatterns)),
     url(r'^admin/', admin.site.urls),
     url(r'^accounts/', include(account_urlpatterns)),
     url(r'^graphql/$',

--- a/web/impact/impact/urls.py
+++ b/web/impact/impact/urls.py
@@ -97,7 +97,7 @@ urls = [
     url(r'^api/accelerator/', include(schema_router.urls),
         name='api-root'),
     url(r'^sso/', include(sso_urlpatterns, namespace="sso")),
-    url(r'^admin/', include(admin.site.urls)),
+    url(r'^admin/', admin.site.urls),
     url(r'^accounts/', include(account_urlpatterns)),
     url(r'^graphql/$',
         csrf_exempt(SafeGraphQLView.as_view(

--- a/web/impact/impact/views/index_view.py
+++ b/web/impact/impact/views/index_view.py
@@ -12,6 +12,6 @@ class IndexView(View):
     template_name = 'base.html'
 
     def get(self, request, *args, **kwargs):
-        if request.user and request.user.is_authenticated():
+        if request.user and request.user.is_authenticated:
             return HttpResponseRedirect(reverse('api-root'))
         return render(request, self.template_name, {})

--- a/web/impact/requirements/base.txt
+++ b/web/impact/requirements/base.txt
@@ -36,7 +36,7 @@ django-filter==2.2.0
 django-multidb-router
 django-oauth-toolkit<1.1
 django-paypal
-django-polymorphic==1.3
+django-polymorphic==2.1.2
 django-redis-cache
 django-registration==2.4.1
 django-rest-framework-proxy


### PR DESCRIPTION
## [AC-7025](https://masschallenge.atlassian.net/browse/AC-7025)

### To test
Run `make test` and confirm you see no warnings of the `RemovedInDjango20Warning` family **from impact-api code**.

**You'll see a lot of warnings from django-accelerator code**, mostly about `on_delete`, until [AC-7044](https://github.com/masschallenge/django-accelerator/pull/278) is merged.

You'll see  some non-django2 warnings - some from dependencies (`algoliasearch`, `numpy`, `configurations`, `django-registration`, `parler`) and a few about other things like tests that should be using `assertEqual`. I let these lie as they're outside the ticket's purview.

Also note: I decided to add code to `settings.py` to squelch an unhelpful warning caused by our use of SQLite for our test DB ("SQLite database adapter received an aware datetime"). I could be argued out of this if it offends you.
