### PR TITLE
[AC-7504] Error on /v1/user when PRG has null created_at

### DIFF
--- a/web/impact/impact/tests/test_user_detail_view.py
+++ b/web/impact/impact/tests/test_user_detail_view.py
@@ -651,8 +651,12 @@ class TestUserDetailView(APITestCase):
         with self.login(email=self.basic_user().email):
             url = reverse(UserDetailView.view_name, args=[user.id])
             response = self.client.get(url)
-            confirmed_program_families = response.data['confirmed_user_program_families']
-            assert user_program.program_family.name in confirmed_program_families.keys()
+            confirmed_program_families = response.data[
+                'confirmed_user_program_families'
+            ]
+
+            keys = confirmed_program_families.keys()
+            assert user_program.program_family.name in keys
 
     def test_get_user_with_no_created_at_in_prgs_handled(self):
         role_grant = ProgramRoleGrantFactory(
@@ -675,12 +679,15 @@ class TestUserDetailView(APITestCase):
 
         role_grant.save()
         role_grant2.save()
-        
+
         with self.login(email=self.basic_user().email):
             url = reverse(UserDetailView.view_name, args=[user.id])
             response = self.client.get(url)
-            confirmed_program_families = response.data['confirmed_user_program_families']
-            assert user_program.program_family.name in confirmed_program_families.keys()
+            confirmed_program_families = response.data[
+                'confirmed_user_program_families'
+            ]
+            keys = confirmed_program_families.keys()
+            assert user_program.program_family.name in keys
 
 
 def _valid_note(messages):

--- a/web/impact/impact/tests/test_user_detail_view.py
+++ b/web/impact/impact/tests/test_user_detail_view.py
@@ -662,7 +662,6 @@ class TestUserDetailView(APITestCase):
         role_grant = ProgramRoleGrantFactory(
             program_role__program__program_status=ACTIVE_PROGRAM_STATUS,
             program_role__program__program_family__name="Quigville",
-            created_at=None
         )
         user = role_grant.person
         user_program = role_grant.program_role.program
@@ -671,7 +670,6 @@ class TestUserDetailView(APITestCase):
             person=user,
             program_role__program__program_status=ACTIVE_PROGRAM_STATUS,
             program_role__program__program_family__name="Quigville",
-            created_at=None
         )
 
         role_grant.created_at = None

--- a/web/impact/impact/tests/test_user_detail_view.py
+++ b/web/impact/impact/tests/test_user_detail_view.py
@@ -661,7 +661,6 @@ class TestUserDetailView(APITestCase):
     def test_get_user_with_no_created_at_in_prgs_handled(self):
         role_grant = ProgramRoleGrantFactory(
             program_role__program__program_status=ACTIVE_PROGRAM_STATUS,
-            program_role__program__program_family__name="Quigville",
         )
         user = role_grant.person
         user_program = role_grant.program_role.program
@@ -669,7 +668,6 @@ class TestUserDetailView(APITestCase):
         role_grant2 = ProgramRoleGrantFactory(
             person=user,
             program_role__program__program_status=ACTIVE_PROGRAM_STATUS,
-            program_role__program__program_family__name="Quigville",
         )
 
         role_grant.created_at = None

--- a/web/impact/impact/tests/test_user_detail_view.py
+++ b/web/impact/impact/tests/test_user_detail_view.py
@@ -654,6 +654,34 @@ class TestUserDetailView(APITestCase):
             confirmed_program_families = response.data['confirmed_user_program_families']
             assert user_program.program_family.name in confirmed_program_families.keys()
 
+    def test_get_user_with_no_created_at_in_prgs_handled(self):
+        role_grant = ProgramRoleGrantFactory(
+            program_role__program__program_status=ACTIVE_PROGRAM_STATUS,
+            program_role__program__program_family__name="Quigville",
+            created_at=None
+        )
+        user = role_grant.person
+        user_program = role_grant.program_role.program
+
+        role_grant2 = ProgramRoleGrantFactory(
+            person=user,
+            program_role__program__program_status=ACTIVE_PROGRAM_STATUS,
+            program_role__program__program_family__name="Quigville",
+            created_at=None
+        )
+
+        role_grant.created_at = None
+        role_grant2.created_at = None
+
+        role_grant.save()
+        role_grant2.save()
+        
+        with self.login(email=self.basic_user().email):
+            url = reverse(UserDetailView.view_name, args=[user.id])
+            response = self.client.get(url)
+            confirmed_program_families = response.data['confirmed_user_program_families']
+            assert user_program.program_family.name in confirmed_program_families.keys()
+
 
 def _valid_note(messages):
     note_prefix = VALID_KEYS_NOTE.format("")

--- a/web/impact/impact/v1/helpers/profile_helper.py
+++ b/web/impact/impact/v1/helpers/profile_helper.py
@@ -365,17 +365,17 @@ def validate_home_program_family_id(helper, field, value):
     return validate_object_id(ProgramFamily, helper, field, value)
 
 
