### PR TITLE
[AC-6835] Increase remote-clean-db MAX_UPLOAD_SIZE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -403,27 +403,27 @@ dump-db: mysql-container
 	@gzip $(DB_CACHE_DIR)$(db_name).sql
 	@echo Created $(DB_CACHE_DIR)$(s3_key)
 
-MAX_UPLOAD_SIZE = 160000000
+MAX_UPLOAD_SIZE = 80000000
 
-upload-db: build-aws
+upload-db:
 	@if [ `wc -c < $(gz_file) | tr -d '[:space:]'` -gt $(MAX_UPLOAD_SIZE) ]; \
 	then \
 	  echo Dump file exceeds $(MAX_UPLOAD_SIZE) bytes.; \
 	  echo This may indicate that this dump contains sensitive data; \
-	  false; \
-	fi
-	@echo Uploading $(gz_file) as $(s3_key)
-	@read -r -p "Are you sure? [y/N] " response; \
-	if [[ "$$response" =~ ^([yY][eE][sS]|[yY])+$$ ]]; \
-	then \
-	  echo Uploading $(gz_file) as $(s3_key)...; \
-	  docker run -v $$PWD/$(gz_file):/data/$(notdir $(gz_file)) --rm  \
+	else \
+	  echo Uploading $(gz_file) as $(s3_key); \
+	  read -r -p "Are you sure? [y/N] " response; \
+	  if [[ "$$response" =~ ^([yY][eE][sS]|[yY])+$$ ]]; \
+	  then \
+	    echo Uploading $(gz_file) as $(s3_key)...; \
+		docker run -v $$PWD/$(gz_file):/data/$(notdir $(gz_file)) --rm  \
 		--env-file .dev.env \
 		masschallenge/aws \
 		aws s3 cp $(notdir $(gz_file)) \
-		s3://public-clean-saved-db-states/$(s3_key) --acl public-read; \
-	else \
-	  echo Cancelled upload successfully.; \
+		s3://public-clean-saved-db-states/test-$(s3_key) --acl public-read; \
+	  else \
+	    echo Cancelled upload successfully.; \
+	  fi \
 	fi
 
 build-aws:

--- a/Makefile
+++ b/Makefile
@@ -403,7 +403,7 @@ dump-db: mysql-container
 	@gzip $(DB_CACHE_DIR)$(db_name).sql
 	@echo Created $(DB_CACHE_DIR)$(s3_key)
 
-MAX_UPLOAD_SIZE = 80000000
+MAX_UPLOAD_SIZE = 160000000
 
 upload-db:
 	@if [ `wc -c < $(gz_file) | tr -d '[:space:]'` -gt $(MAX_UPLOAD_SIZE) ]; \
@@ -420,7 +420,7 @@ upload-db:
 		--env-file .dev.env \
 		masschallenge/aws \
 		aws s3 cp $(notdir $(gz_file)) \
-		s3://public-clean-saved-db-states/test-$(s3_key) --acl public-read; \
+		s3://public-clean-saved-db-states/$(s3_key) --acl public-read; \
 	  else \
 	    echo Cancelled upload successfully.; \
 	  fi \

--- a/Makefile
+++ b/Makefile
@@ -403,10 +403,10 @@ dump-db: mysql-container
 	@gzip $(DB_CACHE_DIR)$(db_name).sql
 	@echo Created $(DB_CACHE_DIR)$(s3_key)
 
-MAX_UPLOAD_SIZE = 80000000
+MAX_UPLOAD_SIZE = 160000000
 
 upload-db: build-aws
-	@if [ `wc -c < $(gz_file)` \> $(MAX_UPLOAD_SIZE) ]; \
+	@if [ `wc -c < $(gz_file) | tr -d '[:space:]'` -gt $(MAX_UPLOAD_SIZE) ]; \
 	then \
 	  echo Dump file exceeds $(MAX_UPLOAD_SIZE) bytes.; \
 	  echo This may indicate that this dump contains sensitive data; \

--- a/Makefile
+++ b/Makefile
@@ -405,7 +405,7 @@ dump-db: mysql-container
 
 MAX_UPLOAD_SIZE = 160000000
 
-upload-db:
+upload-db: build-aws
 	@if [ `wc -c < $(gz_file) | tr -d '[:space:]'` -gt $(MAX_UPLOAD_SIZE) ]; \
 	then \
 	  echo \\nError: Dump file exceeds $(MAX_UPLOAD_SIZE) bytes.; \

--- a/Makefile
+++ b/Makefile
@@ -408,8 +408,8 @@ MAX_UPLOAD_SIZE = 80000000
 upload-db:
 	@if [ `wc -c < $(gz_file) | tr -d '[:space:]'` -gt $(MAX_UPLOAD_SIZE) ]; \
 	then \
-	  echo Dump file exceeds $(MAX_UPLOAD_SIZE) bytes.; \
-	  echo This may indicate that this dump contains sensitive data; \
+	  echo \\nError: Dump file exceeds $(MAX_UPLOAD_SIZE) bytes.; \
+	  echo This may indicate that this dump contains sensitive data \\n; \
 	else \
 	  echo Uploading $(gz_file) as $(s3_key); \
 	  read -r -p "Are you sure? [y/N] " response; \


### PR DESCRIPTION
### Changes introduced in: [AC-6835](https://masschallenge.atlassian.net/browse/AC-6835):
- Increases the max upload size

### How to test

Ensure that in `db_cache/` there is a database file `initial_schema.sql.gz` (default name) the more the 80MBs
Add aws credentials in `.dev.env`

on development:
- Run `make upload-db`, this returns the following error
```
Dump file exceeds 80000000 bytes.
This may indicate that this dump contains sensitive data
make: *** [upload-db] Error 1
```

on this branch:

prefix the database name to keep the original unaltered `s3://public-clean-saved-db-states/test-$(s3_key) --acl public-read`
- Run `make upload-db`
- Enter `y` and notice the upload starts
- Verify the upload [here](https://s3.console.aws.amazon.com/s3/buckets/public-clean-saved-db-states/?region=us-east-1&tab=overview)

improvement on handling a failed max condition:
- reduce the `MAX_UPLOAD_SIZE` to a `1000000`
- Run `make upload-db` Notice the error message is returned without `make: *** [upload-db] Error 1`