### PR TITLE
AC-7350 :: Winner Statuses are included on People and Expert Profiles

### DIFF
--- a/web/impact/impact/graphql/types/entrepreneur_profile_type.py
+++ b/web/impact/impact/graphql/types/entrepreneur_profile_type.py
@@ -49,13 +49,6 @@ class EntrepreneurProfileType(DjangoObjectType):
 
     def resolve_program_roles(self, info, **kwargs):
         user_roles_of_interest = [UserRole.FINALIST, UserRole.ALUM]
-        startup_roles_of_interest = [
-            StartupRole.ENTRANT,
-            StartupRole.GOLD_WINNER,
-            StartupRole.SILVER_WINNER,
-            StartupRole.PLATINUM_WINNER,
-            StartupRole.DIAMOND_WINNER,
-            StartupRole.IN_KIND_WINNER,
-            StartupRole.SILVER_WINNER]
+        startup_roles_of_interest = [StartupRole.ENTRANT]
         return get_user_program_roles(
             self.user, user_roles_of_interest, startup_roles_of_interest)

--- a/web/impact/impact/graphql/types/entrepreneur_profile_type.py
+++ b/web/impact/impact/graphql/types/entrepreneur_profile_type.py
@@ -15,6 +15,7 @@ from impact.graphql.types.entrepreneur_startup_type import (
 
 from impact.utils import get_user_program_roles
 
+
 class EntrepreneurProfileType(DjangoObjectType):
     image_url = graphene.String()
     title = graphene.String()
@@ -46,9 +47,15 @@ class EntrepreneurProfileType(DjangoObjectType):
             return team_member.title
         return ""
 
-
     def resolve_program_roles(self, info, **kwargs):
         user_roles_of_interest = [UserRole.FINALIST, UserRole.ALUM]
-        startup_roles_of_interest = [StartupRole.ENTRANT]
+        startup_roles_of_interest = [
+            StartupRole.ENTRANT,
+            StartupRole.GOLD_WINNER,
+            StartupRole.SILVER_WINNER,
+            StartupRole.PLATINUM_WINNER,
+            StartupRole.DIAMOND_WINNER,
+            StartupRole.IN_KIND_WINNER,
+            StartupRole.SILVER_WINNER]
         return get_user_program_roles(
             self.user, user_roles_of_interest, startup_roles_of_interest)

--- a/web/impact/impact/graphql/types/entrepreneur_profile_type.py
+++ b/web/impact/impact/graphql/types/entrepreneur_profile_type.py
@@ -49,14 +49,7 @@ class EntrepreneurProfileType(DjangoObjectType):
 
     def resolve_program_roles(self, info, **kwargs):
         user_roles_of_interest = [UserRole.FINALIST, UserRole.ALUM]
-        startup_roles_of_interest = [
-            StartupRole.ENTRANT,
-            StartupRole.WINNER,
-            StartupRole.GOLD_WINNER,
-            StartupRole.SILVER_WINNER,
-            StartupRole.PLATINUM_WINNER,
-            StartupRole.IN_KIND_WINNER,
-            StartupRole.SILVER_WINNER,
-        ]
+        startup_roles_of_interest = [StartupRole.ENTRANT]
+        startup_roles_of_interest += StartupRole.WINNER_STARTUP_ROLES
         return get_user_program_and_startup_roles(
             self.user, user_roles_of_interest, startup_roles_of_interest)

--- a/web/impact/impact/graphql/types/entrepreneur_profile_type.py
+++ b/web/impact/impact/graphql/types/entrepreneur_profile_type.py
@@ -49,6 +49,14 @@ class EntrepreneurProfileType(DjangoObjectType):
 
     def resolve_program_roles(self, info, **kwargs):
         user_roles_of_interest = [UserRole.FINALIST, UserRole.ALUM]
-        startup_roles_of_interest = [StartupRole.ENTRANT]
+        startup_roles_of_interest = [
+            StartupRole.ENTRANT,
+            StartupRole.WINNER,
+            StartupRole.GOLD_WINNER,
+            StartupRole.SILVER_WINNER,
+            StartupRole.PLATINUM_WINNER,
+            StartupRole.IN_KIND_WINNER,
+            StartupRole.SILVER_WINNER,
+        ]
         return get_user_program_roles(
             self.user, user_roles_of_interest, startup_roles_of_interest)

--- a/web/impact/impact/graphql/types/entrepreneur_profile_type.py
+++ b/web/impact/impact/graphql/types/entrepreneur_profile_type.py
@@ -16,7 +16,6 @@ from impact.graphql.types.entrepreneur_startup_type import (
 from impact.utils import get_user_program_and_startup_roles
 
 
-
 class EntrepreneurProfileType(DjangoObjectType):
     image_url = graphene.String()
     title = graphene.String()

--- a/web/impact/impact/graphql/types/expert_profile_type.py
+++ b/web/impact/impact/graphql/types/expert_profile_type.py
@@ -130,7 +130,15 @@ class ExpertProfileType(DjangoObjectType):
 
     def resolve_program_roles(self, info, **kwargs):
         user_roles_of_interest = [UserRole.FINALIST, UserRole.ALUM]
-        startup_roles_of_interest = [StartupRole.ENTRANT]
+        startup_roles_of_interest = [
+            StartupRole.ENTRANT,
+            StartupRole.WINNER,
+            StartupRole.GOLD_WINNER,
+            StartupRole.SILVER_WINNER,
+            StartupRole.PLATINUM_WINNER,
+            StartupRole.IN_KIND_WINNER,
+            StartupRole.SILVER_WINNER,
+        ]
         return get_user_program_roles(
             self.user, user_roles_of_interest, startup_roles_of_interest)
 

--- a/web/impact/impact/graphql/types/expert_profile_type.py
+++ b/web/impact/impact/graphql/types/expert_profile_type.py
@@ -132,15 +132,8 @@ class ExpertProfileType(DjangoObjectType):
         without changing GraphQL queries on the front end.
         """
         user_roles_of_interest = [UserRole.FINALIST, UserRole.ALUM]
-        startup_roles_of_interest = [
-            StartupRole.ENTRANT,
-            StartupRole.WINNER,
-            StartupRole.GOLD_WINNER,
-            StartupRole.SILVER_WINNER,
-            StartupRole.PLATINUM_WINNER,
-            StartupRole.IN_KIND_WINNER,
-            StartupRole.SILVER_WINNER,
-        ]
+        startup_roles_of_interest = [StartupRole.ENTRANT]
+        startup_roles_of_interest += StartupRole.WINNER_STARTUP_ROLES
         return get_user_program_and_startup_roles(
             self.user, user_roles_of_interest, startup_roles_of_interest)
 

--- a/web/impact/impact/graphql/types/expert_profile_type.py
+++ b/web/impact/impact/graphql/types/expert_profile_type.py
@@ -80,8 +80,8 @@ class ExpertProfileType(DjangoObjectType):
                 program_role__user_role__name=UserRole.MENTOR
         ).exists():
             role_grants = obj.user.programrolegrant_set.filter(
-            program_role__user_role__name=UserRole.MENTOR,
-            program_role__program__end_date__gte=datetime.now()
+                program_role__user_role__name=UserRole.MENTOR,
+                program_role__program__end_date__gte=datetime.now()
             ).distinct()
 
             latest_grant = obj.user.programrolegrant_set.filter(
@@ -127,16 +127,10 @@ class ExpertProfileType(DjangoObjectType):
     Time/Space amount to time and space complexity of the three helper functions
     (see functions for time/space comp analysis for each)
     """
+
     def resolve_program_roles(self, info, **kwargs):
         user_roles_of_interest = [UserRole.FINALIST, UserRole.ALUM]
-        startup_roles_of_interest = [
-            StartupRole.ENTRANT,
-            StartupRole.GOLD_WINNER,
-            StartupRole.SILVER_WINNER,
-            StartupRole.PLATINUM_WINNER,
-            StartupRole.DIAMOND_WINNER,
-            StartupRole.IN_KIND_WINNER,
-            StartupRole.SILVER_WINNER]
+        startup_roles_of_interest = [StartupRole.ENTRANT]
         return get_user_program_roles(
             self.user, user_roles_of_interest, startup_roles_of_interest)
 
@@ -148,9 +142,10 @@ def _get_slugs(obj, mentor_program, latest_mentor_program, **kwargs):
             mentor_program[0].url_slug,
         )
     return (
-            latest_mentor_program.program_family.url_slug,
-            latest_mentor_program.url_slug,
-        )
+        latest_mentor_program.program_family.url_slug,
+        latest_mentor_program.url_slug,
+    )
+
 
 def _get_user_programs(user):
     # todo: refactor this and move it to a sensible place

