### PR TITLE
[AC 7393] Update Expert profile pages with accurate labels

### DIFF
--- a/web/impact/impact/graphql/types/expert_profile_type.py
+++ b/web/impact/impact/graphql/types/expert_profile_type.py
@@ -102,7 +102,7 @@ class ExpertProfileType(DjangoObjectType):
         return _get_mentees(self.user, ENDED_PROGRAM_STATUS)
 
     def resolve_confirmed_mentor_program_families(self, info, **kwargs):
-        program_families = _confirmed_non_future_program_role_grant(self)
+        program_families = _visible_confirmed_mentor_role_grants(self)
         program_ids = latest_program_id_for_each_program_family()
         return program_families.filter(
             program_role__program__pk__in=program_ids
@@ -148,7 +148,7 @@ def _get_mentees(user, program_status):
     ).order_by('-startup_mentor_tracking__program__start_date')
 
 
-def _confirmed_non_future_program_role_grant(expert_profile):
+def _visible_confirmed_mentor_role_grants(expert_profile):
     return expert_profile.user.programrolegrant_set.filter(
         program_role__user_role__name=UserRole.MENTOR).exclude(
         program_role__program__program_status__in=[

--- a/web/impact/impact/graphql/types/expert_profile_type.py
+++ b/web/impact/impact/graphql/types/expert_profile_type.py
@@ -29,7 +29,7 @@ class ExpertProfileType(DjangoObjectType):
     office_hours_url = graphene.String()
     program_interests = graphene.List(graphene.String)
     available_office_hours = graphene.Boolean()
-    confirmed_program_families = graphene.List(graphene.String)
+    confirmed_mentor_program_families = graphene.List(graphene.String)
 
     class Meta:
         model = ExpertProfile
@@ -101,7 +101,7 @@ class ExpertProfileType(DjangoObjectType):
     def resolve_previous_mentees(self, info, **kwargs):
         return _get_mentees(self.user, ENDED_PROGRAM_STATUS)
 
-    def resolve_confirmed_program_families(self, info, **kwargs):
+    def resolve_confirmed_mentor_program_families(self, info, **kwargs):
         prg = _confirmed_non_future_program_role_grant(self)
         program_ids = _latest_program_id_foreach_program_family()
         return list(prg.filter(
@@ -147,7 +147,8 @@ def _get_mentees(user, program_status):
 
 
 def _confirmed_non_future_program_role_grant(expert_profile):
-    return expert_profile.user.programrolegrant_set.exclude(
+    return expert_profile.user.programrolegrant_set.filter(
+        program_role__user_role__name=UserRole.MENTOR).exclude(
         program_role__program__program_status__in=[
             HIDDEN_PROGRAM_STATUS,
             UPCOMING_PROGRAM_STATUS]

--- a/web/impact/impact/tests/test_graphql.py
+++ b/web/impact/impact/tests/test_graphql.py
@@ -417,9 +417,24 @@ class TestGraphQL(APITestCase):
 
             response = self.client.post(self.url, data={'query': query})
             data = json.loads(response.content.decode("utf-8"))["data"]
-            ent_profile = data["expertProfile"]
+            expert_profile = data["expertProfile"]
 
             self.assertEqual(
-                ent_profile["confirmedMentorProgramFamilies"],
+                expert_profile["confirmedMentorProgramFamilies"],
                 [user_program.program_family.name])
 
+    def test_get_query_for_user_without_confirmed_mentor_program_families(self):
+        user = ExpertFactory()
+        with self.login(email=self.basic_user().email):
+            query = """
+                query {{
+                    expertProfile(id: {id}) {{
+                        confirmedMentorProgramFamilies
+                    }}
+                }}
+            """.format(id=user.id)
+
+            response = self.client.post(self.url, data={'query': query})
+            data = json.loads(response.content.decode("utf-8"))["data"]
+            expert_profile = data["expertProfile"]
+            self.assertEqual(expert_profile["confirmedMentorProgramFamilies"], [])

--- a/web/impact/impact/tests/test_graphql.py
+++ b/web/impact/impact/tests/test_graphql.py
@@ -398,9 +398,10 @@ class TestGraphQL(APITestCase):
                 }
             )
 
-    def test_get_user_confirmed_program_families(self):
+    def test_get_user_confirmed_mentor_program_families(self):
         role_grant = ProgramRoleGrantFactory(
             program_role__program__program_status=ACTIVE_PROGRAM_STATUS,
+            program_role__user_role__name=UserRole.MENTOR,
             person=ExpertFactory(),
         )
         user = role_grant.person
@@ -409,7 +410,7 @@ class TestGraphQL(APITestCase):
             query = """
                 query {{
                     expertProfile(id: {id}) {{
-                        confirmedProgramFamilies
+                        confirmedMentorProgramFamilies
                     }}
                 }}
             """.format(id=user.id)
@@ -419,6 +420,6 @@ class TestGraphQL(APITestCase):
             ent_profile = data["expertProfile"]
 
             self.assertEqual(
-                ent_profile["confirmedProgramFamilies"],
+                ent_profile["confirmedMentorProgramFamilies"],
                 [user_program.program_family.name])
 

--- a/web/impact/impact/v1/helpers/profile_helper.py
+++ b/web/impact/impact/v1/helpers/profile_helper.py
@@ -512,7 +512,7 @@ class ProfileHelper(ModelHelper):
     @property
     def confirmed_user_program_families(self):
         prg = _confirmed_non_future_program_role_grant(self.subject)
-        program_ids = latest_program_id_foreach_program_family()
+        program_ids = latest_program_id_for_each_program_family()
         program_families = list(
             prg.filter(
                 program_role__program__pk__in=program_ids
@@ -549,7 +549,7 @@ def _latest_confirmed_non_future_program_role_grant(obj):
     return prg.order_by('-created_at').first()
 
 
-def latest_program_id_foreach_program_family():
+def latest_program_id_for_each_program_family():
     latest_program_subquery = Program.objects.filter(
         program_family=OuterRef('pk'),
         program_status__in=[ACTIVE_PROGRAM_STATUS, ENDED_PROGRAM_STATUS]

--- a/web/impact/impact/v1/helpers/profile_helper.py
+++ b/web/impact/impact/v1/helpers/profile_helper.py
@@ -512,7 +512,7 @@ class ProfileHelper(ModelHelper):
     @property
     def confirmed_user_program_families(self):
         prg = _confirmed_non_future_program_role_grant(self.subject)
-        program_ids = _latest_program_id_foreach_program_family()
+        program_ids = latest_program_id_foreach_program_family()
         program_families = list(
             prg.filter(
                 program_role__program__pk__in=program_ids
@@ -549,7 +549,7 @@ def _latest_confirmed_non_future_program_role_grant(obj):
     return prg.order_by('-created_at').first()
 
 
-def _latest_program_id_foreach_program_family():
+def latest_program_id_foreach_program_family():
     latest_program_subquery = Program.objects.filter(
         program_family=OuterRef('pk'),
         program_status__in=[ACTIVE_PROGRAM_STATUS, ENDED_PROGRAM_STATUS]


### PR DESCRIPTION
## [AC 7393](https://masschallenge.atlassian.net/browse/AC-7393)

**Changes Introduced**:
- Industry  section 
  - merge existing primary and secondary industry sections
  - Displays all industries for the user with the primary industry listed first

- Knowledge areas (previously called ‘Expert mentor in’)

  - Displays all functional expertise listed on the mentor profile

- Program Affiliation (replaces Home Program section)

  - Displays all programs in which the mentor has a confirmed program role grant

  - Home program is displayed at the top of the list with a home icon

This ticket clones [AC 7327](https://masschallenge.atlassian.net/browse/AC-7393): The done definition not implemented in this ticket is provided by AC-7327

**Testing**
- As an admin, Select and save all **Interest categories** this [user](http://localhost:8181/admin/simpleuser/user/20863/change/)
- Masquerade [user](http://localhost:8181/admin/simpleuser/user/20863/masquerade/)
- Visit [user profile page](http://localhost:1234/directory/people/20863)

**Expected behavior**
- **Industry**  section displays all industries for the user with the primary industry listed first
- "Expert mentor in" is renamed to **Knowledge areas**
- **Program Affiliation** Displays all programs in which the mentor has a confirmed program role grant
 and the home program is displayed at the top of the list with a home icon

[Related PR](https://github.com/masschallenge/front-end/pull/222)