### PR TITLE
[AC-7891] - P0: [New office hours] Staff unable to create and view office hours

### DIFF
--- a/web/impact/impact/tests/test_create_edit_office_hours_view.py
+++ b/web/impact/impact/tests/test_create_edit_office_hours_view.py
@@ -216,6 +216,13 @@ class TestCreateEditOfficeHourView(APITestCase):
         with self._assert_office_hour_created(created=False):
             self._create_office_hour_session(self.staff_user(), data)
 
+    def test_staff_with_clearance_can_create_office_hours(self):
+        program_family = ProgramFactory().program_family
+        staff_user = self.staff_user(program_family=program_family)
+        data = self._get_post_request_data(staff_user)
+        with self._assert_office_hour_created():
+            self._create_office_hour_session(staff_user, data)
+
     def _expert_with_inactive_program(self, role):
         program = ProgramFactory(program_status='ended')
         return self._expert_user(role, program)

--- a/web/impact/impact/tests/test_office_hours_calendar_view.py
+++ b/web/impact/impact/tests/test_office_hours_calendar_view.py
@@ -28,6 +28,7 @@ from ..v1.views import (
     ISO_8601_DATE_FORMAT,
     OfficeHoursCalendarView,
 )
+from ..v1.views.office_hours_calendar_view import FINALIST, MENTOR, STAFF
 from ..permissions.v1_api_permissions import DEFAULT_PERMISSION_DENIED_DETAIL
 from .factories import UserFactory
 from .utils import nonexistent_object_id
@@ -246,6 +247,47 @@ class TestOfficeHoursCalendarView(APITestCase):
         calendar_data = response.data['calendar_data'][0]
         self.assertIn("meeting_info", calendar_data)
 
