### PR TITLE
[AC-7430] Display relevant program match I have with other users for all the user types

### DIFF
--- a/web/impact/impact/graphql/query.py
+++ b/web/impact/impact/graphql/query.py
@@ -17,18 +17,13 @@ NON_FINALIST_PROFILE_MESSAGE = 'Sorry, You are not allowed to access this page.'
 
 
 class Query(graphene.ObjectType):
-    expert_profile = graphene.Field(
-        ExpertProfileType, id=graphene.Int(), email=graphene.String())
+    expert_profile = graphene.Field(ExpertProfileType, id=graphene.Int())
     entrepreneur_profile = graphene.Field(
         EntrepreneurProfileType, id=graphene.Int())
 
     def resolve_expert_profile(self, info, **kwargs):
         user_id = kwargs.get('id')
-        email = kwargs.get('email', None)
-        if user_id:
-            expert = ExpertProfile.objects.filter(user_id=user_id).first()
-        else:
-            expert = ExpertProfile.objects.filter(user__email=email).first()
+        expert = ExpertProfile.objects.filter(user_id=user_id).first()
 
         if not expert:
             return GraphQLError(EXPERT_NOT_FOUND_MESSAGE)

--- a/web/impact/impact/graphql/types/expert_profile_type.py
+++ b/web/impact/impact/graphql/types/expert_profile_type.py
@@ -12,8 +12,6 @@ from accelerator.models import (
 from accelerator_abstract.models import (
     ACTIVE_PROGRAM_STATUS,
     ENDED_PROGRAM_STATUS,
-    HIDDEN_PROGRAM_STATUS,
-    UPCOMING_PROGRAM_STATUS
 )
 from impact.graphql.types import StartupMentorRelationshipType
 from django.db.models import Q
@@ -28,7 +26,6 @@ class ExpertProfileType(DjangoObjectType):
     office_hours_url = graphene.String()
     program_interests = graphene.List(graphene.String)
     available_office_hours = graphene.Boolean()
-    latest_active_program_location = graphene.String()
 
     class Meta:
         model = ExpertProfile
@@ -98,12 +95,6 @@ class ExpertProfileType(DjangoObjectType):
     def resolve_previous_mentees(self, info, **kwargs):
         return _get_mentees(self.user, ENDED_PROGRAM_STATUS)
 
-    def resolve_latest_active_program_location(self, info, **kwargs):
-        prg = _latest_confirmed_non_future_program_role_grant(self)
-        if not prg:
-            return None
-        return prg.program_role.program.program_family.name
-
 
 def _get_slugs(self, mentor_program, latest_mentor_program, **kwargs):
     if mentor_program:
@@ -138,20 +129,3 @@ def _get_mentees(user, program_status):
         status=CONFIRMED_RELATIONSHIP,
         **mentee_filter
     ).order_by('-startup_mentor_tracking__program__start_date')
-
-
-def _confirmed_non_future_program_role_grant(obj):
-    return obj.user.programrolegrant_set.filter(
-        program_role__user_role__name=UserRole.MENTOR).exclude(
-        program_role__program__program_status__in=[
-            HIDDEN_PROGRAM_STATUS,
-            UPCOMING_PROGRAM_STATUS]
-    ).prefetch_related(
-        'program_role__program',
-        'program_role__program__program_family'
-    )
-
-
-def _latest_confirmed_non_future_program_role_grant(obj):
-    prg = _confirmed_non_future_program_role_grant(obj)
-    return prg.order_by('-created_at').first()

--- a/web/impact/impact/permissions/v1_api_permissions.py
+++ b/web/impact/impact/permissions/v1_api_permissions.py
@@ -8,12 +8,9 @@ SAFE_METHODS = ['GET', 'HEAD', 'OPTIONS']
 
 
 def can_view_user_details_page(request):
-    # importing here to avoid circular import
-    from impact.v1.views.user_detail_view import UserDetailView  # noqa: E402
-    if request.resolver_match.url_name == UserDetailView.view_name:
-        user_id = request.parser_context['kwargs'].get('pk', '')
-        if user_id and request.method in SAFE_METHODS:
-            return str(user_id) == str(request.user.id)
+    user_id = request.parser_context['kwargs'].get('pk', '')
+    if user_id and request.method in SAFE_METHODS:
+        return str(user_id) == str(request.user.id)
 
 
 class V1APIPermissions(BasePermission):
@@ -21,5 +18,10 @@ class V1APIPermissions(BasePermission):
 
     def has_permission(self, request, view):
         return (is_employee(request.user) or
-                can_view_user_details_page(request) or
                 request.user.groups.filter(name=settings.V1_API_GROUP).exists())
