### PR TITLE
[AC-7287] Fix the 404 error that is triggered when viewing a single Mentor profile

### DIFF
--- a/web/impact/impact/settings.py
+++ b/web/impact/impact/settings.py
@@ -251,7 +251,7 @@ class Base(Configuration):
 
     AUTHENTICATION_BACKENDS = (
         'oauth2_provider.backends.OAuth2Backend',
-        'graphql_jwt.backends.JSONWebTokenBackend',
+        'impact.graphql.auth.authentication_backend.JWTokenCookieBackend',
         'simpleuser.email_model_backend.EmailModelBackend',
         'django.contrib.auth.backends.ModelBackend',
     )

--- a/web/impact/requirements/base.txt
+++ b/web/impact/requirements/base.txt
@@ -52,6 +52,6 @@ graphql-core==2.1
 sorl-thumbnail==12.4.1
 django-oidc-provider==0.7.0
 django-sitetree==1.13.1
-django-graphql-jwt==0.1.4
+django-graphql-jwt==0.1.10
 
 git+https://github.com/masschallenge/add2cal


### PR DESCRIPTION
### Changes introduced in [AC-7287](https://masschallenge.atlassian.net/browse/AC-7287):
- Upgrade django-graphql-jwt and restore previous graphql authentication backend

### How to test
- Rebuild impact with `make build`
- Run `make run-all-servers`
- While logged in on accelerate on localhost, when you visit impact api at http://localhost:8000/api/accelerator/ and the directory at http://localhost:1234 you should be automatically logged in which does not currently happen on development