### PR TITLE
AC-7643 :: P1: Entrant label is displayed to non-staff users

### DIFF
--- a/web/impact/impact/graphql/types/__init__.py
+++ b/web/impact/impact/graphql/types/__init__.py
@@ -1,5 +1,6 @@
 from impact.graphql.types.user_type import UserType
 from impact.graphql.types.program_type import ProgramType
+from impact.graphql.types.base_user_profile_type import BaseUserProfileType
 from impact.graphql.types.startup_type import StartupType
 from impact.graphql.types.industry_type import IndustryType
 from impact.graphql.types.program_family_type import ProgramFamilyType

--- a/web/impact/impact/graphql/types/base_user_profile_type.py
+++ b/web/impact/impact/graphql/types/base_user_profile_type.py
@@ -1,0 +1,33 @@
+from graphene_django import DjangoObjectType
+from graphene.types.generic import GenericScalar
+
+from accelerator.models import (
+    BaseProfile,
+    StartupRole,
+    UserRole
+)
+from accelerator_abstract.models.base_user_utils import is_employee
+from impact.utils import (
+    get_user_program_and_startup_roles,
+)
+
+
+class BaseUserProfileType(DjangoObjectType):
+    program_roles = GenericScalar()
+
+    class Meta:
+        model = BaseProfile
+
+    def resolve_program_roles(self, info, **kwargs):
+        """
+        Returns the program roles and startup roles for this user
+        Note that name is deceptive, since startup roles are included in the
+        return but not mentioned in the name. This cannot be fixed here
+        without changing GraphQL queries on the front end.
+        """
+        user_roles_of_interest = [UserRole.FINALIST, UserRole.ALUM]
+        startup_roles_of_interest = StartupRole.WINNER_STARTUP_ROLES
+        if is_employee(info.context.user):
+            startup_roles_of_interest += [StartupRole.ENTRANT]
+        return get_user_program_and_startup_roles(
+            self.user, user_roles_of_interest, startup_roles_of_interest)

--- a/web/impact/impact/graphql/types/entrepreneur_profile_type.py
+++ b/web/impact/impact/graphql/types/entrepreneur_profile_type.py
@@ -8,7 +8,7 @@ from accelerator.models import (
     StartupRole,
     StartupTeamMember
 )
-
+from accelerator_abstract.models.base_user_utils import is_employee
 from impact.graphql.types.entrepreneur_startup_type import (
     EntrepreneurStartupType,
 )
@@ -50,7 +50,7 @@ class EntrepreneurProfileType(DjangoObjectType):
     def resolve_program_roles(self, info, **kwargs):
         user_roles_of_interest = [UserRole.FINALIST, UserRole.ALUM]
         startup_roles_of_interest = StartupRole.WINNER_STARTUP_ROLES
-        if info.context.user.is_staff:
+        if is_employee(info.context.user):
             startup_roles_of_interest += [StartupRole.ENTRANT]
         return get_user_program_and_startup_roles(
             self.user, user_roles_of_interest, startup_roles_of_interest)

--- a/web/impact/impact/graphql/types/entrepreneur_profile_type.py
+++ b/web/impact/impact/graphql/types/entrepreneur_profile_type.py
@@ -49,7 +49,8 @@ class EntrepreneurProfileType(DjangoObjectType):
 
     def resolve_program_roles(self, info, **kwargs):
         user_roles_of_interest = [UserRole.FINALIST, UserRole.ALUM]
-        startup_roles_of_interest = [StartupRole.ENTRANT]
-        startup_roles_of_interest += StartupRole.WINNER_STARTUP_ROLES
+        startup_roles_of_interest = StartupRole.WINNER_STARTUP_ROLES
+        if info.context.user.is_staff:
+            startup_roles_of_interest += [StartupRole.ENTRANT]
         return get_user_program_and_startup_roles(
             self.user, user_roles_of_interest, startup_roles_of_interest)

--- a/web/impact/impact/graphql/types/entrepreneur_profile_type.py
+++ b/web/impact/impact/graphql/types/entrepreneur_profile_type.py
@@ -1,26 +1,21 @@
 import graphene
-from graphene.types.generic import GenericScalar
-from graphene_django import DjangoObjectType
 from accelerator.models import (
     EntrepreneurProfile,
-    UserRole,
     Startup,
-    StartupRole,
     StartupTeamMember
 )
-from accelerator_abstract.models.base_user_utils import is_employee
+from impact.graphql.types import (
+    BaseUserProfileType,
+)
 from impact.graphql.types.entrepreneur_startup_type import (
     EntrepreneurStartupType,
 )
 