-def latest_distinct_program_families_dict(program_families):
-    program_families_dict = {}
+def confirmed_user_program_data(program_families):
+    program_family_to_date_created = {}
     for program_family in program_families:
         location, created_at = program_family[0], program_family[1]
         created_at = created_at or program_family[2]
-        if location in program_families_dict.keys():
-            if created_at > program_families_dict[location]:
-                program_families_dict[location] = created_at
+        if location in program_family_to_date_created.keys():
+            if created_at > program_family_to_date_created[location]:
+                program_family_to_date_created[location] = created_at
         else:
-            program_families_dict[location] = created_at
-    return program_families_dict
+            program_family_to_date_created[location] = created_at
+    return program_family_to_date_created
 
 
 class ProfileHelper(ModelHelper):
@@ -513,10 +513,12 @@ class ProfileHelper(ModelHelper):
             ).values_list(
                 'program_role__program__program_family__name',
                 'created_at',
+                # We include person__date_joined as a
+                # fallback for legacy PRGs with no date
                 'person__date_joined'
             )
         )
-        return latest_distinct_program_families_dict(program_families)
+        return confirmed_user_program_data(program_families)
 
     @property
     def latest_active_program_location(self):

--- a/web/impact/impact/v1/helpers/profile_helper.py
+++ b/web/impact/impact/v1/helpers/profile_helper.py
@@ -368,9 +368,11 @@ def validate_home_program_family_id(helper, field, value):
 def latest_distinct_program_families_dict(program_families):
     program_families_dict = {}
     for program_family in program_families:
-        location, created_at, user_created_at = program_family[0], program_family[1], program_family[2]
+        location, created_at = program_family[0], program_family[1]
+        user_created_at = program_family[2]
         if location in program_families_dict.keys():
-            if (created_at or user_created_at) > program_families_dict[location]:
+            created_at = (created_at or user_created_at)
+            if created_at > program_families_dict[location]:
                 program_families_dict[location] = created_at
         else:
             program_families_dict[location] = (created_at or user_created_at)
@@ -506,10 +508,15 @@ class ProfileHelper(ModelHelper):
     def confirmed_user_program_families(self):
         prg = _confirmed_non_future_program_role_grant(self.subject)
         program_ids = _latest_program_id_foreach_program_family()
-        program_families = list(prg.filter(
-            program_role__program__pk__in=program_ids
-        ).values_list(
-            'program_role__program__program_family__name', 'created_at', 'person__date_joined'))
+        program_families = list(
+            prg.filter(
+                program_role__program__pk__in=program_ids
+            ).values_list(
+                'program_role__program__program_family__name',
+                'created_at',
+                'person__date_joined'
+            )
+        )
         return latest_distinct_program_families_dict(program_families)
 
     @property

--- a/web/impact/impact/v1/helpers/profile_helper.py
+++ b/web/impact/impact/v1/helpers/profile_helper.py
@@ -368,12 +368,12 @@ def validate_home_program_family_id(helper, field, value):
 def latest_distinct_program_families_dict(program_families):
     program_families_dict = {}
     for program_family in program_families:
-        location, created_at = program_family[0], program_family[1]
+        location, created_at, user_created_at = program_family[0], program_family[1], program_family[2]
         if location in program_families_dict.keys():
-            if created_at > program_families_dict[location]:
+            if (created_at or user_created_at) > program_families_dict[location]:
                 program_families_dict[location] = created_at
         else:
-            program_families_dict[location] = created_at
+            program_families_dict[location] = (created_at or user_created_at)
     return program_families_dict
 
 
@@ -509,7 +509,7 @@ class ProfileHelper(ModelHelper):
         program_families = list(prg.filter(
             program_role__program__pk__in=program_ids
         ).values_list(
-            'program_role__program__program_family__name', 'created_at'))
+            'program_role__program__program_family__name', 'created_at', 'person__date_joined'))
         return latest_distinct_program_families_dict(program_families)
 
     @property

--- a/web/impact/impact/v1/helpers/profile_helper.py
+++ b/web/impact/impact/v1/helpers/profile_helper.py
@@ -369,13 +369,12 @@ def latest_distinct_program_families_dict(program_families):
     program_families_dict = {}
     for program_family in program_families:
         location, created_at = program_family[0], program_family[1]
-        user_created_at = program_family[2]
+        created_at = created_at or program_family[2]
         if location in program_families_dict.keys():
-            created_at = (created_at or user_created_at)
             if created_at > program_families_dict[location]:
                 program_families_dict[location] = created_at
         else:
-            program_families_dict[location] = (created_at or user_created_at)
+            program_families_dict[location] = created_at
     return program_families_dict
 
 


### PR DESCRIPTION
[JIRA](https://masschallenge.atlassian.net/browse/AC-7504)

older users have null `created_at`s in their PRGs. 
Since we use this value for comparison, it creates an error for some users

To test
- on development
- Masquerade as a user with PRGs with null `created_at`'s e.g `shankar@masschallenge.org` if you have a recent prod dump
- visit localhost:8000/api/v1/user/{
- should be greated with a 500 error
- check out this branch
- error should be resolved
