### PR TITLE
P0: AC-7590 Directory not displaying member archetype profile cards

### DIFF
--- a/web/impact/impact/views/algolia_api_key_view.py
+++ b/web/impact/impact/views/algolia_api_key_view.py
@@ -41,6 +41,7 @@ IS_TEAM_MEMBER_FILTER = 'is_team_member:true'
 HAS_FINALIST_ROLE_FILTER = 'has_a_finalist_role:true'
 IS_ACTIVE_FILTER = 'is_active:true'
 IS_FINALIST = 'is_finalist:true'
+IS_NOT_MEMBER_FILTER = 'is_of_the_member_achetype:false'
 
 
 class AlgoliaApiKeyView(APIView):
@@ -103,7 +104,7 @@ def _get_filters(request):
             raise PermissionDenied()
         return _build_filter(
             IS_TEAM_MEMBER_FILTER,
-            HAS_FINALIST_ROLE_FILTER, IS_ACTIVE_FILTER)
+            HAS_FINALIST_ROLE_FILTER, IS_ACTIVE_FILTER, IS_NOT_MEMBER_FILTER)
 
     if request.GET['index'] == 'mentor':
         participant_roles = [UserRole.AIR, UserRole.STAFF, UserRole.MENTOR]

--- a/web/impact/impact/views/algolia_api_key_view.py
+++ b/web/impact/impact/views/algolia_api_key_view.py
@@ -41,7 +41,7 @@ IS_TEAM_MEMBER_FILTER = 'is_team_member:true'
 HAS_FINALIST_ROLE_FILTER = 'has_a_finalist_role:true'
 IS_ACTIVE_FILTER = 'is_active:true'
 IS_FINALIST = 'is_finalist:true'
-IS_NOT_MEMBER_FILTER = 'is_of_the_member_achetype:false'
+IS_NOT_MEMBER_FILTER = 'NOT type:member'
 
 
 class AlgoliaApiKeyView(APIView):


### PR DESCRIPTION
### Changes introduced in: [AC-7590](https://masschallenge.atlassian.net/browse/AC-7590):
- add a filter for excluding member archetype profiles
### How to test
- Assuming that your demo admin account has staff privileges, navigate to the people directory and search for this [member archetype profile](http://localhost:1234/people?query=User-First-9109%20User-Last-9109).
- Notice that there is a search result corresponding to this user
- Masquerade as this [finalist user](http://localhost:8181/admin/simpleuser/user/15812/masquerade/)
- Repeat the previous search
- Notice that the user does not appear in the search results
- Go to algolia in the `dev_people` [index](https://www.algolia.com/apps/3WW3PBJ1CW/explorer/browse/dev_people) and search for the same user ie `User-First-9109 User-Last-9109`.
- Look at the type attribute and notice that it has the value `member`
- Try other profiles and confirm that only staff can see `member` archetype profiles in the search results.