### PR TITLE
[AC-7811] P1 Fix Internal server error when canceling a non existing office hour reservation as finalist

### DIFF
--- a/web/impact/impact/tests/test_cancel_office_hour_reservation.py
+++ b/web/impact/impact/tests/test_cancel_office_hour_reservation.py
@@ -4,9 +4,6 @@ from django.urls import reverse
 from accelerator.tests.factories import (
     MentorProgramOfficeHourFactory,
 )
-from impact.permissions.v1_api_permissions import (
-    DEFAULT_PERMISSION_DENIED_DETAIL,
-)
 from impact.tests.api_test_case import APITestCase
 from impact.v1.views import (
     CancelOfficeHourReservationView,
@@ -119,7 +116,7 @@ class TestCancelOfficeHourReservationView(APITestCase):
         office_hour = MentorProgramOfficeHourFactory(finalist=None)
         response = self._submit_cancellation(office_hour,
                                              user=self.make_user())
-        notification = {'detail': DEFAULT_PERMISSION_DENIED_DETAIL}
+        notification = {'detail': NO_SUCH_OFFICE_HOUR}
         self.assertEqual(response.data, notification)
 
     def test_user_cancels_non_existent_reservation_no_notification(self):

--- a/web/impact/impact/tests/test_cancel_office_hour_reservation.py
+++ b/web/impact/impact/tests/test_cancel_office_hour_reservation.py
@@ -116,7 +116,19 @@ class TestCancelOfficeHourReservationView(APITestCase):
         office_hour = MentorProgramOfficeHourFactory(finalist=None)
         response = self._submit_cancellation(office_hour,
                                              user=self.make_user())
-        notification = {'detail': NO_SUCH_OFFICE_HOUR}
+        notification = {
+            'detail': NO_SUCH_RESERVATION,
+            'header': FAIL_HEADER,
+            'success': False}
+        self.assertEqual(response.data, notification)
+
+    def test_user_attempts_to_cancel_non_existent_hour(self):
+        response = self._submit_cancellation(None,
+                                             user=self.make_user())
+        notification = {
+            'detail': NO_SUCH_OFFICE_HOUR,
+            'header': FAIL_HEADER,
+            'success': False}
         self.assertEqual(response.data, notification)
 
     def test_user_cancels_non_existent_reservation_no_notification(self):

--- a/web/impact/impact/tests/test_cancel_office_hour_reservation.py
+++ b/web/impact/impact/tests/test_cancel_office_hour_reservation.py
@@ -116,20 +116,12 @@ class TestCancelOfficeHourReservationView(APITestCase):
         office_hour = MentorProgramOfficeHourFactory(finalist=None)
         response = self._submit_cancellation(office_hour,
                                              user=self.make_user())
-        notification = {
-            'detail': NO_SUCH_RESERVATION,
-            'header': FAIL_HEADER,
-            'success': False}
-        self.assertEqual(response.data, notification)
+        self.assert_ui_notification(response, False, NO_SUCH_RESERVATION)
 
     def test_user_attempts_to_cancel_non_existent_hour(self):
         response = self._submit_cancellation(None,
                                              user=self.make_user())
-        notification = {
-            'detail': NO_SUCH_OFFICE_HOUR,
-            'header': FAIL_HEADER,
-            'success': False}
-        self.assertEqual(response.data, notification)
+        self.assert_ui_notification(response, False, NO_SUCH_OFFICE_HOUR)
 
     def test_user_cancels_non_existent_reservation_no_notification(self):
         office_hour = MentorProgramOfficeHourFactory(finalist=None)

--- a/web/impact/impact/tests/test_cancel_office_hour_reservation.py
+++ b/web/impact/impact/tests/test_cancel_office_hour_reservation.py
@@ -4,15 +4,15 @@ from django.urls import reverse
 from accelerator.tests.factories import (
     MentorProgramOfficeHourFactory,
 )
-from impact.tests.api_test_case import APITestCase
-from impact.v1.views import (
+from ..tests.api_test_case import APITestCase
+from ..v1.views import (
     CancelOfficeHourReservationView,
     formatted_success_notification,
     NO_SUCH_RESERVATION,
     NO_SUCH_OFFICE_HOUR,
 )
 
-from impact.v1.views.cancel_office_hour_reservation_view import (
+from ..v1.views.cancel_office_hour_reservation_view import (
     FAIL_HEADER,
     SUCCESS_HEADER,
 )

--- a/web/impact/impact/v1/views/cancel_office_hour_reservation_view.py
+++ b/web/impact/impact/v1/views/cancel_office_hour_reservation_view.py
@@ -45,9 +45,9 @@ class CancelOfficeHourReservationView(ImpactView):
         self.user = request.user
         self.office_hour = MentorProgramOfficeHour.objects.filter(
                 pk=self.office_hour_id).first()
-        self.check_object_permissions(request, self.office_hour)
         can_cancel, detail = self.check_can_cancel()
         if can_cancel:
+            self.check_object_permissions(request, self.office_hour)
             self.process_cancellation()
         return Response({
             "success": can_cancel,


### PR DESCRIPTION
### Changes introduced in: [AC-7811](https://masschallenge.atlassian.net/browse/AC-7811) :
- Fix potential check_object_permissions failure with office-hour set to None
### How to test on test2
- masquerade as any finalist
- Make a post request on the CancelOfficeHourReservationView review with a non existing officehour id.
- Get the message `The specified office hour was not found.`