### PR TITLE
[AC-6953] Display confirmed mentors for a user's program

### DIFF
--- a/web/impact/impact/graphql/query.py
+++ b/web/impact/impact/graphql/query.py
@@ -18,13 +18,17 @@ NON_FINALIST_PROFILE_MESSAGE = 'Sorry, You are not allowed to access this page.'
 
 class Query(graphene.ObjectType):
     expert_profile = graphene.Field(
-        ExpertProfileType, id=graphene.Int())
+        ExpertProfileType, id=graphene.Int(), email=graphene.String())
     entrepreneur_profile = graphene.Field(
         EntrepreneurProfileType, id=graphene.Int())
 
     def resolve_expert_profile(self, info, **kwargs):
         user_id = kwargs.get('id')
-        expert = ExpertProfile.objects.filter(user_id=user_id).first()
+        email = kwargs.get('email', None)
+        if user_id:
+            expert = ExpertProfile.objects.filter(user_id=user_id).first()
+        else:
+            expert = ExpertProfile.objects.filter(user__email=email).first()
 
         if not expert:
             return GraphQLError(EXPERT_NOT_FOUND_MESSAGE)

--- a/web/impact/impact/graphql/types/expert_profile_type.py
+++ b/web/impact/impact/graphql/types/expert_profile_type.py
@@ -12,6 +12,8 @@ from accelerator.models import (
 from accelerator_abstract.models import (
     ACTIVE_PROGRAM_STATUS,
     ENDED_PROGRAM_STATUS,
+    HIDDEN_PROGRAM_STATUS,
+    UPCOMING_PROGRAM_STATUS
 )
 from impact.graphql.types import StartupMentorRelationshipType
 from django.db.models import Q
@@ -26,6 +28,7 @@ class ExpertProfileType(DjangoObjectType):
     office_hours_url = graphene.String()
     program_interests = graphene.List(graphene.String)
     available_office_hours = graphene.Boolean()
+    latest_active_program_location = graphene.String()
 
     class Meta:
         model = ExpertProfile
@@ -95,6 +98,12 @@ class ExpertProfileType(DjangoObjectType):
     def resolve_previous_mentees(self, info, **kwargs):
         return _get_mentees(self.user, ENDED_PROGRAM_STATUS)
 
+    def resolve_latest_active_program_location(self, info, **kwargs):
+        prg = _latest_confirmed_non_future_program_role_grant(self)
+        if not prg:
+            return None
+        return prg.program_role.program.program_family.name
+
 
 def _get_slugs(self, mentor_program, latest_mentor_program, **kwargs):
     if mentor_program:
@@ -129,3 +138,20 @@ def _get_mentees(user, program_status):
         status=CONFIRMED_RELATIONSHIP,
         **mentee_filter
     ).order_by('-startup_mentor_tracking__program__start_date')
+
+
+def _confirmed_non_future_program_role_grant(obj):
+    return obj.user.programrolegrant_set.filter(
+        program_role__user_role__name=UserRole.MENTOR).exclude(
+        program_role__program__program_status__in=[
+            HIDDEN_PROGRAM_STATUS,
+            UPCOMING_PROGRAM_STATUS]
+    ).prefetch_related(
+        'program_role__program',
+        'program_role__program__program_family'
+    )
+
+
+def _latest_confirmed_non_future_program_role_grant(obj):
+    prg = _confirmed_non_future_program_role_grant(obj)
+    return prg.order_by('-created_at').first()

--- a/web/impact/impact/tests/test_graphql.py
+++ b/web/impact/impact/tests/test_graphql.py
@@ -81,6 +81,7 @@ class TestGraphQL(APITestCase):
                         availableOfficeHours
                         officeHoursUrl
                         programInterests
+                        latestActiveProgramLocation
                     }}
                 }}
             """.format(id=user.id)
@@ -99,7 +100,8 @@ class TestGraphQL(APITestCase):
                                          profile.image.url or ''),
                             'availableOfficeHours': False,
                             'officeHoursUrl': None,
-                            'programInterests': []
+                            'programInterests': [],
+                            'latestActiveProgramLocation': None
                         }
                     }
                 }
@@ -391,6 +393,30 @@ class TestGraphQL(APITestCase):
                         'entrepreneurProfile': {
                             'user': {
                                 'firstName': user.first_name
+                            },
+                        }
+                    }
+                }
+            )
+
+    def test_query_expert_by_email(self):
+        with self.login(email=self.basic_user().email):
+            user = ExpertFactory()
+            query = """
+                query {{
+                    expertProfile(email: "{email}") {{
+                        user {{ firstName }}
+                    }}
+                }}
+            """.format(email=user.email)
+            response = self.client.post(self.url, data={'query': query})
+            self.assertJSONEqual(
+                str(response.content, encoding='utf8'),
+                {
+                    'data': {
+                        'expertProfile': {
+                            'user': {
+                                'firstName': user.first_name,
                             },
                         }
                     }


### PR DESCRIPTION
### Changes introduced in: [AC-6953](https://masschallenge.atlassian.net/browse/AC-6953):
- Display relevant program match a user has with another community member
### How to test
- Check out to  `AC-6953`  on `impact-api` and `front-end`
- On localhost
- in the `front-end` repo run `yarn`
- Masquerade as [User without a matching program {Latest active Program = Mexico}](http://localhost:8181/admin/simpleuser/user/60549/masquerade/)
- Visit [User  Directory page {Latest active Program for this user = Rhode Island}](http://localhost:1234/directory?query=Stephanie%20Connaughton) 
**All Programs** [Rhode Island, Boston, Global Alumni Program]
**Result**: the mentor card displays **Rhode Island** because no match exists with the Mexico entrepreneur

- Masquerade as [User with a matching program {Latest active Program = Boston}](http://localhost:8181/admin/simpleuser/user/29988/masquerade/)
- Visit [User  Directory page {Latest active Program for this user = Rhode Island}](http://localhost:1234/directory?query=Stephanie%20Connaughton) 
**All Programs** [Rhode Island, Boston, Global Alumni Program]
**Result**: the mentor card displays **Boston** because of the match with the Boston entrepreneur
- Hover the mouse over `+ 2 more programs`
**Result**: Popover displays all programs attributed to the card, including the match or home program listed on the card

[Link to front-end PR](https://github.com/masschallenge/front-end/pull/204)