### PR TITLE
[AC-7570] Add minimal mail handler to impact-api

### DIFF
--- a/web/impact/impact/impact_email_backend.py
+++ b/web/impact/impact/impact_email_backend.py
@@ -1,5 +1,5 @@
-from django.core.mail.backends.smtp import EmailBackend
 from django.conf import settings
+from django.core.mail.backends.smtp import EmailBackend
 
 
 class ImpactEmailBackend(EmailBackend):

--- a/web/impact/impact/impact_email_backend.py
+++ b/web/impact/impact/impact_email_backend.py
@@ -1,0 +1,21 @@
+from django.core.mail.backends.smtp import EmailBackend
+from django.conf import settings
+
+
+class ImpactEmailBackend(EmailBackend):
+
+    def send_messages(self, email_messages):
+        messages = []
+        if settings.SES_CONFIGURATION_SET:
+            messages = self._add_logging_headers(email_messages)
+        else:
+            messages = email_messages
+        return super().send_messages(messages)
+
+    def _add_logging_headers(self, email_messages):
+        messages = []
+        for message in email_messages:
+            message.extra_headers[
+                'X-SES-CONFIGURATION-SET'] = settings.SES_CONFIGURATION_SET
+            messages.append(message)
+        return messages

--- a/web/impact/impact/minimal_email_handler.py
+++ b/web/impact/impact/minimal_email_handler.py
@@ -1,0 +1,33 @@
+from django.conf import settings
+from django.core.mail import EmailMultiAlternatives
+
+class MinimalEmailHandler:
+    '''
+    A simplistic outgoing email handler, to consolidate outgoing
+    mail sending needs of impact-api calls
+    attachment, if any, should be a triple of (filename, content, filetype)
+    attach_alternative, if any , should be 
+    '''
+    def __init__(self,
+                 to,
+                 subject,
+                 body,
+                 from_email=None,
+                 bcc=None,
+                 attachment=None,
+                 attach_alternative=None):
+        self.email = EmailMultiAlternatives(
+            subject,
+            body,
+            to=to,
+            bcc=bcc or [settings.BCC_EMAIL],
+            from_email = from_email or [settings.NO_REPLY_EMAIL])
+        if attachment:
+            self.email.attach(*attachment)
+        if attach_alternative:
+            self.email.attach_alternative(*attach_alternative)
+    
+    def send(self):
+        self.email.send()
+        
+            

--- a/web/impact/impact/minimal_email_handler.py
+++ b/web/impact/impact/minimal_email_handler.py
@@ -1,12 +1,14 @@
 from django.conf import settings
 from django.core.mail import EmailMultiAlternatives
 
+
 class MinimalEmailHandler:
     '''
     A simplistic outgoing email handler, to consolidate outgoing
     mail sending needs of impact-api calls
     attachment, if any, should be a triple of (filename, content, filetype)
-    attach_alternative, if any, should be a tuple of (attachment_text, MIME_type)
+    attach_alternative, if any, should be a tuple of
+      (attachment_text, MIME_type)
       (generally used for html version of the email)
     '''
     def __init__(self,
@@ -22,13 +24,11 @@ class MinimalEmailHandler:
             body,
             to=to,
             bcc=bcc or [settings.BCC_EMAIL],
-            from_email = from_email or [settings.NO_REPLY_EMAIL])
+            from_email=from_email or [settings.NO_REPLY_EMAIL])
         if attachment:
             self.email.attach(*attachment)
         if attach_alternative:
             self.email.attach_alternative(*attach_alternative)
-    
+
     def send(self):
         self.email.send()
-        
-            

--- a/web/impact/impact/minimal_email_handler.py
+++ b/web/impact/impact/minimal_email_handler.py
@@ -6,7 +6,8 @@ class MinimalEmailHandler:
     A simplistic outgoing email handler, to consolidate outgoing
     mail sending needs of impact-api calls
     attachment, if any, should be a triple of (filename, content, filetype)
