### PR TITLE
[AC-7450] P1: v0 and V1 API permissions failure

### DIFF
--- a/web/impact/impact/permissions/v0_api_permissions.py
+++ b/web/impact/impact/permissions/v0_api_permissions.py
@@ -8,4 +8,4 @@ class V0APIPermissions(BasePermission):
 
     def has_permission(self, request, view):
         return request.user.groups.filter(
-            name=settings.V0_API_GROUP.decode("utf-8")).exists()
+            name=settings.V0_API_GROUP).exists()

--- a/web/impact/impact/permissions/v0_api_permissions.py
+++ b/web/impact/impact/permissions/v0_api_permissions.py
@@ -8,4 +8,4 @@ class V0APIPermissions(BasePermission):
 
     def has_permission(self, request, view):
         return request.user.groups.filter(
-            name=settings.V0_API_GROUP).exists()
+            name=settings.V0_API_GROUP.decode("utf-8")).exists()

--- a/web/impact/impact/settings.py
+++ b/web/impact/impact/settings.py
@@ -197,8 +197,8 @@ class Base(Configuration):
     V0_SITE_NAME = bytes(os.environ.get(
         'IMPACT_API_V0_SITE_NAME', 'masschallenge.org'), 'utf-8')
 
-    V0_API_GROUP = bytes(os.environ.get(
-        'IMPACT_API_V0_API_GROUP', 'v0_clients'), 'utf-8')
+    V0_API_GROUP = os.environ.get(
+        'IMPACT_API_V0_API_GROUP', 'v0_clients')
 
     # This and the above should get generalized.  See AC-4574.
     V1_API_GROUP = bytes(os.environ.get(

--- a/web/impact/impact/settings.py
+++ b/web/impact/impact/settings.py
@@ -201,8 +201,8 @@ class Base(Configuration):
         'IMPACT_API_V0_API_GROUP', 'v0_clients')
 
     # This and the above should get generalized.  See AC-4574.
-    V1_API_GROUP = bytes(os.environ.get(
-        'IMPACT_API_V1_API_GROUP', 'v1_clients'), 'utf-8')
+    V1_API_GROUP = os.environ.get(
+        'IMPACT_API_V1_API_GROUP', 'v1_clients')
 
     V1_CONFIDENTIAL_API_GROUP = bytes('v1_confidential', 'utf-8')
 


### PR DESCRIPTION
### Changes introduced in: [AC-7450](https://masschallenge.atlassian.net/browse/AC-7450):
- Converts permission value for `v0` and `v1` endpoints to string

### How to test
- Authenticate follow these instructions https://github.com/masschallenge/impact-api/blob/development/api.md#register-your-use-of-the-api
- Required data https://github.com/masschallenge/impact-api/blob/development/api.md#register-your-use-of-the-api

on development:
- send a `POST` request to http://localhost:8000/api/v0/startup_list/ notice that it returns the 403 response
```
{
    "detail": "You do not have permission to perform this action."
}
```
on this branch:
- send a `POST` request to http://localhost:8000/api/v0/startup_list/ and notice that a list of startups is returned