-from impact.utils import get_user_program_and_startup_roles
 
-
-class EntrepreneurProfileType(DjangoObjectType):
+class EntrepreneurProfileType(BaseUserProfileType):
     image_url = graphene.String()
     title = graphene.String()
     startups = graphene.List(EntrepreneurStartupType)
-    program_roles = GenericScalar()
 
     class Meta:
         model = EntrepreneurProfile
@@ -46,11 +41,3 @@ class EntrepreneurProfileType(DjangoObjectType):
         if team_member:
             return team_member.title
         return ""
-
-    def resolve_program_roles(self, info, **kwargs):
-        user_roles_of_interest = [UserRole.FINALIST, UserRole.ALUM]
-        startup_roles_of_interest = StartupRole.WINNER_STARTUP_ROLES
-        if is_employee(info.context.user):
-            startup_roles_of_interest += [StartupRole.ENTRANT]
-        return get_user_program_and_startup_roles(
-            self.user, user_roles_of_interest, startup_roles_of_interest)

--- a/web/impact/impact/graphql/types/expert_profile_type.py
+++ b/web/impact/impact/graphql/types/expert_profile_type.py
@@ -19,6 +19,7 @@ from accelerator_abstract.models import (
     HIDDEN_PROGRAM_STATUS,
     UPCOMING_PROGRAM_STATUS
 )