--- a/web/impact/impact/graphql/types/expert_profile_type.py
+++ b/web/impact/impact/graphql/types/expert_profile_type.py
@@ -129,7 +129,14 @@ class ExpertProfileType(DjangoObjectType):
     """
     def resolve_program_roles(self, info, **kwargs):
         user_roles_of_interest = [UserRole.FINALIST, UserRole.ALUM]
-        startup_roles_of_interest = [StartupRole.ENTRANT]
+        startup_roles_of_interest = [
+            StartupRole.ENTRANT,
+            StartupRole.GOLD_WINNER,
+            StartupRole.SILVER_WINNER,
+            StartupRole.PLATINUM_WINNER,
+            StartupRole.DIAMOND_WINNER,
+            StartupRole.IN_KIND_WINNER,
+            StartupRole.SILVER_WINNER]
         return get_user_program_roles(
             self.user, user_roles_of_interest, startup_roles_of_interest)
 

--- a/web/impact/impact/graphql/types/startup_type.py
+++ b/web/impact/impact/graphql/types/startup_type.py
@@ -30,6 +30,5 @@ class StartupType(DjangoObjectType):
             return self.high_resolution_logo.url
 
     def resolve_program_startup_status(self, info, **kwargs):
-        return self.program_startup_statuses().filter(
-            startupstatus__startup=self).values_list(
-                'startup_status', flat=True).distinct()
+        return self.program_startup_statuses().values_list(
+            'startup_status', flat=True).distinct()

--- a/web/impact/impact/graphql/types/startup_type.py
+++ b/web/impact/impact/graphql/types/startup_type.py
@@ -13,6 +13,7 @@ class StartupType(DjangoObjectType):
     name = graphene.String()
     high_resolution_logo = graphene.String()
     program = graphene.Field(ProgramType)
+    program_startup_status = graphene.List(graphene.String)
 
     class Meta:
         model = Startup
@@ -27,3 +28,8 @@ class StartupType(DjangoObjectType):
     def resolve_high_resolution_logo(self, info, **kwargs):
         if self.high_resolution_logo:
             return self.high_resolution_logo.url
+
+    def resolve_program_startup_status(self, info, **kwargs):
+        return self.program_startup_statuses().filter(
+            startupstatus__startup=self).values_list(
+                'startup_status', flat=True).distinct()

--- a/web/impact/impact/tests/test_graphql.py
+++ b/web/impact/impact/tests/test_graphql.py
@@ -194,7 +194,8 @@ class TestGraphQL(APITestCase):
             self.assertEqual(
                 startup_response["shortPitch"], startup.short_pitch)
             self.assertEqual(
-                startup_response["programStartupStatus"], [StartupRole.GOLD_WINNER])
+                startup_response["programStartupStatus"],
+                [StartupRole.GOLD_WINNER])
             self.assertEqual(
                 startup_response["highResolutionLogo"],
                 startup.high_resolution_logo.url

--- a/web/impact/impact/tests/test_graphql.py
+++ b/web/impact/impact/tests/test_graphql.py
@@ -121,6 +121,7 @@ class TestGraphQL(APITestCase):
 
             ApplicationFactory(cycle=context.cycle, startup=startup)
             ps = ProgramStartupStatusFactory(
+                startup_status=StartupRole.GOLD_WINNER,
                 program=program,
                 startup_list_tab_id='finalists')
             StartupStatusFactory(
@@ -153,6 +154,7 @@ class TestGraphQL(APITestCase):
                             name
                             shortPitch
                             highResolutionLogo
+                            programStartupStatus
                             program {{
                                 year
                                 family
@@ -166,7 +168,6 @@ class TestGraphQL(APITestCase):
             ent_profile = data["entrepreneurProfile"]
 
             self.assertEqual(ent_profile["title"], member.title)
-
             self.assertEqual(
                 ent_profile["imageUrl"],
                 profile.image.url if profile.image else "")
@@ -192,6 +193,8 @@ class TestGraphQL(APITestCase):
             self.assertEqual(startup_response["name"], startup.name)
             self.assertEqual(
                 startup_response["shortPitch"], startup.short_pitch)
+            self.assertEqual(
+                startup_response["programStartupStatus"], [StartupRole.GOLD_WINNER])
             self.assertEqual(
                 startup_response["highResolutionLogo"],
                 startup.high_resolution_logo.url
@@ -219,12 +222,12 @@ class TestGraphQL(APITestCase):
         family_slug = mentor_program.program_family.url_slug
         program_slug = mentor_program.url_slug
         office_hours_url = (
-                        "/officehours/list/{family_slug}/{program_slug}/"
-                        .format(
-                            family_slug=family_slug,
-                            program_slug=program_slug) + (
-                            '?mentor_id={mentor_id}'.format(
-                                mentor_id=confirmed.id)))
+            "/officehours/list/{family_slug}/{program_slug}/"
+            .format(
+                family_slug=family_slug,
+                program_slug=program_slug) + (
+                '?mentor_id={mentor_id}'.format(
+                    mentor_id=confirmed.id)))
 
         query = """
             query {{
@@ -423,12 +426,12 @@ class TestGraphQL(APITestCase):
             }}
         """.format(id=user.id)
         expected_json = {
-                    'data': {
-                        'entrepreneurProfile': {
-                            'programRoles': program_roles
-                        }
-                    }
+            'data': {
+                'entrepreneurProfile': {
+                    'programRoles': program_roles
                 }
+            }
+        }
         self._assert_response_equals_json(query, expected_json)
 
     def test_query_program_roles_for_expert_returns_correct_value(self):
@@ -449,12 +452,12 @@ class TestGraphQL(APITestCase):
             }}
         """.format(id=user.id)
         expected_json = {
-                    'data': {
-                        'expertProfile': {
-                            'programRoles': program_roles
-                        }
-                    }
+            'data': {
+                'expertProfile': {
+                    'programRoles': program_roles
                 }
+            }
+        }
         self._assert_response_equals_json(query, expected_json)
 
     def test_query_program_roles_program_role_names_are_normalized(self):
