### PR TITLE
[AC-7790v2] P0: Mentor confirmation emails not sending

### DIFF
--- a/web/impact/impact/minimal_email_handler.py
+++ b/web/impact/impact/minimal_email_handler.py
@@ -11,6 +11,7 @@ class MinimalEmailHandler:
       (attachment_text, MIME_type)
       (generally used for html version of the email)
     '''
+
     def __init__(self,
                  to,
                  subject,
@@ -24,7 +25,7 @@ class MinimalEmailHandler:
             body,
             to=to,
             bcc=bcc or [settings.BCC_EMAIL],
-            from_email=from_email or [settings.NO_REPLY_EMAIL])
+            from_email=from_email or settings.NO_REPLY_EMAIL)
         if attachment:
             self.email.attach(*attachment)
         if attach_alternative:


### PR DESCRIPTION
Changes introduced in [AC-7790](https://masschallenge.atlassian.net/browse/AC-7790)
 -  change the from_email from an array to a string as per django.core.mail docs, so as to get rid of the `smtplib.SMTPDataError: (554, b'Transaction failed: Illegal address') ` error