### PR TITLE
[AC-7557] Cancellation workflow for office hours

### DIFF
--- a/web/impact/impact/tests/api_test_case.py
+++ b/web/impact/impact/tests/api_test_case.py
@@ -99,4 +99,4 @@ class APITestCase(TestCase):
                 self.assertEqual(options[key], params)
 
     def assert_ui_notification(self, response, notification):
-        self.assertEqual(response.data['detail'], notification)
+        self.assertEqual(response.data, notification)

--- a/web/impact/impact/tests/api_test_case.py
+++ b/web/impact/impact/tests/api_test_case.py
@@ -98,5 +98,10 @@ class APITestCase(TestCase):
                 self.assertIn(key, options)
                 self.assertEqual(options[key], params)
 
-    def assert_ui_notification(self, response, notification):
-        self.assertEqual(response.data, notification)
+    def assert_ui_notification(self, response, success, notification):
+        expected_ui_notification = {
+            'success': success,
+            'header': self.success_header if success else self.fail_header,
+            'detail': notification
+        }
+        self.assertEqual(response.data, expected_ui_notification)

--- a/web/impact/impact/tests/api_test_case.py
+++ b/web/impact/impact/tests/api_test_case.py
@@ -99,9 +99,10 @@ class APITestCase(TestCase):
                 self.assertEqual(options[key], params)
 
     def assert_ui_notification(self, response, success, notification):
-        expected_ui_notification = {
-            'success': success,
-            'header': self.success_header if success else self.fail_header,
-            'detail': notification
-        }
-        self.assertEqual(response.data, expected_ui_notification)
+        data = response.data
+        header = self.success_header if success else self.fail_header
+        self.assertTrue(all([
+            data['success'] == success,
+            data['header'] == header,
+            data['detail'] == notification
+        ]), msg='Notification data was not as expected')

--- a/web/impact/impact/tests/test_cancel_office_hour_reservation.py
+++ b/web/impact/impact/tests/test_cancel_office_hour_reservation.py
@@ -8,7 +8,6 @@ from impact.permissions.v1_api_permissions import (
     DEFAULT_PERMISSION_DENIED_DETAIL,
 )
 from impact.tests.api_test_case import APITestCase