@@ -497,12 +500,12 @@ class TestGraphQL(APITestCase):
             }}
         """.format(id=user.id)
         expected_json = {
-                    'data': {
-                        'expertProfile': {
-                            'programRoles': program_roles
-                        }
-                    }
+            'data': {
+                'expertProfile': {
+                    'programRoles': program_roles
                 }
+            }
+        }
         self._assert_response_equals_json(query, expected_json)
 
     def test_query_prg_roles_for_selected_roles(self):

--- a/web/impact/impact/utils.py
+++ b/web/impact/impact/utils.py
@@ -1,10 +1,6 @@
 # MIT License
 # Copyright (c) 2017 MassChallenge, Inc.
 
-from accelerator.models import (
-    StartupRole
-)
-
 from datetime import datetime
 import dateutil.parser
 from pytz import utc
@@ -146,6 +142,7 @@ def _group_by_program_family(array):
         else:
             by_program_family[program_family] = [program_role]
     return by_program_family
+
 
 def _combine_prg_roles(user_prg_roles, startup_prg_roles):
     """

--- a/web/impact/impact/utils.py
+++ b/web/impact/impact/utils.py
@@ -42,8 +42,6 @@ def parse_date(date_str):
 def get_profile(user):
     try:
         user_type = user.baseprofile.user_type
