### PR TITLE
[AC-7908] P0: [New office hours] /office_hours_calendar/ endpoint includes null values in timezones list

### DIFF
--- a/web/impact/impact/tests/test_office_hours_calendar_view.py
+++ b/web/impact/impact/tests/test_office_hours_calendar_view.py
@@ -247,7 +247,7 @@ class TestOfficeHoursCalendarView(APITestCase):
         self.assertIn("meeting_info", calendar_data)
 
     def test_timezone_response_data_excludes_null_values(self):
-        office_hour = MentorProgramOfficeHourFactory(mentor=_mentor(), location=None)
+        office_hour = self.create_office_hour(timezone=None)
         response = self.get_response(target_user_id=office_hour.mentor_id)
         timezone_data = response.data['timezones']
         self.assertEqual(timezone_data.count(), 0)
@@ -258,7 +258,8 @@ class TestOfficeHoursCalendarView(APITestCase):
                            start_date_time=None,
                            duration_minutes=30,
                            timezone="America/New_York",
-                           program=None):
+                           program=None,
+                           location=None):
         create_params = {}
         mentor = mentor or _mentor(program)
         create_params['mentor'] = mentor
@@ -270,6 +271,8 @@ class TestOfficeHoursCalendarView(APITestCase):
         create_params['location__timezone'] = timezone
         create_params['finalist'] = finalist
         create_params['program'] = program
+        if not timezone:
+            create_params['location'] = location
         return MentorProgramOfficeHourFactory(**create_params)
 
     def assert_hour_in_response(self, response, hour):

--- a/web/impact/impact/tests/test_office_hours_calendar_view.py
+++ b/web/impact/impact/tests/test_office_hours_calendar_view.py
@@ -246,6 +246,12 @@ class TestOfficeHoursCalendarView(APITestCase):
         calendar_data = response.data['calendar_data'][0]
         self.assertIn("meeting_info", calendar_data)
 
+    def test_timezone_response_data_excludes_null_values(self):
+        office_hour = MentorProgramOfficeHourFactory(mentor=_mentor(), location=None)
+        response = self.get_response(target_user_id=office_hour.mentor_id)
+        timezone_data = response.data['timezones']
+        self.assertEqual(timezone_data.count(), 0)
+
     def create_office_hour(self,
                            mentor=None,
                            finalist=None,

--- a/web/impact/impact/v1/views/office_hours_calendar_view.py
+++ b/web/impact/impact/v1/views/office_hours_calendar_view.py
@@ -217,9 +217,10 @@ class OfficeHoursCalendarView(ImpactView):
             startup_name=F("startup__organization__name"),
         )
         self.response_elements['location_choices'] = self.location_choices()
-        self.response_elements['timezones'] = office_hours.order_by(
+        self.response_elements['timezones'] = office_hours.filter(
+            location__isnull=False).order_by(
             "location__timezone").values_list(
-                "location__timezone", flat=True).distinct()
+            "location__timezone", flat=True).distinct()
         self.response_elements['location_choices'] = self.location_choices()
         program_families = self.mentor_program_families()
         self.response_elements['mentor_program_families'] = program_families

--- a/web/impact/impact/v1/views/office_hours_calendar_view.py
+++ b/web/impact/impact/v1/views/office_hours_calendar_view.py
@@ -219,8 +219,8 @@ class OfficeHoursCalendarView(ImpactView):
         self.response_elements['location_choices'] = self.location_choices()
         self.response_elements['timezones'] = office_hours.filter(
             location__isnull=False).order_by(
-            "location__timezone").values_list(
-            "location__timezone", flat=True).distinct()
+                "location__timezone").values_list("location__timezone",
+                                                  flat=True).distinct()
         self.response_elements['location_choices'] = self.location_choices()
         program_families = self.mentor_program_families()
         self.response_elements['mentor_program_families'] = program_families


### PR DESCRIPTION
## [AC-7908](https://masschallenge.atlassian.net/browse/AC-7908)

**Changes introduced**
- Exclude null values in timezone list

**Testing**
- As a user with office hours, go to http://localhost:8000/api/v1/office_hours_calendar/
- choose one office hour session id in the `calendar_data` and set its location to None (shell/django admin)
- On development:
  - Confirm that `null` is included in the timezone list
- On this branch
  - Confirm that `null` is excluded in the timezone list

[Sibling PR](https://github.com/masschallenge/accelerate/pull/2655)