### PR TITLE
[AC-7790] P0: Mentor confirmation emails not sending

### DIFF
--- a/web/impact/impact/settings.py
+++ b/web/impact/impact/settings.py
@@ -361,7 +361,7 @@ class Base(Configuration):
             },
         }
     }
-    NO_REPLY_EMAIL = "noreply@masschallenge.org"
+    NO_REPLY_EMAIL = "no-reply@masschallenge.org"
     BCC_EMAIL = "systemlogbcc@masschallenge.org"
     EMAIL_BACKEND = "impact.impact_email_backend.ImpactEmailBackend"
     SES_CONFIGURATION_SET = None


### PR DESCRIPTION
Changes introduced in [AC-7790](https://masschallenge.atlassian.net/browse/AC-7790)
 - Correct the no-reply email

