### PR TITLE
[AC-7648] Remove obsoleted tests

### DIFF
--- a/web/impact/impact/tests/test_organization_history_view.py
+++ b/web/impact/impact/tests/test_organization_history_view.py
@@ -247,56 +247,6 @@ class TestOrganizationHistoryView(APITestCase):
             self.assertEqual(cycle_deadline,
                              events[0]["datetime"])
 
-    def test_startup_became_entrant_no_final_deadline(self):
-        cycle = ProgramCycleFactory(
-            application_final_deadline_date=None)
-        application = ApplicationFactory(
-            application_status=SUBMITTED_APP_STATUS,
-            application_type=cycle.default_application_type,
-            cycle=cycle,
-            submission_datetime=None)
-        startup = application.startup
-        StartupProgramInterestFactory(startup=startup,
-                                      program__cycle=cycle,
-                                      applying=True)
-        with self.login(email=self.basic_user().email):
-            url = reverse(OrganizationHistoryView.view_name,
-                          args=[startup.organization.id])
-            response = self.client.get(url)
-            events = find_events(response.data["results"],
-                                 OrganizationBecameEntrantEvent.EVENT_TYPE)
-            self.assertEqual(1, len(events))
-            self.assertEqual(DAWN_OF_TIME,
-                             events[0]["datetime"])
-
-    def test_startup_became_entrant_no_final_deadline_with_other_cycles(self):
-        prev_deadline = days_from_now(-10)
-        ProgramCycleFactory(application_final_deadline_date=prev_deadline)
-        cycle = ProgramCycleFactory(
-            application_final_deadline_date=None)
-        next_deadline = days_from_now(-5)
-        ProgramCycleFactory(application_final_deadline_date=next_deadline)
-        application = ApplicationFactory(
-            application_status=SUBMITTED_APP_STATUS,
-            application_type=cycle.default_application_type,
-            cycle=cycle,
-            submission_datetime=None)
-        startup = application.startup
-        StartupProgramInterestFactory(startup=startup,
-                                      program__cycle=cycle,
-                                      applying=True)
-        with self.login(email=self.basic_user().email):
-            url = reverse(OrganizationHistoryView.view_name,
-                          args=[startup.organization.id])
-            response = self.client.get(url)
-            events = find_events(response.data["results"],
-                                 OrganizationBecameEntrantEvent.EVENT_TYPE)
-            self.assertEqual(1, len(events))
-            self.assertEqual(prev_deadline,
-                             events[0]["datetime"])
-            self.assertEqual(next_deadline,
-                             events[0]["latest_datetime"])
-
     def test_startup_became_finalist(self):
         startup = StartupFactory()
         startup_status = StartupStatusFactory(

--- a/web/impact/impact/tests/test_user_history_view.py
+++ b/web/impact/impact/tests/test_user_history_view.py
@@ -137,24 +137,6 @@ class TestUserHistoryView(APITestCase):
             self.assertEqual(1, len(events))
             self.assertEqual(deadline, events[0]["datetime"])
 
-    def test_user_became_judge_with_no_cycle_deadline(self):
-        user_date = days_from_now(-4)
-        user = UserFactory(date_joined=user_date)
-        cycle = ProgramCycleFactory(application_final_deadline_date=None)
-        prg = ProgramRoleGrantFactory(
-            person=user,
-            program_role__program__cycle=cycle,
-            program_role__user_role__name=UserRole.JUDGE)
-        prg.created_at = None
-        prg.save()
-        with self.login(email=self.basic_user().email):
-            url = reverse(UserHistoryView.view_name, args=[prg.person.id])
-            response = self.client.get(url)
-            events = find_events(response.data["results"],
-                                 UserBecameConfirmedJudgeEvent.EVENT_TYPE)
-            self.assertEqual(1, len(events))
-            self.assertEqual(user_date, events[0]["datetime"])
-
     def test_user_became_confirmed_judge(self):
         prg = ProgramRoleGrantFactory(
             program_role__user_role__name=UserRole.JUDGE)


### PR DESCRIPTION
AC-7365 made some of the tests on impact-api obsolete, since the conditions they were testing were no longer possible due to the new db constraints. Removed those tests, which were now failing. 

There was also a null check in our code which has been removed since null is no longer allowed for that field

To test: 
verify that the changes are consistent with the changes made on AC-7365