### PR TITLE
[AC-7523] changing read replica router to pinning database router

### DIFF
--- a/web/impact/impact/settings.py
+++ b/web/impact/impact/settings.py
@@ -63,15 +63,6 @@ class Base(Configuration):
 
     SLAVE_DATABASES = ['default']
 
-    if os.environ.get('READ_REPLICA_DATABASE_URL'):
-        DATABASES.update(values.DatabaseURLValue(  # pragma: no cover
-            alias='read-replica',
-            environ_name='READ_REPLICA_DATABASE_URL').value)
-
-        SLAVE_DATABASES = ['read-replica']  # pragma: no cover
-
-        DATABASE_ROUTERS = ('multidb.MasterSlaveRouter',)  # pragma: no cover
-
     EMAIL = values.EmailURLValue()
 
     SECRET_KEY = values.Value()
@@ -130,6 +121,20 @@ class Base(Configuration):
         'oauth2_provider.middleware.OAuth2TokenMiddleware',
         'impact.middleware.MethodOverrideMiddleware',
     ]
+
+    if os.environ.get('READ_REPLICA_DATABASE_URL'):
+        DATABASES.update(values.DatabaseURLValue(  # pragma: no cover
+            alias='read-replica',
+            environ_name='READ_REPLICA_DATABASE_URL').value)
+
+        SLAVE_DATABASES = ['read-replica']  # pragma: no cover
+
+        DATABASE_ROUTERS = (  # pragma: no cover
+            'multidb.PinningReplicaRouter',)
+
+        MIDDLEWARE = [  # pragma: no cover
+            'multidb.middleware.PinningRouterMiddleware'] + (
+            MIDDLEWARE)
 
     CACHES = {
         'default': {


### PR DESCRIPTION
This PR fixes a bug on impact api which shows up in production with a read-replica setup. 

to see the existing issue:
- attempt to get an oauth token from production in rapid succession using the follow command (fill in the values where needed): ```curl --header "Content-Type: application/x-www-form-urlencoded" --header "Accept: application/json; indent=4" --request POST --data "username=<username>&password=<password>&client_id=<client id>&grant_type=password" https://api.masschallenge.org/oauth/token/;```
- you will see that sometimes the command returns a json blob with a token and other times it fails with a 500.

to test the fix:
- I had trouble coming up with a reasonably quick way to test this locally with a read-replica. For the time being I've deployed this branch to the staging api server. running this on staging should not throw a 500 ever: ```curl --header "Content-Type: application/x-www-form-urlencoded" --header "Accept: application/json; indent=4" --request POST --data "username=<username>&password=<password>&client_id=<client id>&grant_type=password" https://stagingapi.masschallenge.org/oauth/token/;```