-    attach_alternative, if any , should be 
+    attach_alternative, if any, should be a tuple of (attachment_text, MIME_type)
+      (generally used for html version of the email)
     '''
     def __init__(self,
                  to,

--- a/web/impact/impact/settings.py
+++ b/web/impact/impact/settings.py
@@ -361,7 +361,9 @@ class Base(Configuration):
             },
         }
     }
-
+    NO_REPLY_EMAIL = "noreply@masschallenge.org"
+    BCC_EMAIL = "systemlogbcc@masschallenge.org"
+    EMAIL_BACKEND = "mc.email_backends.AccelerateEmailBackend"
 
 class Dev(Base):
     DEBUG = True

--- a/web/impact/impact/settings.py
+++ b/web/impact/impact/settings.py
@@ -366,6 +366,7 @@ class Base(Configuration):
     EMAIL_BACKEND = "impact.impact_email_backend.ImpactEmailBackend"
     SES_CONFIGURATION_SET = None
 
+
 class Dev(Base):
     DEBUG = True
 

--- a/web/impact/impact/settings.py
+++ b/web/impact/impact/settings.py
@@ -363,7 +363,7 @@ class Base(Configuration):
     }
     NO_REPLY_EMAIL = "noreply@masschallenge.org"
     BCC_EMAIL = "systemlogbcc@masschallenge.org"
-    EMAIL_BACKEND = "impact.email_backends.ImpactEmailBackend"
+    EMAIL_BACKEND = "impact.impact_email_backend.ImpactEmailBackend"
     SES_CONFIGURATION_SET = None
 
 class Dev(Base):

--- a/web/impact/impact/settings.py
+++ b/web/impact/impact/settings.py
@@ -363,7 +363,8 @@ class Base(Configuration):
     }
     NO_REPLY_EMAIL = "noreply@masschallenge.org"
     BCC_EMAIL = "systemlogbcc@masschallenge.org"
-    EMAIL_BACKEND = "mc.email_backends.AccelerateEmailBackend"
+    EMAIL_BACKEND = "impact.email_backends.ImpactEmailBackend"
+    SES_CONFIGURATION_SET = None
 
 class Dev(Base):
     DEBUG = True

--- a/web/impact/impact/tests/test_impact_email_backend.py
+++ b/web/impact/impact/tests/test_impact_email_backend.py
@@ -1,0 +1,40 @@
+from mock import patch
+from django.core import mail
+from django.test import TestCase
+from django.urls import reverse
+
+from impact.minimal_email_handler import MinimalEmailHandler
+
+class TestEmailBackend(TestCase):
+
+    @patch("impact.impact_email_backend.ImpactEmailBackend._add_logging_headers")
+    @patch("django.core.mail.backends.smtp.EmailBackend.send_messages")
+    def test_email_contains_header_if_ses_config_set(
+        self,
+        mocked_backend,
+        mock_add_logging_headers
+    ):
+        with self.settings(
+                SES_CONFIGURATION_SET="test",
+                EMAIL_BACKEND='mc.email_backends.AccelerateEmailBackend'):
+            MinimalEmailHandler(["a@example.com"],
+                                "subject",
+                                "body").send()
+            self.assertTrue(mock_add_logging_headers.called)
+
+    @patch("impact.impact_email_backend.ImpactEmailBackend._add_logging_headers")
+    @patch("django.core.mail.backends.smtp.EmailBackend.send_messages")
+    def test_email_does_not_contain_header_if_ses_config_not_set(
+        self,
+        mocked_backend,
+        mock_add_logging_headers
+    ):
+        with self.settings(
+                SES_CONFIGURATION_SET="",
+                EMAIL_BACKEND='mc.email_backends.AccelerateEmailBackend'):
+            MinimalEmailHandler(["a@example.com"],
+                                "subject",
+                                "body").send()
+            self.assertFalse(mock_add_logging_headers.called)
+
+        

--- a/web/impact/impact/tests/test_impact_email_backend.py
+++ b/web/impact/impact/tests/test_impact_email_backend.py
@@ -5,9 +5,32 @@ from django.urls import reverse
 
 from impact.minimal_email_handler import MinimalEmailHandler
 
+
+IMPACT_BACKEND_PATH = 'impact.impact_email_backend.ImpactEmailBackend'
+ADD_LOGGING_HEADERS = ".".join(["impact",
+                                "impact_email_backend",
+                                "ImpactEmailBackend",
+                                "_add_logging_headers"])
+
 class TestEmailBackend(TestCase):
 
-    @patch("impact.impact_email_backend.ImpactEmailBackend._add_logging_headers")
+    @patch(ADD_LOGGING_HEADERS)
+    @patch("django.core.mail.backends.smtp.EmailBackend.send_messages")
+    def test_sending_email_hits_backend(
+        self,
+        mocked_backend,
+        mock_add_logging_headers
+    ):
+        with self.settings(
+                SES_CONFIGURATION_SET="test",
+                EMAIL_BACKEND=IMPACT_BACKEND_PATH):
+            MinimalEmailHandler(["a@example.com"],
+                                "subject",
+                                "body").send()
+            self.assertTrue(mocked_backend.called)
+ 
+
+    @patch(ADD_LOGGING_HEADERS)
     @patch("django.core.mail.backends.smtp.EmailBackend.send_messages")
     def test_email_contains_header_if_ses_config_set(
         self,
@@ -16,13 +39,13 @@ class TestEmailBackend(TestCase):
     ):
         with self.settings(
                 SES_CONFIGURATION_SET="test",
-                EMAIL_BACKEND='mc.email_backends.AccelerateEmailBackend'):
+                EMAIL_BACKEND=IMPACT_BACKEND_PATH):
             MinimalEmailHandler(["a@example.com"],
                                 "subject",
                                 "body").send()
             self.assertTrue(mock_add_logging_headers.called)
-
-    @patch("impact.impact_email_backend.ImpactEmailBackend._add_logging_headers")
+           
+    @patch(ADD_LOGGING_HEADERS)
     @patch("django.core.mail.backends.smtp.EmailBackend.send_messages")
     def test_email_does_not_contain_header_if_ses_config_not_set(
         self,
@@ -31,7 +54,7 @@ class TestEmailBackend(TestCase):
     ):
         with self.settings(
                 SES_CONFIGURATION_SET="",
-                EMAIL_BACKEND='mc.email_backends.AccelerateEmailBackend'):
+                EMAIL_BACKEND=IMPACT_BACKEND_PATH):
             MinimalEmailHandler(["a@example.com"],
                                 "subject",
                                 "body").send()

--- a/web/impact/impact/tests/test_impact_email_backend.py
+++ b/web/impact/impact/tests/test_impact_email_backend.py
@@ -5,6 +5,11 @@ from impact.minimal_email_handler import MinimalEmailHandler
 
 
 IMPACT_BACKEND_PATH = 'impact.impact_email_backend.ImpactEmailBackend'
+# Note that this definition, which duplicates a value in settings.py, 
+# is necessary since the value is not included in the settings for test
+# See AC-7670 for a ticket aimed at resolving this and other issues 
+# around testing email backends   
+
 ADD_LOGGING_HEADERS = ".".join(["impact",
                                 "impact_email_backend",
                                 "ImpactEmailBackend",

--- a/web/impact/impact/tests/test_impact_email_backend.py
+++ b/web/impact/impact/tests/test_impact_email_backend.py
@@ -1,7 +1,5 @@
 from mock import patch
-from django.core import mail
 from django.test import TestCase
-from django.urls import reverse
 
 from impact.minimal_email_handler import MinimalEmailHandler
 
@@ -11,6 +9,7 @@ ADD_LOGGING_HEADERS = ".".join(["impact",
                                 "impact_email_backend",
                                 "ImpactEmailBackend",
                                 "_add_logging_headers"])
+
 
 class TestEmailBackend(TestCase):
 
@@ -28,7 +27,6 @@ class TestEmailBackend(TestCase):
                                 "subject",
                                 "body").send()
             self.assertTrue(mocked_backend.called)
- 
 
     @patch(ADD_LOGGING_HEADERS)
     @patch("django.core.mail.backends.smtp.EmailBackend.send_messages")
@@ -44,7 +42,7 @@ class TestEmailBackend(TestCase):
                                 "subject",
                                 "body").send()
             self.assertTrue(mock_add_logging_headers.called)
-           
+
     @patch(ADD_LOGGING_HEADERS)
     @patch("django.core.mail.backends.smtp.EmailBackend.send_messages")
     def test_email_does_not_contain_header_if_ses_config_not_set(
@@ -59,5 +57,3 @@ class TestEmailBackend(TestCase):
                                 "subject",
                                 "body").send()
             self.assertFalse(mock_add_logging_headers.called)
-
-        

--- a/web/impact/impact/tests/test_minimal_mail_handler.py
+++ b/web/impact/impact/tests/test_minimal_mail_handler.py
@@ -7,10 +7,11 @@ DEFAULT_PARAM_KEYS = ("to",
                       "subject",
                       "body")
 
+
 DEFAULT_PARAM_VALS = (["a@example.com"],
                       "TEST SUBJECT",
                       "TEST BODY")
-                      
+
 
 class TestMinimalEmailHandler(TestCase):
     def test_simple_email(self):
@@ -27,16 +28,18 @@ class TestMinimalEmailHandler(TestCase):
     def test_email_with_bcc_specified(self):
         params = email_params(DEFAULT_PARAM_KEYS + ("bcc",),
                               DEFAULT_PARAM_VALS + (["e@example.com"],))
-        email = send_email(params)        
+        email = send_email(params)
         self._assert_email_matches_expected_values(email, params)
 
     def _assert_email_matches_expected_values(self, email, values_dict):
         for key, val in values_dict.items():
             self.assertEqual(val, getattr(email, key))
 
+
 def send_email(params):
     MinimalEmailHandler(**params).send()
     return mail.outbox[-1]
+
 
 def email_params(keys=DEFAULT_PARAM_KEYS,
                  vals=DEFAULT_PARAM_VALS):

--- a/web/impact/impact/tests/test_minimal_mail_handler.py
+++ b/web/impact/impact/tests/test_minimal_mail_handler.py
@@ -1,0 +1,43 @@
+from django.test import TestCase
+from django.core import mail
+from impact.minimal_email_handler import MinimalEmailHandler
+
+
+DEFAULT_PARAM_KEYS = ("to",
+                      "subject",
+                      "body")
+
+DEFAULT_PARAM_VALS = (["a@b.com"],
+                      "TEST SUBJECT",
+                      "TEST BODY")
+                      
+
+class TestMinimalEmailHandler(TestCase):
+    def test_simple_email(self):
+        params = email_params()
+        email = send_email(params)
+        self._assert_email_matches_expected_values(email, params)
+
+    def test_email_with_sender_specified_is_sent(self):
+        params = email_params(DEFAULT_PARAM_KEYS + ("from_email",),
+                              DEFAULT_PARAM_VALS + ("c@d.com",))
+        email = send_email(params)
+        self._assert_email_matches_expected_values(email, params)
+
+    def test_email_with_bcc_specified(self):
+        params = email_params(DEFAULT_PARAM_KEYS + ("bcc",),
+                              DEFAULT_PARAM_VALS + (["e@f.com"],))
+        email = send_email(params)        
+        self._assert_email_matches_expected_values(email, params)
+
+    def _assert_email_matches_expected_values(self, email, values_dict):
+        for key, val in values_dict.items():
+            self.assertEqual(val, getattr(email, key))
+
+def send_email(params):
+    MinimalEmailHandler(**params).send()
+    return mail.outbox[-1]
+
+def email_params(keys=DEFAULT_PARAM_KEYS,
+                 vals=DEFAULT_PARAM_VALS):
+    return dict(zip(keys, vals))

--- a/web/impact/impact/tests/test_minimal_mail_handler.py
+++ b/web/impact/impact/tests/test_minimal_mail_handler.py
@@ -7,7 +7,7 @@ DEFAULT_PARAM_KEYS = ("to",
                       "subject",
                       "body")
 
-DEFAULT_PARAM_VALS = (["a@b.com"],
+DEFAULT_PARAM_VALS = (["a@example.com"],
                       "TEST SUBJECT",
                       "TEST BODY")
                       
@@ -20,13 +20,13 @@ class TestMinimalEmailHandler(TestCase):
 
     def test_email_with_sender_specified_is_sent(self):
         params = email_params(DEFAULT_PARAM_KEYS + ("from_email",),
-                              DEFAULT_PARAM_VALS + ("c@d.com",))
+                              DEFAULT_PARAM_VALS + ("c@example.com",))
         email = send_email(params)
         self._assert_email_matches_expected_values(email, params)
 
     def test_email_with_bcc_specified(self):
         params = email_params(DEFAULT_PARAM_KEYS + ("bcc",),
-                              DEFAULT_PARAM_VALS + (["e@f.com"],))
+                              DEFAULT_PARAM_VALS + (["e@example.com"],))
         email = send_email(params)        
         self._assert_email_matches_expected_values(email, params)
 


### PR DESCRIPTION
https://masschallenge.atlassian.net/browse/AC-7570

Review notes:
This is prep work for office hours api endpoints that will need to send emails. It's a thin wrapper on the EmailMultiAlternatives provided by django, and does not add much to that. 

Difficult to QA since I have not been able to get it deployed successfully to test4 yet, but working on that. 