+    def test_staff_with_clearance_sees_own_office_hour(self):
+        program = ProgramFactory()
+        staff_user = self.staff_user(program_family=program.program_family)
+        office_hour = self.create_office_hour(mentor=staff_user)
+        response = self.get_response(user=staff_user)
+        self.assert_hour_in_response(response, office_hour)
+
+    def test_location_choices_for_staff_with_clearance_in_response(self):
+        program_family_location = ProgramFamilyLocationFactory()
+        program_family = program_family_location.program_family
+        location = program_family_location.location
+        ProgramFactory(program_family=program_family)
+        staff_user = self.staff_user(program_family=program_family)
+        self.create_office_hour(mentor=staff_user)
+        response = self.get_response(user=staff_user)
+        location_choices = response.data['location_choices']
+        response_location_names = location_choices.values_list(
+            'location_name', flat=True
+        )
+        self.assertTrue(location.name in response_location_names)
+
+    def test_program_family_for_staff_with_clearance_in_response(self):
+        program_family = ProgramFactory().program_family
+        staff_user = self.staff_user(program_family=program_family)
+        self.create_office_hour(mentor=staff_user)
+        response = self.get_response(user=staff_user)
+        mentor_program_families = response.data['mentor_program_families']
+        self.assertTrue(program_family.name in mentor_program_families)
+
+    def test_mentor_user_type_is_returned_in_response(self):
+        response = self.get_response(user=_mentor())
+        self.assert_correct_user_type(response, MENTOR)
+
+    def test_finalist_user_type_is_returned_in_response(self):
+        response = self.get_response(user=_finalist())
+        self.assert_correct_user_type(response, FINALIST)
+
+    def test_staff_user_type_is_returned_in_response(self):
+        response = self.get_response()
+        self.assert_correct_user_type(response, STAFF)
+
     def create_office_hour(self,
                            mentor=None,
                            finalist=None,
@@ -287,6 +329,9 @@ class TestOfficeHoursCalendarView(APITestCase):
         self.assertFalse(data['success'])
         self.assertEqual(data['header'], self.view.FAIL_HEADER)
         self.assertEqual(data['detail'], failure_message)
+
+    def assert_correct_user_type(self, response, user_type):
+        self.assertEqual(response.data['user_type'], user_type)
 
     def get_response(self,
                      user=None,

--- a/web/impact/impact/v1/serializers/office_hours_serializer.py
+++ b/web/impact/impact/v1/serializers/office_hours_serializer.py
@@ -4,7 +4,9 @@ from rest_framework.serializers import (
     ModelSerializer,
     ValidationError,
 )
-
+from accelerator_abstract.models.base_clearance import (
+    CLEARANCE_LEVEL_STAFF
+)
 from accelerator_abstract.models.base_user_utils import is_employee
 from accelerator.models import (
     MentorProgramOfficeHour,
@@ -14,8 +16,8 @@ from .location_serializer import LocationSerializer
 from .user_serializer import UserSerializer
 
 INVALID_END_DATE = 'office hour end time must be later than the start time'
-INVALID_USER = ('must be of type Mentor or Alumni in residence '
-                'in an active program')
+INVALID_USER = ('must have clearance or be of type Mentor or Alumni in '
+                'residence in an active program')
 INVALID_SESSION_DURATION = 'Please specify a duration of 30 minutes or more.'
 THIRTY_MINUTES = timedelta(minutes=30)
 NO_START_DATE_TIME = "start_date_time must be specified"
@@ -36,7 +38,7 @@ class OfficeHourSerializer(ModelSerializer):
         if self.instance is not None:
             start_date_time = self.instance.start_date_time
             end_date_time = self.instance.end_date_time
-        
+
         start_date_time = attrs.get('start_date_time') or start_date_time
         end_date_time = attrs.get('end_date_time') or end_date_time
         if not start_date_time:
@@ -45,7 +47,7 @@ class OfficeHourSerializer(ModelSerializer):
         if not end_date_time:
             raise ValidationError({
                 'end_date_time': NO_END_DATE_TIME})
-        
+
         if start_date_time > end_date_time:
             raise ValidationError({
                 'end_date_time': INVALID_END_DATE})
@@ -54,17 +56,25 @@ class OfficeHourSerializer(ModelSerializer):
                 'end_date_time': INVALID_SESSION_DURATION})
 
         return attrs
-        
+
+    def is_allowed_mentor(self, mentor):
+        staff_user = self.context['request'].user
+        roles = [UserRole.MENTOR, UserRole.AIR]
+        if staff_user == mentor:
+            return staff_user.clearances.filter(
+                level=CLEARANCE_LEVEL_STAFF,
+                program_family__programs__program_status='active'
+            ).exists()
+        return mentor.programrolegrant_set.filter(
+            program_role__user_role__name__in=roles,
+            program_role__program__program_status='active',
+        ).exists()
+
     def validate_mentor(self, mentor):
         user = self.context['request'].user
         if not is_employee(user):
             return user
-        roles = [UserRole.MENTOR, UserRole.AIR]
-        is_allowed_mentor = mentor.programrolegrant_set.filter(
-            program_role__user_role__name__in=roles,
-            program_role__program__program_status='active',
-        ).exists()
-        if not is_allowed_mentor:
+        if not self.is_allowed_mentor(mentor):
             raise ValidationError(INVALID_USER)
         return mentor
 

--- a/web/impact/impact/v1/serializers/office_hours_serializer.py
+++ b/web/impact/impact/v1/serializers/office_hours_serializer.py
@@ -58,10 +58,10 @@ class OfficeHourSerializer(ModelSerializer):
         return attrs
 
     def is_allowed_mentor(self, mentor):
-        staff_user = self.context['request'].user
+        user = self.context['request'].user
         roles = [UserRole.MENTOR, UserRole.AIR]
-        if staff_user == mentor:
-            return staff_user.clearances.filter(
+        if user == mentor:
+            return user.clearances.filter(
                 level=CLEARANCE_LEVEL_STAFF,
                 program_family__programs__program_status='active'
             ).exists()

--- a/web/impact/impact/v1/views/office_hours_calendar_view.py
+++ b/web/impact/impact/v1/views/office_hours_calendar_view.py
@@ -139,7 +139,8 @@ class OfficeHoursCalendarView(ImpactView):
             OFFICE_HOURS_HOLDER &
             in_visible_program_family).values_list(
                 "person__id", flat=True)
-        active_mentors = Q(mentor__in=program_mentors)
+        mentors = list(program_mentors) + [self.target_user.id]
+        active_mentors = Q(mentor__in=mentors)
         return MentorProgramOfficeHour.objects.filter(
             active_mentors,
             start_date_time__range=[self.start_date, self.end_date]).order_by(

--- a/web/impact/impact/v1/views/office_hours_calendar_view.py
+++ b/web/impact/impact/v1/views/office_hours_calendar_view.py
@@ -29,6 +29,9 @@ from accelerator.models import (
     ProgramRoleGrant,
     UserRole,
 )
+from accelerator_abstract.models.base_clearance import (
+    CLEARANCE_LEVEL_STAFF
+)
 from accelerator_abstract.models.base_user_utils import is_employee
 User = get_user_model()
 
@@ -65,6 +68,7 @@ class OfficeHoursCalendarView(ImpactView):
         (self._get_target_user(request) and
          self._check_request_user_type(request) and
          self._get_date_range(request) and
+         self._set_user_query() and
          self._get_office_hours_data())
         return Response(self.response_elements)
 
@@ -182,6 +186,30 @@ class OfficeHoursCalendarView(ImpactView):
                             default=Value(False),
                             output_field=BooleanField()))
 
