### PR TITLE
[AC-6440] Remove current_program from graphql output

### DIFF
--- a/web/impact/impact/graphql/types/entrepreneur_profile_type.py
+++ b/web/impact/impact/graphql/types/entrepreneur_profile_type.py
@@ -12,7 +12,6 @@ from impact.graphql.types.entrepreneur_startup_type import (
 
 
 class EntrepreneurProfileType(DjangoObjectType):
-    current_program = graphene.String()
     image_url = graphene.String()
     title = graphene.String()
     startups = graphene.List(EntrepreneurStartupType)
@@ -27,9 +26,6 @@ class EntrepreneurProfileType(DjangoObjectType):
             'twitter_handle',
             'user',
         )
-
-    def resolve_current_program(self, info, **kwargs):
-        return self.current_program.name
 
     def resolve_image_url(self, info, **kwargs):
         return self.image and self.image.url

--- a/web/impact/impact/tests/test_graphql.py
+++ b/web/impact/impact/tests/test_graphql.py
@@ -128,7 +128,6 @@ class TestGraphQL(APITestCase):
                     entrepreneurProfile(id: {id}) {{
                         title
                         twitterHandle
-                        currentProgram
                         imageUrl
                         linkedInUrl
                         facebookUrl
@@ -172,9 +171,6 @@ class TestGraphQL(APITestCase):
                 ent_profile["facebookUrl"], profile.facebook_url)
             self.assertEqual(
                 ent_profile["twitterHandle"], profile.twitter_handle)
-            self.assertEqual(
-                ent_profile["currentProgram"],
-                profile.current_program.name)
 
             user_resp = ent_profile["user"]
             self.assertEqual(user_resp["id"], str(user.id))


### PR DESCRIPTION
https://masschallenge.atlassian.net/browse/AC-6440

Does what it says on the tin: removes current_program from the graphql output

Note that this should merge and deploy after or simultaneously with the related PR on front-end