+
+
+class UserDetailViewPermission(V1APIPermissions):
+    def has_permission(self, request, view):
+        return (super().has_permission(request, view) or
+                can_view_user_details_page(request))

--- a/web/impact/impact/permissions/v1_api_permissions.py
+++ b/web/impact/impact/permissions/v1_api_permissions.py
@@ -1,12 +1,23 @@
 from accelerator_abstract.models.base_user_utils import is_employee
 from impact.permissions import (
     settings,
-    BasePermission)
+    BasePermission,
+)
+
+SAFE_METHODS = ['GET', 'HEAD', 'OPTIONS']
+
+
+def is_object_owner(request, user_id):
+    if user_id and request.method in SAFE_METHODS:
+        return str(user_id) == str(request.user.id)
 
 
 class V1APIPermissions(BasePermission):
     authenticated_users_only = True
 
     def has_permission(self, request, view):
+        user_id = request.parser_context['kwargs'].get('pk', '')
+
         return request.user.groups.filter(
-            name=settings.V1_API_GROUP).exists() or is_employee(request.user)
+            name=settings.V1_API_GROUP
+        ).exists() or is_employee(request.user) or is_object_owner(request, user_id)

--- a/web/impact/impact/permissions/v1_api_permissions.py
+++ b/web/impact/impact/permissions/v1_api_permissions.py
@@ -7,17 +7,19 @@ from impact.permissions import (
 SAFE_METHODS = ['GET', 'HEAD', 'OPTIONS']
 
 
-def is_object_owner(request, user_id):
-    if user_id and request.method in SAFE_METHODS:
-        return str(user_id) == str(request.user.id)
+def can_view_user_details_page(request):
+    # importing here to avoid circular import
+    from impact.v1.views.user_detail_view import UserDetailView  # noqa: E402
+    if request.resolver_match.url_name == UserDetailView.view_name:
+        user_id = request.parser_context['kwargs'].get('pk', '')
+        if user_id and request.method in SAFE_METHODS:
+            return str(user_id) == str(request.user.id)
 
 
 class V1APIPermissions(BasePermission):
     authenticated_users_only = True
 
     def has_permission(self, request, view):
-        user_id = request.parser_context['kwargs'].get('pk', '')
-
-        return request.user.groups.filter(
-            name=settings.V1_API_GROUP
-        ).exists() or is_employee(request.user) or is_object_owner(request, user_id)
+        return (is_employee(request.user) or
+                can_view_user_details_page(request) or
+                request.user.groups.filter(name=settings.V1_API_GROUP).exists())

--- a/web/impact/impact/tests/contexts/user_context.py
+++ b/web/impact/impact/tests/contexts/user_context.py
@@ -11,8 +11,6 @@ from impact.tests.factories import (
     IndustryFactory,
     MemberProfileFactory,
     UserFactory,
-    ProgramRoleFactory,
-    ProgramRoleGrantFactory,
 )
 
 
@@ -22,13 +20,11 @@ class UserContext(object):
                  primary_industry=None,
                  additional_industries=None,
                  functional_expertise=None,
-                 program_families=[],
-                 program=None):
+                 program_families=[]):
         user = UserFactory(date_joined=(timezone.now() + timedelta(-10)))
         self.user = user
         self.program_families = program_families
         self.baseprofile = BaseProfileFactory(user=user, user_type=user_type)
-        self.program = program
         if user_type == "ENTREPRENEUR":
             self.profile = EntrepreneurProfileFactory(
                 user=user,
@@ -48,9 +44,4 @@ class UserContext(object):
         elif user_type == "MEMBER":
             self.profile = MemberProfileFactory(user=self.user)
             user.memberprofile = self.profile
-        if program:
-            self.program_role = ProgramRoleFactory(program=self.program)
-            self.program_role_grant = ProgramRoleGrantFactory(
-                person=self.user,
-                program_role=self.program_role)
         user.save()

--- a/web/impact/impact/tests/contexts/user_context.py
+++ b/web/impact/impact/tests/contexts/user_context.py
@@ -11,6 +11,8 @@ from impact.tests.factories import (
     IndustryFactory,
     MemberProfileFactory,
     UserFactory,
+    ProgramRoleFactory,
+    ProgramRoleGrantFactory,
 )
 
 
@@ -20,11 +22,13 @@ class UserContext(object):
                  primary_industry=None,
                  additional_industries=None,
                  functional_expertise=None,
-                 program_families=[]):
+                 program_families=[],
+                 program=None):
         user = UserFactory(date_joined=(timezone.now() + timedelta(-10)))
         self.user = user
         self.program_families = program_families
         self.baseprofile = BaseProfileFactory(user=user, user_type=user_type)
