### PR TITLE
[AC-7805] Cancellation workflow for office hours patch

### DIFF
--- a/web/impact/impact/tests/test_cancel_office_hour_session_view.py
+++ b/web/impact/impact/tests/test_cancel_office_hour_session_view.py
@@ -16,7 +16,6 @@ from impact.v1.views.cancel_office_hour_session_view import (
     FAIL_HEADER,
     OFFICE_HOUR_SESSION_404,
     MENTOR_NOTIFICATION,
-    PERMISSION_DENIED,
     STAFF_NOTIFICATION,
     SUCCESS_HEADER,
     CancelOfficeHourSessionView,
@@ -54,13 +53,6 @@ class TestCancelOfficeHourSession(APITestCase):
             office_hour, response
         )
 
-    def test_mentor_cannot_cancel_their_own_reserved_office_hour(self):
-        mentor = self._expert_user(UserRole.MENTOR)
-        office_hour = MentorProgramOfficeHourFactory(
-            mentor=mentor)
-        response = self._cancel_office_hour_session(office_hour.id, mentor)
-        self.assert_ui_notification(response, False, PERMISSION_DENIED)
-
     def test_mentor_cannot_cancel_someone_else_unreserved_office_hour(self):
         mentor = self._expert_user(UserRole.MENTOR)
         mentor2 = self._expert_user(UserRole.MENTOR)
@@ -85,7 +77,8 @@ class TestCancelOfficeHourSession(APITestCase):
         self._cancel_office_hour_session(office_hour.id, self.staff_user())
         self.assert_office_hour_session_was_cancelled(office_hour)
 
-    def test_mail_is_sent_to_attendees_on_reserved_session_cancellation(self):
+    def test_mail_sent_to_mentor_finalist_when_admin_cancels_reserved_session(
+            self):
         office_hour = MentorProgramOfficeHourFactory()
         self._cancel_office_hour_session(office_hour.id, self.staff_user())
         attendees_email = [email.to[0] for email in mail.outbox]
@@ -119,6 +112,29 @@ class TestCancelOfficeHourSession(APITestCase):
     def test_office_hour_session_not_existing_ui_notification(self):
         response = self._cancel_office_hour_session(0, self.staff_user())
         self.assert_ui_notification(response, False, OFFICE_HOUR_SESSION_404)
+
+    def test_mentor_cancel_their_own_reserved_office_hour(self):
+        mentor = self._expert_user(UserRole.MENTOR)
+        office_hour = MentorProgramOfficeHourFactory(mentor=mentor)
+        self._cancel_office_hour_session(office_hour.id, mentor)
+        self.assert_office_hour_session_was_cancelled(office_hour)
+
+    def test_mentor_cancel_own_reserved_office_hour_ui_notification(self):
+        mentor = self._expert_user(UserRole.MENTOR)
+        office_hour = MentorProgramOfficeHourFactory(mentor=mentor)
+        response = self._cancel_office_hour_session(office_hour.id, mentor)
+        self.assert_mentor_cancel_reservation_ui_notification(
+            office_hour, response)
+
+    def test_mail_sent_to_mentor_finalist_when_mentor_cancels_reserved_session(
+            self):
+        mentor = self._expert_user(UserRole.MENTOR)
+        office_hour = MentorProgramOfficeHourFactory(mentor=mentor)
+        self._cancel_office_hour_session(office_hour.id, mentor)
+        attendees_email = [email.to[0] for email in mail.outbox]
+        to_addresses = [office_hour.mentor.email,
+                        office_hour.finalist.email]
+        self.assertEqual(set(attendees_email), set(to_addresses))
 
     def test_none_staff_or_none_mentor_ui_notification(self):
         office_hour = MentorProgramOfficeHourFactory()


### PR DESCRIPTION
## [AC-7805](https://masschallenge.atlassian.net/browse/AC-7805)

**Changes introduced**
- allow mentors to cancel reserved office hour sessions

**Testing**
- checkout to this branch and `make run-server-1`
- As a mentor with a reserved office hour session visit [cancel office hour endpoint](http://localhost:8000/api/v1/cancel_office_hour_session/). 
Allowed methods = [POST]
- POST data format:
```
 {
    'id': <office hour session id>,
    'message': <optional message to attendees>
}
```
Confirm that:

- A mentor can cancel reserved office hour session:
- Email notification is sent to the **office hours holder’s** and **finalist's** email address when a reserved session is canceled by the office hour holder
  - including the message to attendees if provided

[Accelerate sibling PR](https://github.com/masschallenge/accelerate/pull/2629)