+    def _set_user_query(self):
+        if self.request_user_type == STAFF:
+            self.user_query = self.target_user.clearances.filter(
+                level=CLEARANCE_LEVEL_STAFF,
+                program_family__programs__program_status='active'
+            )
+            self.location_path = "__".join(["program_family",
+                                            "programfamilylocation",
+                                            "location"])
+            self.program_family = "__".join(["program_family", "name"])
+        else:
+            self.user_query = self.target_user.programrolegrant_set.filter(
+                OFFICE_HOURS_HOLDER & ACTIVE_PROGRAM)
+            self.location_path = "__".join(["program_role",
+                                            "program",
+                                            "program_family",
+                                            "programfamilylocation",
+                                            "location"])
+            self.program_family = "__".join(["program_role",
+                                             "program",
+                                             "program_family",
+                                             "name"])
+        return True
+
     def _get_office_hours_data(self):
         primary_industry_key = "mentor__expertprofile__primary_industry__name"
         office_hours = self._office_hours_queryset().filter(
@@ -224,6 +252,7 @@ class OfficeHoursCalendarView(ImpactView):
         program_families = self.mentor_program_families()
         self.response_elements['mentor_program_families'] = program_families
         self.response_elements['user_startups'] = self._user_startups()
+        self.response_elements['user_type'] = self.request_user_type
         self.succeed()
 
     def _user_startups(self):
@@ -233,16 +262,12 @@ class OfficeHoursCalendarView(ImpactView):
                 name=F("startup__organization__name")).distinct()
 
     def mentor_program_families(self):
-        return self.target_user.programrolegrant_set.filter(
-            OFFICE_HOURS_HOLDER & ACTIVE_PROGRAM).values_list(
-                "program_role__program__program_family__name",
-                flat=True).distinct()
+        return self.user_query.values_list(
+            self.program_family, flat=True).distinct()
 
     def location_choices(self):
-        location_choices = self.target_user.programrolegrant_set.filter(
-            OFFICE_HOURS_HOLDER &
-            ACTIVE_PROGRAM).values(**_location_lookups())
-        return location_choices.distinct()
+        return self.user_query.values(
+            **_location_lookups(self.location_path)).distinct()
 
     def fail(self, detail):
         self.response_elements['success'] = False
@@ -255,24 +280,19 @@ class OfficeHoursCalendarView(ImpactView):
         self.response_elements['header'] = self.SUCCESS_HEADER
 
 
-def _location_lookups():
-        location_path = "__".join(["program_role",
-                                   "program",
-                                   "program_family",
-                                   "programfamilylocation",
-                                   "location"])
-        location_fields = (
-            'id',
-            'street_address',
-            'timezone',
-            'country',
-            'state',
-            'name',
-            'city',
-        )
-        return dict([("location_" + field, F("{}__{}".format(
-            location_path, field)))
-                     for field in location_fields])
+def _location_lookups(location_path):
+    location_fields = (
+        'id',
+        'street_address',
+        'timezone',
+        'country',
+        'state',
+        'name',
+        'city',
+    )
+    return dict([("location_" + field, F("{}__{}".format(
+        location_path, field)))
+                 for field in location_fields])
 
 
 def _date_range(date_spec=None):


### PR DESCRIPTION
## [AC-7891](https://masschallenge.atlassian.net/browse/AC-7891)

**Changes introduced**
- allow staff users with clearance to view location choices, program families and be able to hold office hour sessions

**Testing**
- As a staff user with staff clearance in an active program
- go to http://localhost:8000/api/v1/office_hours_calendar/, confirm that the response data has the correct user `location_choices` and `mentor_program_families`
- go to http://localhost:8000/api/v1/office_hour/, confirm that the staff user is able to create an office hour session