### PR TITLE
AC-7818 Add 'Meeting Information' to Office Hours model

### DIFF
--- a/web/impact/impact/tests/test_office_hours_calendar_view.py
+++ b/web/impact/impact/tests/test_office_hours_calendar_view.py
@@ -162,6 +162,12 @@ class TestOfficeHoursCalendarView(APITestCase):
         with self.assertNumQueries(total_queries):
             self.get_response(target_user_id=office_hour.mentor_id)
 
+    def test_meeting_info_returned_in_response(self):
+        office_hour = self.create_office_hour()
+        response = self.get_response(target_user_id=office_hour.mentor_id)
+        calendar_data = response.data['calendar_data'][0]
+        self.assertIn("meeting_info", calendar_data)
+
     def create_office_hour(self,
                            mentor=None,
                            finalist=None,

--- a/web/impact/impact/v1/views/office_hours_calendar_view.py
+++ b/web/impact/impact/v1/views/office_hours_calendar_view.py
@@ -99,6 +99,7 @@ class OfficeHoursCalendarView(ImpactView):
             "topics",
             "startup_id",
             "reserved",
+            "meeting_info",
             location_name=F("location__name"),
             location_timezone=F("location__timezone"),
             finalist_first_name=F("finalist__first_name"),


### PR DESCRIPTION
### Changes introduced in: [AC-7818](https://masschallenge.atlassian.net/browse/AC-7818):
- Add a migration to add meeting_info
### How to test
- Check out this branch
- On accelerate `make migrate`
- Check out this branch too on impact and run `make runserver`
- Schedule office hours as a mentor and and navigate to this [api endpoint](http://localhost:8000/api/v1/office_hours_calendar/)
- Notice the new field `meeting_info`
### [Sibling PR](https://github.com/masschallenge/django-accelerator/pull/326)