+        self.program = program
         if user_type == "ENTREPRENEUR":
             self.profile = EntrepreneurProfileFactory(
                 user=user,
@@ -44,4 +48,9 @@ class UserContext(object):
         elif user_type == "MEMBER":
             self.profile = MemberProfileFactory(user=self.user)
             user.memberprofile = self.profile
+        if program:
+            self.program_role = ProgramRoleFactory(program=self.program)
+            self.program_role_grant = ProgramRoleGrantFactory(
+                person=self.user,
+                program_role=self.program_role)
         user.save()

--- a/web/impact/impact/tests/test_api_routes.py
+++ b/web/impact/impact/tests/test_api_routes.py
@@ -18,6 +18,8 @@ from impact.tests.factories import (
     StartupFactory,
 )
 
+from impact.v1.views.user_detail_view import UserDetailView
+
 
 class TestApiRoute(TestCase):
     client_class = APIClient
@@ -376,3 +378,16 @@ class TestApiRoute(TestCase):
             response_dict = json.loads(response.content)
             self.assertIn("is_visible", response_dict.keys())
             self.assertEqual(response_dict["is_visible"], True)
+
+    def test_current_user_can_view_their_user_detail_page(self):
+        url_name = UserDetailView.view_name
+        basic_user = self.make_user('basic_user@test.com')
+        view_kwargs = {"pk": basic_user.id}
+
+        response = self.get(url_name, **view_kwargs)
+        self.response_401(response)
+
+        with self.login(basic_user):
+            response = self.get(url_name, **view_kwargs)
+            self.response_200(response)
+

--- a/web/impact/impact/tests/test_graphql.py
+++ b/web/impact/impact/tests/test_graphql.py
@@ -81,7 +81,6 @@ class TestGraphQL(APITestCase):
                         availableOfficeHours
                         officeHoursUrl
                         programInterests
-                        latestActiveProgramLocation
                     }}
                 }}
             """.format(id=user.id)
@@ -101,7 +100,6 @@ class TestGraphQL(APITestCase):
                             'availableOfficeHours': False,
                             'officeHoursUrl': None,
                             'programInterests': [],
-                            'latestActiveProgramLocation': None
                         }
                     }
                 }
@@ -393,30 +391,6 @@ class TestGraphQL(APITestCase):
                         'entrepreneurProfile': {
                             'user': {
                                 'firstName': user.first_name
-                            },
-                        }
-                    }
-                }
-            )
-
-    def test_query_expert_by_email(self):
-        with self.login(email=self.basic_user().email):
-            user = ExpertFactory()
-            query = """
-                query {{
-                    expertProfile(email: "{email}") {{
-                        user {{ firstName }}
-                    }}
-                }}
-            """.format(email=user.email)
-            response = self.client.post(self.url, data={'query': query})
-            self.assertJSONEqual(
-                str(response.content, encoding='utf8'),
-                {
-                    'data': {
-                        'expertProfile': {
-                            'user': {
-                                'firstName': user.first_name,
                             },
                         }
                     }

--- a/web/impact/impact/tests/test_user_detail_view.py
+++ b/web/impact/impact/tests/test_user_detail_view.py
@@ -14,7 +14,7 @@ from impact.tests.factories import (
     IndustryFactory,
     MentoringSpecialtiesFactory,
     ProgramFamilyFactory,
-    ProgramFactory
+    ProgramRoleGrantFactory,
 )
 from impact.tests.api_test_case import APITestCase
 from impact.tests.utils import (
@@ -631,32 +631,26 @@ class TestUserDetailView(APITestCase):
             assert MISSING_SUBJECT_ERROR in response.data
 
     def test_get_user_latest_active_program_location(self):
-        program = ProgramFactory(
-            program_status=ACTIVE_PROGRAM_STATUS,
-            program_family=ProgramFamilyFactory(),
+        role_grant = ProgramRoleGrantFactory(
+            program_role__program__program_status=ACTIVE_PROGRAM_STATUS
         )
-        context = UserContext(user_type=EXPERT_USER_TYPE, program=program)
-        user = context.user
+        user = role_grant.person
+        user_program = role_grant.program_role.program
         with self.login(email=self.basic_user().email):
             url = reverse(UserDetailView.view_name, args=[user.id])
             response = self.client.get(url)
-            user_program = user.programrolegrant_set.order_by(
-                '-created_at'
-            ).first().program_role.program
             program_location = response.data['latest_active_program_location']
             assert user_program.program_family.name == program_location
 
     def test_get_user_confirmed_program_families(self):
-        program = ProgramFactory(
-            program_status=ACTIVE_PROGRAM_STATUS,
-            program_family=ProgramFamilyFactory(),
+        role_grant = ProgramRoleGrantFactory(
+            program_role__program__program_status=ACTIVE_PROGRAM_STATUS,
         )
-        context = UserContext(user_type=EXPERT_USER_TYPE, program=program)
-        user = context.user
+        user = role_grant.person
+        user_program = role_grant.program_role.program
         with self.login(email=self.basic_user().email):
             url = reverse(UserDetailView.view_name, args=[user.id])
             response = self.client.get(url)
-            user_program = user.programrolegrant_set.last().program_role.program
             confirmed_program_families = response.data['confirmed_user_program_families']
             assert user_program.program_family.name in confirmed_program_families.keys()
 

--- a/web/impact/impact/v1/helpers/profile_helper.py
+++ b/web/impact/impact/v1/helpers/profile_helper.py
@@ -365,6 +365,18 @@ def validate_home_program_family_id(helper, field, value):
     return validate_object_id(ProgramFamily, helper, field, value)
 
 
+def latest_distinct_program_families_dict(program_families):
+    program_families_dict = {}
+    for program_family in program_families:
+        location, created_at = program_family[0], program_family[1]
+        if location in program_families_dict.keys():
+            if created_at > program_families_dict[location]:
+                program_families_dict[location] = created_at
+        else:
+            program_families_dict[location] = created_at
+    return program_families_dict
+
+
 class ProfileHelper(ModelHelper):
     VALIDATORS = {
         "bio": validate_non_member_string,
@@ -498,15 +510,7 @@ class ProfileHelper(ModelHelper):
             program_role__program__pk__in=program_ids
         ).values_list(
             'program_role__program__program_family__name', 'created_at'))
-        program_families_dict = {}
-        for program_family in program_families:
-            location, created_at = program_family[0], program_family[1]
-            if location in program_families_dict.keys():
-                if created_at > program_families_dict[location]:
-                    program_families_dict[location] = created_at
-            else:
-                program_families_dict[location] = created_at
-        return program_families_dict
+        return latest_distinct_program_families_dict(program_families)
 
     @property
     def latest_active_program_location(self):

--- a/web/impact/impact/v1/helpers/user_helper.py
+++ b/web/impact/impact/v1/helpers/user_helper.py
@@ -17,6 +17,7 @@ from impact.v1.helpers.model_helper import (
     REQUIRED_STRING_FIELD,
     TWITTER_FIELD,
     OPTIONAL_URL_FIELD,
+    READ_ONLY_OBJECT_FIELD
 )
 from impact.v1.helpers.validators import (
     validate_boolean,
@@ -76,6 +77,8 @@ USER_FIELDS = {
     "personal_website_url": PERSONAL_WEBSITE_URL_FIELD,
     "functional_expertise": MPTT_ARRAY_FIELD,
     "program_families": MPTT_ARRAY_FIELD,
+    "confirmed_user_program_families": READ_ONLY_OBJECT_FIELD,
+    "latest_active_program_location": READ_ONLY_STRING_FIELD,
 }
 
 

--- a/web/impact/impact/v1/views/user_detail_view.py
+++ b/web/impact/impact/v1/views/user_detail_view.py
@@ -14,6 +14,7 @@ from impact.v1.helpers import (
 )
 from impact.v1.views.base_detail_view import BaseDetailView
 from impact.v1.views.utils import valid_keys_note
+from impact.permissions.v1_api_permissions import UserDetailViewPermission
 
 INVALID_KEYS_ERROR = "Recevied invalid key(s): {invalid_keys}."
 MISSING_PROFILE_ERROR = "User ({}) has no profile"
@@ -26,6 +27,9 @@ class UserDetailView(BaseDetailView):
     view_name = "user_detail"
     helper_class = UserHelper
     actions = ["GET", "PATCH"]
+    permission_classes = (
+        UserDetailViewPermission,
+    )
 
     def __init__(self, *args, **kwargs):
         self.user = None


### PR DESCRIPTION
### Changes introduced in: [AC-7430](https://masschallenge.atlassian.net/browse/AC-7430):
- Provides API functionality to ensure that all the users (not only experts) can GET their `confirmed_user_program_families` and `latest_active_program_location` to be used on the front-end to get relevant program matches
### How to test
- Check out to  `AC-7430`  on `impact-api`
- Visit http://localhost:8000/api/v1/user/(logged-in-user-id)/
You should be able to see the current authenticated user dict of `confirmed_user_program_families` and string of `latest_active_program_location`
example of data: 
```
    "confirmed_user_program_families": {
        "Israel": "2019-02-06T22:46:00Z",
        "Boston": "2019-05-15T19:03:22Z",
        "Mexico": "2019-06-28T22:31:18Z"
    },
    "latest_active_program_location": "Mexico"
```
Date as value in confirmed_user_program_families dict will be used to obtain the most recent program role for the user that matches with a program on the card incase of multiple matches on the front-end

[Link to front end PR](https://github.com/masschallenge/front-end/pull/208)

