### PR TITLE
[AC-7291] P0 - Running make run-server on impact rebuilds images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,7 +182,6 @@ setup: .env
 
 ACCELERATE_VERSION:=$(shell git describe --tags --abbrev=0)
 build: shutdown-vms delete-vms setup
-	@echo $(ACCELERATE_VERSION)
 	@docker build -f Dockerfile.fpdiff -t masschallenge/fpdiff .
 	@docker build  -f Dockerfile.semantic-release -t semantic-release .
 	@docker-compose build --build-arg ACCELERATE_VERSION=$(ACCELERATE_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -180,10 +180,12 @@ setup: .env
 	@mkdir -p ./mysql/data
 	@mkdir -p ./redis
 
+ACCELERATE_VERSION:=$(shell git describe --tags --abbrev=0)
 build: shutdown-vms delete-vms setup
+	@echo $(ACCELERATE_VERSION)
 	@docker build -f Dockerfile.fpdiff -t masschallenge/fpdiff .
 	@docker build  -f Dockerfile.semantic-release -t semantic-release .
-	@docker-compose build
+	@docker-compose build --build-arg ACCELERATE_VERSION=$(ACCELERATE_VERSION)
 
 # Testing, coverage, and code checking targets
 
@@ -298,10 +300,7 @@ run-server: run-server-$(debug)
 run-server-0: .env initial-db-setup watch-frontend ensure-mysql
 	@docker-compose up
 
-ACCELERATE_VERSION:=$(shell git describe --tags --abbrev=0)
 run-detached-server: .env initial-db-setup watch-frontend ensure-mysql
-	@echo $(ACCELERATE_VERSION)
-	@docker-compose build --build-arg ACCELERATE_VERSION=$(ACCELERATE_VERSION)
 	@docker-compose up -d
 	@docker-compose run --rm web /usr/bin/mysqlwait.sh
 


### PR DESCRIPTION
### Changes introduced in [AC-7291](https://masschallenge.atlassian.net/browse/AC-7291):
- Removes 'docker-compose build' when running containers in the `Makefile`

### How to test
on this branch
- Notice that when running `make run-server` or `make run-all-servers` impact is not rebuilt

Test that the latest version is still accessible in the container

- run `make build`
- run `make run-server`
- run `docker exec -it impact-api_web_1 /bin/bash` to access the impact-api container
- inside the container's terminal run `printenv | grep ACCELERATE_VERSION`