+from accelerator_abstract.models.base_user_utils import is_employee
 from impact.graphql.types import StartupMentorRelationshipType
 
 from impact.utils import (
@@ -133,7 +134,7 @@ class ExpertProfileType(DjangoObjectType):
         """
         user_roles_of_interest = [UserRole.FINALIST, UserRole.ALUM]
         startup_roles_of_interest = StartupRole.WINNER_STARTUP_ROLES
-        if info.context.user.is_staff:
+        if is_employee(info.context.user):
             startup_roles_of_interest += [StartupRole.ENTRANT]
         return get_user_program_and_startup_roles(
             self.user, user_roles_of_interest, startup_roles_of_interest)

--- a/web/impact/impact/graphql/types/expert_profile_type.py
+++ b/web/impact/impact/graphql/types/expert_profile_type.py
@@ -132,8 +132,9 @@ class ExpertProfileType(DjangoObjectType):
         without changing GraphQL queries on the front end.
         """
         user_roles_of_interest = [UserRole.FINALIST, UserRole.ALUM]
-        startup_roles_of_interest = [StartupRole.ENTRANT]
-        startup_roles_of_interest += StartupRole.WINNER_STARTUP_ROLES
+        startup_roles_of_interest = StartupRole.WINNER_STARTUP_ROLES
+        if info.context.user.is_staff:
+            startup_roles_of_interest += [StartupRole.ENTRANT]
         return get_user_program_and_startup_roles(
             self.user, user_roles_of_interest, startup_roles_of_interest)
 

--- a/web/impact/impact/tests/api_test_case.py
+++ b/web/impact/impact/tests/api_test_case.py
@@ -51,6 +51,8 @@ class APITestCase(TestCase):
         clearance = ClearanceFactory(
             level=CLEARANCE_LEVEL_STAFF,
             user=user)
+        clearance.user.is_staff = True
+        clearance.user.save()
         return clearance.user
 
     def global_operations_manager(self, program_family):

--- a/web/impact/impact/tests/api_test_case.py
+++ b/web/impact/impact/tests/api_test_case.py
@@ -51,8 +51,6 @@ class APITestCase(TestCase):
         clearance = ClearanceFactory(
             level=CLEARANCE_LEVEL_STAFF,
             user=user)
-        clearance.user.is_staff = True
-        clearance.user.save()
         return clearance.user
 
     def global_operations_manager(self, program_family):

--- a/web/impact/impact/tests/test_graphql.py
+++ b/web/impact/impact/tests/test_graphql.py
@@ -78,40 +78,36 @@ class TestGraphQL(APITestCase):
         self.assertNotIn(NOT_LOGGED_IN_MSG, error_messages)
 
     def test_query_with_expert(self):
-        with self.login(email=self.basic_user().email):
-            user = ExpertFactory()
-            query = """
-                query {{
-                    expertProfile(id: {id}) {{
-                        user {{ firstName }}
-                        bio
-                        imageUrl
-                        availableOfficeHours
-                        officeHoursUrl
-                        programInterests
-                    }}
+        user = ExpertFactory()
+        query = """
+            query {{
+                expertProfile(id: {id}) {{
+                    user {{ firstName }}
+                    bio
+                    imageUrl
+                    availableOfficeHours
+                    officeHoursUrl
+                    programInterests
                 }}
-            """.format(id=user.id)
-            response = self.client.post(self.url, data={'query': query})
-            profile = user.expertprofile
-            self.assertJSONEqual(
-                str(response.content, encoding='utf8'),
-                {
-                    'data': {
-                        'expertProfile': {
-                            'user': {
-                                'firstName': user.first_name,
-                            },
-                            'bio': profile.bio,
-                            'imageUrl': (profile.image and
-                                         profile.image.url or ''),
-                            'availableOfficeHours': False,
-                            'officeHoursUrl': None,
-                            'programInterests': [],
-                        }
-                    }
+            }}
+        """.format(id=user.id)
+        profile = user.expertprofile
+        expected_json = {
+            'data': {
+                'expertProfile': {
+                    'user': {
+                        'firstName': user.first_name,
+                    },
+                    'bio': profile.bio,
+                    'imageUrl': (profile.image and
+                                 profile.image.url or ''),
+                    'availableOfficeHours': False,
+                    'officeHoursUrl': None,
+                    'programInterests': [],
                 }
-            )
+            }
+        }
+        self._assert_response_equals_json(query, expected_json)
 
     def test_query_with_entrepreneur(self):
         with self.login(email=self.staff_user().email):
@@ -239,68 +235,61 @@ class TestGraphQL(APITestCase):
             }}
         """.format(id=confirmed.id)
 
-        with self.login(email=self.basic_user().email):
-            response = self.client.post(self.url, data={'query': query})
-            self.assertJSONEqual(
-                str(response.content, encoding='utf8'),
-                {
-                    'data': {
-                        'expertProfile': {
-                            'user': {
-                                'firstName': confirmed.first_name,
-                            },
-                            'officeHoursUrl': office_hours_url
-                        }
-                    }
+        expected_json = {
+            'data': {
+                'expertProfile': {
+                    'user': {
+                        'firstName': confirmed.first_name,
+                    },
+                    'officeHoursUrl': office_hours_url
                 }
-            )
+            }
+        }
+
+        self._assert_response_equals_json(query, expected_json)
 
     def test_requested_fields_for_startup_mentor_relationship_type(self):
-        with self.login(email=self.basic_user().email):
-            mentor = ExpertFactory()
-            relationship = StartupMentorRelationshipFactory(mentor=mentor)
-            startup = relationship.startup_mentor_tracking.startup
-            program = relationship.startup_mentor_tracking.program
-            query = """
-                query {{
-                    expertProfile(id: {id}) {{
-                        currentMentees {{
-                            {MENTEE_FIELDS}
-                        }}
-                        previousMentees {{
-                            {MENTEE_FIELDS}
-                        }}
+        mentor = ExpertFactory()
+        relationship = StartupMentorRelationshipFactory(mentor=mentor)
+        startup = relationship.startup_mentor_tracking.startup
+        program = relationship.startup_mentor_tracking.program
+        query = """
+            query {{
+                expertProfile(id: {id}) {{
+                    currentMentees {{
+                        {MENTEE_FIELDS}
+                    }}
+                    previousMentees {{
+                        {MENTEE_FIELDS}
                     }}
                 }}
-            """.format(id=relationship.mentor.id,
-                       MENTEE_FIELDS=MENTEE_FIELDS)
-            response = self.client.post(self.url, data={'query': query})
-            self.assertEqual(
-                json.loads(response.content.decode("utf-8")),
-                {
-                    'data': {
-                        'expertProfile': {
-                            'currentMentees': [{
-                                'startup': {
-                                    'id': str(startup.id),
-                                    'name': startup.name,
-                                    'highResolutionLogo':
-                                        (startup.high_resolution_logo and
-                                            startup.high_resolution_logo.url or
-                                            None),
-                                    'shortPitch': startup.short_pitch,
-                                },
-                                'program': {
-                                        'family':
-                                            program.program_family.name,
-                                        'year': str(program.start_date.year),
-                                },
-                            }],
-                            'previousMentees': []
-                        }
-                    }
+            }}
+        """.format(id=relationship.mentor.id,
+                   MENTEE_FIELDS=MENTEE_FIELDS)
+        expected_json = {
+            'data': {
+                'expertProfile': {
+                    'currentMentees': [{
+                        'startup': {
+                            'id': str(startup.id),
+                            'name': startup.name,
+                            'highResolutionLogo':
+                            (startup.high_resolution_logo and
+                             startup.high_resolution_logo.url or
+                             None),
+                                'shortPitch': startup.short_pitch,
+                        },
+                        'program': {
+                            'family':
+                            program.program_family.name,
+                            'year': str(program.start_date.year),
+                        },
+                    }],
+                    'previousMentees': []
                 }
-            )
+            }
+        }
+        self._assert_response_equals_json(query, expected_json)
 
     def test_query_with_non_expert_user_id(self):
         with self.login(email=self.basic_user().email):
@@ -363,53 +352,47 @@ class TestGraphQL(APITestCase):
             self.assertIn(NON_FINALIST_PROFILE_MESSAGE, error_messages)
 
     def test_staff_user_can_access_non_finalist_graphql_view(self):
-        with self.login(email=self.staff_user().email):
-            user = EntrepreneurFactory()
-            query = """
-                        query {{
-                                entrepreneurProfile(id: {id}) {{
-                                    user {{ firstName }}
-                                }}
+        user = EntrepreneurFactory()
+        query = """
+                    query {{
+                            entrepreneurProfile(id: {id}) {{
+                                user {{ firstName }}
                             }}
-                    """.format(id=user.id)
-            response = self.client.post(self.url, data={'query': query})
-            self.assertJSONEqual(
-                str(response.content, encoding='utf8'),
-                {
-                    'data': {
-                        'entrepreneurProfile': {
-                            'user': {
-                                'firstName': user.first_name
-                            },
-                        }
-                    }
+                        }}
+                """.format(id=user.id)
+        response = self.client.post(self.url, data={'query': query})
+        expected_json = {
+            'data': {
+                'entrepreneurProfile': {
+                    'user': {
+                        'firstName': user.first_name
+                    },
                 }
-            )
+            }
+        }
+        self._assert_response_equals_json(query, expected_json, True)
 
     def test_non_staff_user_can_access_finalist_graphql_view(self):
-        with self.login(email=self.basic_user().email):
-            user = EntrepreneurFactory()
-            UserRoleContext(UserRole.FINALIST, user=user)
-            query = """
-                        query {{
-                                entrepreneurProfile(id: {id}) {{
-                                    user {{ firstName }}
-                                }}
+        user = EntrepreneurFactory()
+        UserRoleContext(UserRole.FINALIST, user=user)
+        query = """
+                    query {{
+                            entrepreneurProfile(id: {id}) {{
+                                user {{ firstName }}
                             }}
-                    """.format(id=user.id)
-            response = self.client.post(self.url, data={'query': query})
-            self.assertJSONEqual(
-                str(response.content, encoding='utf8'),
-                {
-                    'data': {
-                        'entrepreneurProfile': {
-                            'user': {
-                                'firstName': user.first_name
-                            },
-                        }
-                    }
+                        }}
+                """.format(id=user.id)
+        response = self.client.post(self.url, data={'query': query})
+        expected_json = {
+            'data': {
+                'entrepreneurProfile': {
+                    'user': {
+                        'firstName': user.first_name
+                    },
                 }
-            )
+            }
+        }
+        self._assert_response_equals_json(query, expected_json)
 
     def test_query_program_roles_for_entrepreneur_returns_correct_value(self):
         user_roles_of_interest = [UserRole.FINALIST, UserRole.ALUM]
@@ -509,41 +492,35 @@ class TestGraphQL(APITestCase):
         }
         self._assert_response_equals_json(query, expected_json)
 
-    def test_query_prg_roles_for_selected_roles(self):
-        with self.login(email=self.staff_user().email):
-            user_roles_of_interest = [UserRole.FINALIST, UserRole.ALUM]
-            startup_roles_of_interest = [StartupRole.ENTRANT]
-            startup_status_names = [StartupRole.ENTRANT,
-                                    StartupRole.FINALIST,
-                                    StartupRole.FINALIST,
-                                    StartupRole.ENTRANT]
-            user = UserContext(
-                user_type="EXPERT",
-                program_role_names=user_roles_of_interest,
-                startup_status_names=startup_status_names).user
-            program_roles = get_user_program_and_startup_roles(
-                user, user_roles_of_interest, startup_roles_of_interest)
+    def test_query_for_prg_roles_as_staff_user(self):
+        user_roles_of_interest = [UserRole.FINALIST, UserRole.ALUM]
+        startup_roles_of_interest = [StartupRole.ENTRANT]
+        startup_status_names = [StartupRole.ENTRANT,
+                                StartupRole.FINALIST,
+                                StartupRole.FINALIST,
+                                StartupRole.ENTRANT]
+        user = UserContext(
+            user_type="EXPERT",
+            program_role_names=user_roles_of_interest,
+            startup_status_names=startup_status_names).user
+        program_roles = get_user_program_and_startup_roles(
+            user, user_roles_of_interest, startup_roles_of_interest)
 
-            query = """
-                query{{
-                    expertProfile(id:{id}) {{
-                        programRoles
-                    }}
+        query = """
+            query{{
+                expertProfile(id:{id}) {{
+                    programRoles
                 }}
-            """.format(id=user.id)
-            expected_json = {
-                'data': {
-                    'expertProfile': {
-                        'programRoles': program_roles
-                    }
+            }}
+        """.format(id=user.id)
+        expected_json = {
+            'data': {
+                'expertProfile': {
+                    'programRoles': program_roles
                 }
             }
-            response = self.client.post(self.url, data={'query': query})
-
-            self.assertJSONEqual(
-                str(response.content, encoding='utf8'),
-                expected_json
-            )
+        }
+        self._assert_response_equals_json(query, expected_json, True)
 
     def test_get_user_confirmed_mentor_program_families(self):
         role_grant = ProgramRoleGrantFactory(
@@ -587,8 +564,12 @@ class TestGraphQL(APITestCase):
             self.assertEqual(expert_profile["confirmedMentorProgramFamilies"],
                              [])
 
-    def _assert_response_equals_json(self, query, expected_json):
-        with self.login(email=self.basic_user().email):
+    def _assert_response_equals_json(self, query, expected_json, is_staff=False):
+        if is_staff:
+            user = self.staff_user()
+        else:
+            user = self.basic_user()
+        with self.login(email=user.email):
             response = self.client.post(self.url, data={'query': query})
             self.assertJSONEqual(
                 str(response.content, encoding='utf8'),

--- a/web/impact/impact/tests/test_graphql.py
+++ b/web/impact/impact/tests/test_graphql.py
@@ -360,7 +360,6 @@ class TestGraphQL(APITestCase):
                             }}
                         }}
                 """.format(id=user.id)
-        response = self.client.post(self.url, data={'query': query})
         expected_json = {
             'data': {
                 'entrepreneurProfile': {
@@ -382,7 +381,6 @@ class TestGraphQL(APITestCase):
                             }}
                         }}
                 """.format(id=user.id)
-        response = self.client.post(self.url, data={'query': query})
         expected_json = {
             'data': {
                 'entrepreneurProfile': {
@@ -564,7 +562,8 @@ class TestGraphQL(APITestCase):
             self.assertEqual(expert_profile["confirmedMentorProgramFamilies"],
                              [])
 
-    def _assert_response_equals_json(self, query, expected_json, is_staff=False):
+    def _assert_response_equals_json(self, query, expected_json,
+                                     is_staff=False):
         if is_staff:
             user = self.staff_user()
         else:

--- a/web/impact/impact/tests/test_graphql.py
+++ b/web/impact/impact/tests/test_graphql.py
@@ -562,8 +562,11 @@ class TestGraphQL(APITestCase):
             self.assertEqual(expert_profile["confirmedMentorProgramFamilies"],
                              [])
 
-    def _assert_response_equals_json(self, query, expected_json,
-                                     is_staff=False):
+    def _assert_response_equals_json(
+            self,
+            query,
+            expected_json,
+            is_staff=False):
         if is_staff:
             user = self.staff_user()
         else:

--- a/web/impact/impact/tests/test_impact_email_backend.py
+++ b/web/impact/impact/tests/test_impact_email_backend.py
@@ -5,10 +5,10 @@ from impact.minimal_email_handler import MinimalEmailHandler
 
 
 IMPACT_BACKEND_PATH = 'impact.impact_email_backend.ImpactEmailBackend'
-# Note that this definition, which duplicates a value in settings.py, 
+# Note that this definition, which duplicates a value in settings.py,
 # is necessary since the value is not included in the settings for test
-# See AC-7670 for a ticket aimed at resolving this and other issues 
-# around testing email backends   
+# See AC-7670 for a ticket aimed at resolving this and other issues
+# around testing email backends
 
 ADD_LOGGING_HEADERS = ".".join(["impact",
                                 "impact_email_backend",


### PR DESCRIPTION
**Changes introduced in [AC-7643 ](https://masschallenge.atlassian.net/browse/AC-7643)**
- Added flag for entrant status

**How to test:** 
- Login in as a non staff [user](http://localhost:8181/admin/simpleuser/user/20697/masquerade)
- Navigate to this user's [profile](http://localhost:1234/directory/people/22973)
- See that the user has no Entrant label

- Login in as a staff user (Demoadmin)
- Navigate to this user's [profile](http://localhost:1234/directory/people/22973)
- See that the user now has Entrant label