### PR TITLE
[AC 7642] P1: Users unable to access some people directory profiles

### DIFF
--- a/web/impact/impact/graphql/query.py
+++ b/web/impact/impact/graphql/query.py
@@ -1,42 +1,21 @@
 import graphene
+from graphql import GraphQLError
 
-from impact.graphql.types import (
-    EntrepreneurProfileType,
-    ExpertProfileType,
-)
 from accelerator.models import (
     EntrepreneurProfile,
-    ExpertProfile,
-    UserRole,
+    ExpertProfile
 )
-from accelerator_abstract.models.base_user_utils import is_employee
-from graphql import GraphQLError
+from impact.graphql.types import (
+    EntrepreneurProfileType,
+    ExpertProfileType
+)
+from impact.permissions.graphql_permissions import (
+    can_view_entrepreneur_profile
+)
 
 ENTREPRENEUR_NOT_FOUND_MESSAGE = 'Entrepreneur matching the id does not exist.'
 EXPERT_NOT_FOUND_MESSAGE = 'Expert matching the id does not exist.'
 NOT_ALLOWED_ACCESS_MESSAGE = 'Sorry, You are not allowed to access this page.'
-
-
-def visible_roles(current_user):
-    basic_user_roles = [
-        UserRole.FINALIST,
-        UserRole.AIR,
-        UserRole.MENTOR,
-        UserRole.PARTNER,
-        UserRole.ALUM
-    ]
-    basic_visible_roles = [UserRole.FINALIST, UserRole.STAFF, UserRole.ALUM]
-
-    current_user_roles = list(
-        current_user.programrolegrant_set.values_list(
-            'program_role__user_role__name', flat=True).distinct()
-    )
-    if not current_user_roles:
-        return [UserRole.STAFF]
-    if set(basic_user_roles).intersection(current_user_roles):
-        return basic_visible_roles + [UserRole.MENTOR]
-    if UserRole.JUDGE in current_user_roles:
-        return basic_visible_roles
 
 
 def has_permission(profile_user, roles):
@@ -66,9 +45,8 @@ class Query(graphene.ObjectType):
         if not entrepreneur:
             return GraphQLError(ENTREPRENEUR_NOT_FOUND_MESSAGE)
 
-        if not is_employee(info.context.user):
-            roles = visible_roles(info.context.user)
-            if not has_permission(entrepreneur.user, roles):
-                return GraphQLError(NOT_ALLOWED_ACCESS_MESSAGE)
+        if not can_view_entrepreneur_profile(info.context.user,
+                                             entrepreneur.user):
+            return GraphQLError(NOT_ALLOWED_ACCESS_MESSAGE)
 
         return entrepreneur

