### PR TITLE
AC-7848 P0: Directory pages returning error for users

### DIFF
--- a/web/impact/impact/permissions/graphql_permissions.py
+++ b/web/impact/impact/permissions/graphql_permissions.py
@@ -41,8 +41,7 @@ def visible_roles(current_user):
 
 def can_view_profile(profile_user, roles):
     return profile_user.programrolegrant_set.filter(
-        program_role__user_role__name__in=roles,
-        program_role__program__program_status=ACTIVE_PROGRAM_STATUS
+        program_role__user_role__name__in=roles
     ).exists()
 
 

--- a/web/impact/impact/tests/test_graphql.py
+++ b/web/impact/impact/tests/test_graphql.py
@@ -604,6 +604,24 @@ class TestGraphQL(APITestCase):
             self.assertEqual(expert_profile["confirmedMentorProgramFamilies"],
                              [])
 
+    def test_user_can_view_profile_with_non_current_allowed_roles(self):
+        allowed_user = expert_user(UserRole.FINALIST)
+        user = EntrepreneurFactory()
+        UserRoleContext(
+            UserRole.MENTOR,
+            user=user,
+            program=ProgramFactory(program_status=ENDED_PROGRAM_STATUS))
+        query = """
+                    query{{
+                        entrepreneurProfile(id:{id}) {{
+                            programRoles
+                        }}
+                    }}
+                """.format(id=user.id)
+
+        expected_json={'data': {'entrepreneurProfile': {'programRoles': {}}}}
+        self._assert_response_equals_json(
+            query, expected_json, email=allowed_user.email)
 
     def test_allowed_user_with_non_current_user_role_cannot_view_profile(self):
         current_user = expert_user(
@@ -743,7 +761,7 @@ class TestGraphQL(APITestCase):
             user_type='EXPERT',
             program_role_names=desired_user_roles,
             program_families=[program_family]
-            ).user
+        ).user
 
         program_role = user.programrolegrant_set.filter(
             program_role__program__program_status="active",

--- a/web/impact/impact/tests/test_graphql.py
+++ b/web/impact/impact/tests/test_graphql.py
@@ -604,23 +604,6 @@ class TestGraphQL(APITestCase):
             self.assertEqual(expert_profile["confirmedMentorProgramFamilies"],
                              [])
 
-    def test_user_cannot_view_profile_with_non_current_allowed_roles(self):
-        allowed_user = expert_user(UserRole.FINALIST)
-        with self.login(email=allowed_user.email):
-            user = EntrepreneurFactory()
-            UserRoleContext(
-                UserRole.MENTOR,
-                user=user,
-                program=ProgramFactory(program_status=ENDED_PROGRAM_STATUS))
-            query = """
-                        query{{
-                            entrepreneurProfile(id:{id}) {{
-                                programRoles
-                            }}
-                        }}
-                    """.format(id=user.id)
-
-            self._assert_error_in_response(query, NOT_ALLOWED_ACCESS_MESSAGE)
 
     def test_allowed_user_with_non_current_user_role_cannot_view_profile(self):
         current_user = expert_user(


### PR DESCRIPTION
### Changes Introduced in [AC-7848](https://masschallenge.atlassian.net/browse/AC-7848):
- Removed program status check
### Testing:
- Check out this branch
- Masquerade as a finalist
- The people directory and look up a finalist whose program is no longer active
- Notice that you can view this user's profile