### PR TITLE
[AC-7325] Django Security release, severity "high"

### DIFF
--- a/web/impact/requirements/base.txt
+++ b/web/impact/requirements/base.txt
@@ -42,7 +42,7 @@ django-registration==2.5.2
 django-rest-framework-proxy
 drf-yasg==1.17.0
 django-storages==1.8
-Django==1.11.23
+Django==1.11.27
 djangorestframework==3.10.3
 djangorestframework-jwt
 drf-schema-adapter


### PR DESCRIPTION
### Changes introduced in: [AC-7325](https://masschallenge.atlassian.net/browse/AC-7325):
- Bumps up django version

### How to test
- Travis build with Django 1.11.27 does not fail

local testing
- delete the `impact-api_web` Docker image with `docker rmi impact-api_web`
- rebuild impact api `make build`
- run `make run-server` to setup
- run `make django-shell`
- run the following in the django shell
```
In [1]: import django

In [2]: django.__version__
Out[2]: '1.11.27'
```