-from impact.tests.utils import get_ui_notification_dict
 from impact.v1.views import (
     CancelOfficeHourReservationView,
     formatted_success_notification,
@@ -23,6 +22,9 @@ from impact.v1.views.cancel_office_hour_reservation_view import (
 
 
 class TestCancelOfficeHourReservationView(APITestCase):
+    fail_header = FAIL_HEADER
+    success_header = SUCCESS_HEADER
+
     def test_finalist_cancels_their_own_office_hour_reservation(self):
         office_hour = MentorProgramOfficeHourFactory()
         self._submit_cancellation(office_hour, user=office_hour.finalist)
@@ -42,9 +44,7 @@ class TestCancelOfficeHourReservationView(APITestCase):
         response = self._submit_cancellation(office_hour,
                                              user=office_hour.finalist)
         notification = formatted_success_notification(office_hour)
-        expected_ui_notification = get_ui_notification_dict(
-            True, SUCCESS_HEADER, notification)
-        self.assert_ui_notification(response, expected_ui_notification)
+        self.assert_ui_notification(response, True, notification)
 
     def test_finalist_cancels_mentor_gets_notification(self):
         '''A finalist cancelling their reservation should trigger a
@@ -74,24 +74,18 @@ class TestCancelOfficeHourReservationView(APITestCase):
         response = self._submit_cancellation(office_hour,
                                              user=self.staff_user())
         notification = formatted_success_notification(office_hour)
-        expected_ui_notification = get_ui_notification_dict(
-            True, SUCCESS_HEADER, notification)
-        self.assert_ui_notification(response, expected_ui_notification)
+        self.assert_ui_notification(response, True, notification)
 
     def test_staff_user_cancels_nonexistent_reservation_ui_notification(self):
         office_hour = MentorProgramOfficeHourFactory(finalist=None)
         response = self._submit_cancellation(office_hour,
                                              user=self.staff_user())
-        expected_ui_notification = get_ui_notification_dict(
-            False, FAIL_HEADER, NO_SUCH_RESERVATION)
-        self.assert_ui_notification(response, expected_ui_notification)
+        self.assert_ui_notification(response, False, NO_SUCH_RESERVATION)
 
     def test_staff_user_cancels_nonexistent_hour_ui_notification(self):
         response = self._submit_cancellation(None,
                                              user=self.staff_user())
-        expected_ui_notification = get_ui_notification_dict(
-            False, FAIL_HEADER, NO_SUCH_OFFICE_HOUR)
-        self.assert_ui_notification(response, expected_ui_notification)
+        self.assert_ui_notification(response, False, NO_SUCH_OFFICE_HOUR)
 
     def test_staff_user_trigger_notification_mentor(self):
         '''A staff user cancelling someone else's office hour should trigger a
@@ -126,7 +120,7 @@ class TestCancelOfficeHourReservationView(APITestCase):
         response = self._submit_cancellation(office_hour,
                                              user=self.make_user())
         notification = {'detail': DEFAULT_PERMISSION_DENIED_DETAIL}
-        self.assert_ui_notification(response, notification)
+        self.assertEqual(response.data, notification)
 
     def test_user_cancels_non_existent_reservation_no_notification(self):
         office_hour = MentorProgramOfficeHourFactory(finalist=None)

--- a/web/impact/impact/tests/test_cancel_office_hour_session_view.py
+++ b/web/impact/impact/tests/test_cancel_office_hour_session_view.py
@@ -11,7 +11,6 @@ from impact.permissions.v1_api_permissions import (
 )
 from impact.tests.api_test_case import APITestCase
 from impact.tests.factories import MentorProgramOfficeHourFactory
-from impact.tests.utils import get_ui_notification_dict
 from impact.v1.views.cancel_office_hour_session_view import (
     DEFAULT_TIMEZONE,
     FAIL_HEADER,
@@ -26,6 +25,8 @@ from impact.v1.views.cancel_office_hour_session_view import (
 
 
 class TestCancelOfficeHourSession(APITestCase):
+    fail_header = FAIL_HEADER
+    success_header = SUCCESS_HEADER
     url = reverse(CancelOfficeHourSessionView.view_name)
 
     def test_mentor_can_cancel_their_own_unreserved_office_hour(self):
@@ -58,9 +59,7 @@ class TestCancelOfficeHourSession(APITestCase):
         office_hour = MentorProgramOfficeHourFactory(
             mentor=mentor)
         response = self._cancel_office_hour_session(office_hour.id, mentor)
-        expected_ui_notification = get_ui_notification_dict(
-            False, FAIL_HEADER, PERMISSION_DENIED)
-        self.assert_ui_notification(response, expected_ui_notification)
+        self.assert_ui_notification(response, False, PERMISSION_DENIED)
 
     def test_mentor_cannot_cancel_someone_else_unreserved_office_hour(self):
         mentor = self._expert_user(UserRole.MENTOR)
@@ -119,16 +118,14 @@ class TestCancelOfficeHourSession(APITestCase):
 
     def test_office_hour_session_not_existing_ui_notification(self):
         response = self._cancel_office_hour_session(0, self.staff_user())
-        expected_ui_notification = get_ui_notification_dict(
-            False, FAIL_HEADER, OFFICE_HOUR_SESSION_404)
-        self.assert_ui_notification(response, expected_ui_notification)
+        self.assert_ui_notification(response, False, OFFICE_HOUR_SESSION_404)
 
     def test_none_staff_or_none_mentor_ui_notification(self):
         office_hour = MentorProgramOfficeHourFactory()
         response = self._cancel_office_hour_session(office_hour.id,
                                                     self.basic_user())
         notification = {'detail': DEFAULT_PERMISSION_DENIED_DETAIL}
-        self.assert_ui_notification(response, notification)
+        self.assertEqual(response.data, notification)
 
     def assert_office_hour_session_was_cancelled(self, office_hour):
         self.assertFalse(MentorProgramOfficeHour.objects.filter(
@@ -141,17 +138,15 @@ class TestCancelOfficeHourSession(APITestCase):
     def assert_mentor_cancel_reservation_ui_notification(
             self, office_hour, response):
         context = self._get_office_hour_context(office_hour)
-        expected_ui_notification = get_ui_notification_dict(
-            True, SUCCESS_HEADER, MENTOR_NOTIFICATION.format(**context))
-        self.assert_ui_notification(response, expected_ui_notification)
+        self.assert_ui_notification(
+            response, True, MENTOR_NOTIFICATION.format(**context))
 
     def assert_staff_cancel_reservation_ui_notification(self,
                                                         office_hour,
                                                         response):
         context = self._get_office_hour_context(office_hour)
-        expected_ui_notification = get_ui_notification_dict(
-            True, SUCCESS_HEADER, STAFF_NOTIFICATION.format(**context))
-        self.assert_ui_notification(response, expected_ui_notification)
+        self.assert_ui_notification(
+            response, True, STAFF_NOTIFICATION.format(**context))
 
     def _get_office_hour_context(self, office_hour):
         tz = timezone(office_hour.location.timezone or DEFAULT_TIMEZONE)

--- a/web/impact/impact/tests/utils.py
+++ b/web/impact/impact/tests/utils.py
@@ -72,3 +72,11 @@ def capture_stderr(command, *args, **kwargs):
         yield result, sys.stderr.read()
     finally:
         sys.stderr = err
+
+
+def get_ui_notification_dict(success, header, notification):
+    return {
+        'success': success,
+        'header': header,
+        'detail': notification
+    }

--- a/web/impact/impact/tests/utils.py
+++ b/web/impact/impact/tests/utils.py
@@ -72,11 +72,3 @@ def capture_stderr(command, *args, **kwargs):
         yield result, sys.stderr.read()
     finally:
         sys.stderr = err
-
-
-def get_ui_notification_dict(success, header, notification):
-    return {
-        'success': success,
-        'header': header,
-        'detail': notification
-    }

--- a/web/impact/impact/v1/views/cancel_office_hour_reservation_view.py
+++ b/web/impact/impact/v1/views/cancel_office_hour_reservation_view.py
@@ -51,8 +51,8 @@ class CancelOfficeHourReservationView(ImpactView):
             self.process_cancellation()
         return Response({
             "success": can_cancel,
+            "header": SUCCESS_HEADER if can_cancel else FAIL_HEADER,
             "detail": detail,
-            "header": SUCCESS_HEADER if can_cancel else FAIL_HEADER
         })
 
     def check_can_cancel(self):


### PR DESCRIPTION
## [AC-7557](https://masschallenge.atlassian.net/browse/AC-7557)

**Changes Introduced:**
- standardize office hour cancellation response

**Testing**
- checkout to `AC-7557` on `accelerate`, `semantic-ui-theme` and `impact-api`
- run servers ( accelerate and impact-api)
- On semantic-ui-theme:
    - run `gulp build`
    - run `yarn link`
- On accelerate
    - run `yarn link "semantic-ui-theme"`
    - run `yarn start`

- Visit [http://localhost:8181/newofficehour](http://localhost:8181/newofficehour)
For test purposes you can set `office_hour_id` and `mentor_id (office hour holder id)` using URL query. i.e `http://localhost:8181/newofficehour?office_hour_id=1&mentor_id=2`
- Verify that the cancellation workflow meets the definition of done according to [AC-7557](https://masschallenge.atlassian.net/browse/AC-7557)
- Allowed users: 
    - Staff users - Can cancel session/reservation on behalf of mentor/finalist
    - Office hour session owner(mentor) - can cancel their unreserved office hour sessions
    - Finalist- can cancel their reserved office hour sessions


**Sibling PRs**
- [semantic UI theme PR](https://github.com/masschallenge/semantic-ui-theme/pull/44)
- [Accelerate PR](https://github.com/masschallenge/accelerate/pull/2614)