### PR TITLE
[AC-7131] Add mentor_type and judge_type to user patch endpoint

### DIFF
--- a/web/impact/impact/tests/test_user_detail_view.py
+++ b/web/impact/impact/tests/test_user_detail_view.py
@@ -340,6 +340,8 @@ class TestUserDetailView(APITestCase):
                 "speaker_topics": speaker_topics,
                 "judge_interest": False,
                 "mentor_interest": True,
+                "mentor_type": "f",
+                "judge_type": "1",
             }
             self.client.patch(url, data)
             user.refresh_from_db()
@@ -356,6 +358,8 @@ class TestUserDetailView(APITestCase):
             assert helper.field_value("speaker_topics") == speaker_topics
             assert helper.field_value("judge_interest") is False
             assert helper.field_value("mentor_interest") is True
+            assert helper.field_value("mentor_type") == "f"
+            assert helper.field_value("judge_type") == "1"
 
     def test_patch_personal_website_url_with_email_and_password_url(self):
         context = UserContext(user_type=ENTREPRENEUR_USER_TYPE)

--- a/web/impact/impact/v1/helpers/profile_helper.py
+++ b/web/impact/impact/v1/helpers/profile_helper.py
@@ -140,6 +140,51 @@ EXPERT_CATEGORY_FIELD = {
     },
 }
 
+
+MENTOR_TYPE_FIELD = {
+    "json-schema": {
+        "type": "string"
+    },
+    "GET": {
+        "included": COULD_BE_EXPERT_CHECK,
+        "description": EXPERT_DESCRIPTION,
+    },
+    "PATCH": {
+        "required": False,
+        "allowed": IS_EXPERT_CHECK,
+        "description": ("Allowed only when user_type is 'expert' and "
+                        "Mentor Type is valid"),
+    },
+    "POST": {
+        "required": False,
+        "allowed": IS_EXPERT_CHECK,
+        "description": ("Allowed only when user_type is 'expert' and "
+                        "Mentor Type is valid"),
+    },
+}
+
+JUDGE_TYPE_FIELD = {
+    "json-schema": {
+        "type": "string"
+    },
+    "GET": {
+        "included": COULD_BE_EXPERT_CHECK,
+        "description": EXPERT_DESCRIPTION,
+    },
+    "PATCH": {
+        "required": False,
+        "allowed": IS_EXPERT_CHECK,
+        "description": ("Allowed only when user_type is 'expert' and "
+                        "Judge Type is valid"),
+    },
+    "POST": {
+        "required": False,
+        "allowed": IS_EXPERT_CHECK,
+        "description": ("Allowed only when user_type is 'expert' and "
+                        "Judge Type is valid"),
+    },
+}
+
 MENTORING_SPECIALTIES_FIELD = {
     "json-schema": {
         "type": "array",
@@ -353,6 +398,8 @@ class ProfileHelper(ModelHelper):
         "office_hours_topics",
         "referred_by",
         "speaker_topics",
+        "mentor_type",
+        "judge_type",
     ]
     EXPERT_OPTIONAL_BOOLEAN_KEYS = [
         "judge_interest",


### PR DESCRIPTION
https://masschallenge.atlassian.net/browse/AC-7131

To test: send a PATCH request via Postman (or your favorite request-sending tool) to update some existing expert's mentor_type and judge_type, then check that those values have changed in the DB