### PR TITLE
[AC-7871] Add "own_office_hour" flag to office_hours_calendar output

### DIFF
--- a/web/impact/impact/tests/test_office_hours_calendar_view.py
+++ b/web/impact/impact/tests/test_office_hours_calendar_view.py
@@ -119,6 +119,15 @@ class TestOfficeHoursCalendarView(APITestCase):
         response = self.get_response(user=staff_user)
         self.assert_hour_in_response(response, office_hour)
 
+    def test_staff_sees_own_office_hour_flag_for_their_hours(self):
+        program = ProgramFactory()
+        staff_user = self.staff_user(program_family=program.program_family)
+        _mentor(program=program, user=staff_user)
+        self.create_office_hour(mentor=staff_user)
+        response = self.get_response(user=staff_user)
+        office_hour_data = response.data['calendar_data'][0]
+        self.assertTrue(office_hour_data['own_office_hour'])
+
     def test_staff_sees_only_relevant_open_hours(self):
         program = ProgramFactory()
         staff_user = self.staff_user(program_family=program.program_family)
@@ -302,18 +311,18 @@ def check_hour_in_response(response, hour):
                        for response_hour in response_data]
 
 
-def _user_with_role(role_name, program):
+def _user_with_role(role_name, program, user):
     program = program or ProgramFactory()
-    return UserRoleContext(role_name, program=program).user
+    return UserRoleContext(role_name, program=program, user=user).user
 
 
-def _finalist(program=None):
-    return _user_with_role(UserRole.FINALIST, program)
+def _finalist(program=None, user=None):
+    return _user_with_role(UserRole.FINALIST, program, user)
 
 
-def _mentor(program=None):
-    return _user_with_role(UserRole.MENTOR, program)
+def _mentor(program=None, user=None):
+    return _user_with_role(UserRole.MENTOR, program, user)
 
 
-def _judge(program=None):
-    return _user_with_role(UserRole.JUDGE, program)
+def _judge(program=None, user=None):
+    return _user_with_role(UserRole.JUDGE, program, user)

--- a/web/impact/impact/v1/views/office_hours_calendar_view.py
+++ b/web/impact/impact/v1/views/office_hours_calendar_view.py
@@ -140,14 +140,24 @@ class OfficeHoursCalendarView(ImpactView):
             active_mentors,
             start_date_time__range=[self.start_date, self.end_date]).order_by(
                 'start_date_time').annotate(
-                    finalist_count=Count("finalist"))
+                    finalist_count=Count("finalist")).annotate(
+                        own_office_hour=Case(
+                            When(mentor_id=self.target_user.id, then=Value(True)),
+                            default=Value(False),
+                            output_field=BooleanField()))
+
+
+
 
     def _mentor_office_hours_queryset(self):
         return MentorProgramOfficeHour.objects.filter(
              mentor=self.target_user,
              start_date_time__range=[self.start_date, self.end_date]).order_by(
                  'start_date_time').annotate(
-                     finalist_count=Count("finalist"))
+                     finalist_count=Count("finalist")).annotate(
+                        own_office_hour=Case(
+                            default=Value(False),
+                            output_field=BooleanField()))
 
     def _finalist_office_hours_queryset(self):
         reserved_by_user = Q(finalist=self.target_user)
@@ -163,10 +173,17 @@ class OfficeHoursCalendarView(ImpactView):
                                               user_programs))
         return MentorProgramOfficeHour.objects.filter(
             reserved_by_user | unreserved & relevant_mentors,
-            start_date_time__range=[self.start_date, self.end_date])
+            start_date_time__range=[self.start_date, self.end_date]).annotate(
+                own_office_hour=Case(
+                    default=Value(False),
+                    output_field=BooleanField()))                
 
     def _null_office_hours_queryset(self):
-        return MentorProgramOfficeHour.objects.none()
+        return MentorProgramOfficeHour.objects.none().annotate(
+                        own_office_hour=Case(
+                            When(mentor_id=self.target_user.id, then=Value(True)),
+                            default=Value(False),
+                            output_field=BooleanField()))
 
     def _get_office_hours_data(self):
         primary_industry_key = "mentor__expertprofile__primary_industry__name"
@@ -190,6 +207,7 @@ class OfficeHoursCalendarView(ImpactView):
             "startup_id",
             "reserved",
             "meeting_info",
+            "own_office_hour",
             location_name=F("location__name"),
             location_timezone=F("location__timezone"),
             finalist_first_name=F("finalist__first_name"),

--- a/web/impact/impact/v1/views/office_hours_calendar_view.py
+++ b/web/impact/impact/v1/views/office_hours_calendar_view.py
@@ -179,8 +179,6 @@ class OfficeHoursCalendarView(ImpactView):
     def _null_office_hours_queryset(self):
         return MentorProgramOfficeHour.objects.none().annotate(
                         own_office_hour=Case(
-                            When(mentor_id=self.target_user.id,
-                                 then=Value(True)),
                             default=Value(False),
                             output_field=BooleanField()))
 

--- a/web/impact/impact/v1/views/office_hours_calendar_view.py
+++ b/web/impact/impact/v1/views/office_hours_calendar_view.py
@@ -142,12 +142,10 @@ class OfficeHoursCalendarView(ImpactView):
                 'start_date_time').annotate(
                     finalist_count=Count("finalist")).annotate(
                         own_office_hour=Case(
-                            When(mentor_id=self.target_user.id, then=Value(True)),
+                            When(mentor_id=self.target_user.id,
+                                 then=Value(True)),
                             default=Value(False),
                             output_field=BooleanField()))
-
-
-
 
     def _mentor_office_hours_queryset(self):
         return MentorProgramOfficeHour.objects.filter(
@@ -176,12 +174,13 @@ class OfficeHoursCalendarView(ImpactView):
             start_date_time__range=[self.start_date, self.end_date]).annotate(
                 own_office_hour=Case(
                     default=Value(False),
-                    output_field=BooleanField()))                
+                    output_field=BooleanField()))
 
     def _null_office_hours_queryset(self):
         return MentorProgramOfficeHour.objects.none().annotate(
                         own_office_hour=Case(
-                            When(mentor_id=self.target_user.id, then=Value(True)),
+                            When(mentor_id=self.target_user.id,
+                                 then=Value(True)),
                             default=Value(False),
                             output_field=BooleanField()))
 


### PR DESCRIPTION
https://masschallenge.atlassian.net/browse/AC-7871

Flags office hours owned by a staff member as "own_office_hour" when viewed by that staff member

Office hours owned by non-staff members do not get this flag. 