-        print(">>>>------------------")
-        print(user_type)
         if user_type == "ENTREPRENEUR":
             return user.entrepreneurprofile
         if user_type == "EXPERT":
@@ -93,13 +91,9 @@ def get_user_program_roles(
 
     user_prg_roles = _get_user_prg_role_by_program_family(
         user, user_roles_of_interest)
-    print('asddfasdfasdf')
-    print(user_prg_roles)
     startup_prg_roles = _get_user_startup_prg_role_by_program_family(
         user, startup_roles_of_interest
     )
-    print('basdbfasbdfba')
-    print(startup_prg_roles)
     return _combine_prg_roles(
         user_prg_roles=user_prg_roles, startup_prg_roles=startup_prg_roles
     )
@@ -147,7 +141,7 @@ def _get_user_startup_prg_role_by_program_family(user, startup_roles=[]):
         query = startup.program_startup_statuses()
         if startup_roles:
             query = query.filter(Q(startup_role__name__in=startup_roles) | Q(
-                startup_status__contains=StartupRole.WINNER))
+                startup_status__in=startup_roles))
         result = query.values_list(
             "startup_status", "program__program_family__name")
     return _group_by_program_family(result)


### PR DESCRIPTION
**Changes introduced in [AC-7350](https://masschallenge.atlassian.net/browse/AC-7350)**
 -  Added Winner Status label to the expert profile, entrepreneur profile and startup cards.

**How to test**
- Checkout this branch `AC-7572v2` on both `impact-api`  and `front-end`
- See test instructions on related [PR](https://github.com/masschallenge/front-end/pull/236)


**Note:** Named the branch incorrectly