--- a/web/impact/impact/graphql/query.py
+++ b/web/impact/impact/graphql/query.py
@@ -7,13 +7,41 @@ from impact.graphql.types import (
 from accelerator.models import (
     EntrepreneurProfile,
     ExpertProfile,
+    UserRole,
 )
-from accelerator_abstract.models.base_user_role import is_finalist_user
 from accelerator_abstract.models.base_user_utils import is_employee
 from graphql import GraphQLError
+
 ENTREPRENEUR_NOT_FOUND_MESSAGE = 'Entrepreneur matching the id does not exist.'
 EXPERT_NOT_FOUND_MESSAGE = 'Expert matching the id does not exist.'
-NON_FINALIST_PROFILE_MESSAGE = 'Sorry, You are not allowed to access this page.'
+NOT_ALLOWED_ACCESS_MESSAGE = 'Sorry, You are not allowed to access this page.'
+
+
+def visible_roles(current_user):
+    basic_user_roles = [
+        UserRole.FINALIST,
+        UserRole.AIR,
+        UserRole.MENTOR,
+        UserRole.PARTNER,
+        UserRole.ALUM
+    ]
+    basic_visible_roles = [UserRole.FINALIST, UserRole.STAFF, UserRole.ALUM]
+
+    current_user_roles = list(
+        current_user.programrolegrant_set.values_list(
+            'program_role__user_role__name', flat=True).distinct()
+    )
+    if not current_user_roles:
+        return [UserRole.STAFF]
+    if set(basic_user_roles).intersection(current_user_roles):
+        return basic_visible_roles + [UserRole.MENTOR]
+    if UserRole.JUDGE in current_user_roles:
+        return basic_visible_roles
+
+
+def has_permission(profile_user, roles):
+    return profile_user.programrolegrant_set.filter(
+        program_role__user_role__name__in=roles).exists()
 
 
 class Query(graphene.ObjectType):
@@ -32,12 +60,15 @@ class Query(graphene.ObjectType):
 
     def resolve_entrepreneur_profile(self, info, **kwargs):
         user_id = kwargs.get('id')
-        entrepreneur = EntrepreneurProfile.objects.filter(user_id=user_id).first()
+        entrepreneur = EntrepreneurProfile.objects.filter(
+            user_id=user_id).first()
 
         if not entrepreneur:
             return GraphQLError(ENTREPRENEUR_NOT_FOUND_MESSAGE)
 
-        if not is_employee(info.context.user) and not is_finalist_user(entrepreneur.user):
-            return GraphQLError(NON_FINALIST_PROFILE_MESSAGE)
+        if not is_employee(info.context.user):
+            roles = visible_roles(info.context.user)
+            if not has_permission(entrepreneur.user, roles):
+                return GraphQLError(NOT_ALLOWED_ACCESS_MESSAGE)
 
         return entrepreneur

--- a/web/impact/impact/graphql/query.py
+++ b/web/impact/impact/graphql/query.py
@@ -9,6 +9,7 @@ from impact.graphql.types import (
     EntrepreneurProfileType,
     ExpertProfileType
 )
+
 from impact.permissions.graphql_permissions import (
     can_view_entrepreneur_profile
 )
@@ -16,11 +17,6 @@ from impact.permissions.graphql_permissions import (
 ENTREPRENEUR_NOT_FOUND_MESSAGE = 'Entrepreneur matching the id does not exist.'
 EXPERT_NOT_FOUND_MESSAGE = 'Expert matching the id does not exist.'
 NOT_ALLOWED_ACCESS_MESSAGE = 'Sorry, You are not allowed to access this page.'
-
-
-def has_permission(profile_user, roles):
-    return profile_user.programrolegrant_set.filter(
-        program_role__user_role__name__in=roles).exists()
 
 
 class Query(graphene.ObjectType):

--- a/web/impact/impact/permissions/graphql_permissions.py
+++ b/web/impact/impact/permissions/graphql_permissions.py
@@ -1,6 +1,4 @@
 from accelerator.models import (
-    EntrepreneurProfile,
-    ExpertProfile,
     UserRole,
 )
 from accelerator_abstract.models.base_user_utils import is_employee

--- a/web/impact/impact/permissions/graphql_permissions.py
+++ b/web/impact/impact/permissions/graphql_permissions.py
@@ -1,0 +1,45 @@
+from accelerator.models import (
+    EntrepreneurProfile,
+    ExpertProfile,
+    UserRole,
+)
+from accelerator_abstract.models.base_user_utils import is_employee
+from accelerator.models import ACTIVE_PROGRAM_STATUS
+
+
+def visible_roles(current_user):
+    basic_user_roles = [
+        UserRole.FINALIST,
+        UserRole.AIR,
+        UserRole.MENTOR,
+        UserRole.PARTNER,
+        UserRole.ALUM
+    ]
+    basic_visible_roles = [UserRole.FINALIST, UserRole.STAFF, UserRole.ALUM]
+
+    current_logged_in_user_roles = list(
+        current_user.programrolegrant_set.filter(
+            program_role__program__program_status=ACTIVE_PROGRAM_STATUS
+        ).values_list(
+            'program_role__user_role__name', flat=True).distinct()
+    )
+    if not current_logged_in_user_roles:
+        return [UserRole.STAFF]
+    if set(basic_user_roles).intersection(current_logged_in_user_roles):
+        return basic_visible_roles + [UserRole.MENTOR]
+    if UserRole.JUDGE in current_logged_in_user_roles:
+        return basic_visible_roles
+
+
+def can_view_profile(profile_user, roles):
+    return profile_user.programrolegrant_set.filter(
+        program_role__user_role__name__in=roles,
+        program_role__program__program_status=ACTIVE_PROGRAM_STATUS
+    ).exists()
+
+
+def can_view_entrepreneur_profile(current_user, profile_user):
+    if not is_employee(current_user):
+        roles = visible_roles(current_user)
+        return can_view_profile(profile_user, roles)
+    return True

--- a/web/impact/impact/tests/test_graphql.py
+++ b/web/impact/impact/tests/test_graphql.py
@@ -687,8 +687,8 @@ class TestGraphQL(APITestCase):
                 user_role=user_role,
                 program__program_status=program_status or ACTIVE_PROGRAM_STATUS
             )
-            ProgramRoleGrantFactory.create(person=user,
-                                           program_role=program_role)
+            ProgramRoleGrantFactory(person=user,
+                                    program_role=program_role)
         user.set_password('password')
         user.save()
         return user


### PR DESCRIPTION
## [AC 7642](https://masschallenge.atlassian.net/browse/AC-7642)

**Changes introduced**
- Implement access control for people directory profiles

**Testing**
- Check out this branch 
- Login or masquerade as a user with the current user role of [Staff, Finalist, Alumni in residence, Mentor, Partner, Alum or No user role]
- Visit the people directory pages: `/people/<user_id>` of the users they can view and confirm that access control is as defined in the table below:
<img width="653" alt="Screenshot 2020-04-15 at 17 19 27" src="https://user-images.githubusercontent.com/24381733/79348203-5e4c1b00-7f3d-11ea-80cf-0cc2ca154e73.png">
