### PR TITLE
AC-7511 - fix impact-api build breakage caused by semantic-release 

### DIFF
--- a/Dockerfile.semantic-release
+++ b/Dockerfile.semantic-release
@@ -1,9 +1,5 @@
-FROM python:3.7-slim-buster
-RUN apt update
-RUN apt install -y git
-RUN pip install python-semantic-release==5.2.0 
+FROM 997386117669.dkr.ecr.us-east-1.amazonaws.com/semantic-release:py3
 RUN git config --global user.email semantic-release@masschallenge.org
 RUN mkdir /app
 WORKDIR /app
 ADD setup.cfg .
-

--- a/Dockerfile.semantic-release
+++ b/Dockerfile.semantic-release
@@ -1,11 +1,7 @@
-FROM jfloff/alpine-python:2.7-slim
-RUN apk update
-RUN apk add --no-cache bash git
-RUN /entrypoint.sh \
-    -a git \
-    -p python-semantic-release==3.11.2 \
-    && echo
-RUN apk add pcre git
+FROM python:3.7-slim-buster
+RUN apt update
+RUN apt install -y git
+RUN pip install python-semantic-release==5.2.0 
 RUN git config --global user.email semantic-release@masschallenge.org
 RUN mkdir /app
 WORKDIR /app

--- a/create_release.sh
+++ b/create_release.sh
@@ -1,11 +1,10 @@
-
-# if a tag hasn't been passed in as a parameter, create a semantic one
+# If a tag hasn't been passed in as a parameter, create a semantic one
 if [ ! -n "$tag" ]; then
-    git commit --allow-empty -m "generating a new release"
+    git commit --allow-empty -m "Generating a new release"
     docker run --rm  -v"$(pwd)":/app  -ti semantic-release  -- semantic-release version
-    export pwd=$(pwd)
-    git push        
-    export TAG=$(docker run --tty=false --rm  -v$pwd:/app  -i semantic-release -- semantic-release version --noop | grep "Current version: " | cut -d ' ' -f 3 | sed -e "s/\r//")
+    git push
+    # Run semantic-release again, in no-op mode, to grab the generated version for tagging
+    export TAG=$(docker run --tty=false --rm  -v$(pwd):/app  -i semantic-release -- semantic-release version --noop | grep "Current version: " | cut -d ' ' -f 3 | sed -e "s/\r//")
 else
     echo "You passed in '$tag' as the custom tag"
     # TR == test release


### PR DESCRIPTION
## [AC-7511](https://masschallenge.atlassian.net/browse/AC-7511)

**TLDR**: We generate our accelerate release numbers (e.g. "v1.2.3") via `python-semantic-release` running in a Docker container. It needed an update to keep working.

We use Docker to provide a reproducible environtment for running `python-semantic-release`. This container only had Python 2, but the now-broken legacy version of `python-semantic-release` we've been using (3.11.2) is the last one that worked on Python 2.

In the running container, I installed current (5.2.0) python-semantic-release and Python 3 and all the other stuff that was needed; I generated the image from that updated container. Details on the ticket.

### Test procedure
This exercises the new image with the key version-bumping command from [create_release.sh](https://github.com/masschallenge/impact-api/blob/AC-7511/create_release.sh), without running `make release` -- which you **should not do** here because it tags all your repos and pushes those tags to origin. Feel free to invent your own evaluation protocol, but read through this one first.
1. `cd` to your impact-api directory and `git checkout AC-7511`
1. Delete your local semantic-release image: `docker images | grep release` then `docker rmi $ID` for each semantic-release "IMAGE ID" listed.
1. `docker pull 997386117669.dkr.ecr.us-east-1.amazonaws.com/semantic-release:py3`
1. `docker build -t semantic-release . -f Dockerfile.semantic-release`
1. Set "current" version number to something new: `sed -ix s/1.2.37/2.2.2/ web/impact/impact/__init__.py`
1. `cat web/impact/impact/__init__.py` to confirm the recorded version is now v2.2.2
1. Run [command that generates the new version number](https://github.com/masschallenge/impact-api/blob/AC-7511/create_release.sh#L4): `docker run --rm  -v"$(pwd)":/app  -ti semantic-release  -- semantic-release version`
1. `cat web/impact/impact/__init__.py` again to confirm version is now v2.2.3
1. `git log -1` to see that HEAD was tagged
1. **Done**! **Now clean up**: `git reset --hard origin/development; git tag --delete v2.2.3`