### PR TITLE
[AC-7073] Calendar picker for individual office hours holder availability

### DIFF
--- a/web/impact/impact/v1/views/mentor_program_office_hour_list_view.py
+++ b/web/impact/impact/v1/views/mentor_program_office_hour_list_view.py
@@ -18,6 +18,7 @@ class MentorProgramOfficeHourListView(BaseListView):
     permission_classes = ()
     view_name = "office_hour"
     helper_class = MentorProgramOfficeHourHelper
+    DEFAULT_LIMIT = 150
 
     def filter(self, qs):
         qs = super().filter(qs)
@@ -26,6 +27,9 @@ class MentorProgramOfficeHourListView(BaseListView):
         if 'my_hours' in self.request.query_params.keys():
             qs = self._filter_by_user_open_hours(qs)
         if 'upcoming' in self.request.query_params.keys():
+            today = datetime.utcnow()
+            qs = qs.filter(start_date_time__gte=today)
+        if 'month' in self.request.query_params.keys():
             today = datetime.utcnow()
             qs = qs.filter(start_date_time__gte=today)
 

--- a/web/impact/impact/v1/views/mentor_program_office_hour_list_view.py
+++ b/web/impact/impact/v1/views/mentor_program_office_hour_list_view.py
@@ -29,10 +29,6 @@ class MentorProgramOfficeHourListView(BaseListView):
         if 'upcoming' in self.request.query_params.keys():
             today = datetime.utcnow()
             qs = qs.filter(start_date_time__gte=today)
-        if 'month' in self.request.query_params.keys():
-            today = datetime.utcnow()
-            qs = qs.filter(start_date_time__gte=today)
-
         if self._has_mentor_or_finalist_filter(NAME_FIELDS):
             return self._filter_by_mentor_or_finalist_names(qs)
 


### PR DESCRIPTION
### Changes introduced in: [AC-7073](https://masschallenge.atlassian.net/browse/AC-7073):
- Add a calendar picker for individual office hours holder availability
### How to test
- Checkout this branch on `accelerate, impact and frontend`
- On localhost
- Navigate to this mentor's office hours [page](http://localhost:8181/officehours/bos/2019/?mentor_id=59788) and schedule office hours on his behalf.
- Masquerade as this [finalist](http://localhost:8181/admin/simpleuser/user/13884/masquerade/)
- Visit http://localhost:1234/directory/people/56778
- Click the `Available Office Hours` button
- See that a modal show up with the calendar.
- Follow the mockups attached on this ticket and ensure that the feature works as required.

