### PR TITLE
[AC-7888] Prevent experts from creating conflicting office hours

### DIFF
--- a/web/impact/impact/tests/test_create_edit_office_hours_view.py
+++ b/web/impact/impact/tests/test_create_edit_office_hours_view.py
@@ -275,6 +275,18 @@ class TestCreateEditOfficeHourView(APITestCase):
         with self._assert_office_hour_created(created=True):
             self._create_office_hour_session(mentor, data)
 
+    def test_cant_create_session_when_conflict_exists_in_the_block(self):
+        mentor = self._expert_user(UserRole.MENTOR)
+        start_time = _now()
+        self._create_office_hour_obj(
+            mentor, start_date_time=start_time, block_duration=120)
+        data = self._get_post_request_data(
+            mentor,
+            get_data={'start_date_time': start_time + timedelta(minutes=60),
+                      'end_date_time': start_time + timedelta(minutes=150)})
+        with self._assert_office_hour_created(count=0):
+            self._create_office_hour_session(mentor, data)
+
     def _expert_with_inactive_program(self, role):
         program = ProgramFactory(program_status='ended')
         return self._expert_user(role, program)
@@ -315,10 +327,11 @@ class TestCreateEditOfficeHourView(APITestCase):
                                 minutes_from_now=0,
                                 finalist=None,
                                 start_date_time=None,
+                                block_duration=30,
                                 ):
         start_time = start_date_time or _now() + timedelta(
             minutes=minutes_from_now)
-        end_time = start_time + timedelta(minutes=30)
+        end_time = start_time + timedelta(minutes=block_duration)
         return MentorProgramOfficeHourFactory(
             mentor=mentor,
             start_date_time=start_time,

--- a/web/impact/impact/tests/test_create_edit_office_hours_view.py
+++ b/web/impact/impact/tests/test_create_edit_office_hours_view.py
@@ -247,7 +247,6 @@ class TestCreateEditOfficeHourView(APITestCase):
         self._create_office_hour_obj(mentor, start_date_time=start_time)
         office_hour = self._create_office_hour_obj(mentor)
         data = {
-            'topics': self.updated_topics,
             'start_date_time': start_time,
             'end_date_time': start_time + timedelta(minutes=30)}
         self._edit_office_hour_session(mentor, office_hour, data)
@@ -286,7 +285,7 @@ class TestCreateEditOfficeHourView(APITestCase):
                       'end_date_time': start_time + timedelta(minutes=150)})
         with self._assert_office_hour_created(count=0):
             self._create_office_hour_session(mentor, data)
-    
+
     def test_staff_with_clearance_can_create_office_hours(self):
         program_family = ProgramFactory().program_family
         staff_user = self.staff_user(program_family=program_family)
@@ -354,7 +353,14 @@ class TestCreateEditOfficeHourView(APITestCase):
     def _assert_office_hour_not_updated(self, office_hour):
         updated_office_hour = MentorProgramOfficeHour.objects.get(
             pk=office_hour.id)
-        self.assertEqual(updated_office_hour.topics, office_hour.topics)
+        self.assertTrue(all([
+            updated_office_hour.topics == office_hour.topics,
+            updated_office_hour.description == office_hour.description,
+            updated_office_hour.mentor == office_hour.mentor,
+            updated_office_hour.start_date_time == office_hour.start_date_time,
+            updated_office_hour.end_date_time == office_hour.end_date_time,
+            updated_office_hour.location == office_hour.location,
+        ]))
 
     def _create_office_hour_session(self, user, data):
         with self.login(email=user.email):

--- a/web/impact/impact/tests/test_create_edit_office_hours_view.py
+++ b/web/impact/impact/tests/test_create_edit_office_hours_view.py
@@ -377,16 +377,9 @@ class TestCreateEditOfficeHourView(APITestCase):
         self.assertEqual(updated_office_hour.topics, self.updated_topics)
 
     def _assert_office_hour_not_updated(self, office_hour):
-        updated_office_hour = MentorProgramOfficeHour.objects.get(
-            pk=office_hour.id)
-        self.assertTrue(all([
-            updated_office_hour.topics == office_hour.topics,
-            updated_office_hour.description == office_hour.description,
-            updated_office_hour.mentor == office_hour.mentor,
-            updated_office_hour.start_date_time == office_hour.start_date_time,
-            updated_office_hour.end_date_time == office_hour.end_date_time,
-            updated_office_hour.location == office_hour.location,
-        ]))
+        previously_updated_at = office_hour.updated_at
+        office_hour.refresh_from_db()
+        self.assertEqual(previously_updated_at, office_hour.updated_at)
 
     def _create_office_hour_session(self, user, data):
         with self.login(email=user.email):

--- a/web/impact/impact/v1/serializers/office_hours_serializer.py
+++ b/web/impact/impact/v1/serializers/office_hours_serializer.py
@@ -38,10 +38,10 @@ class OfficeHourSerializer(ModelSerializer):
         office_hour = self.instance
         start_time = attrs.get('start_date_time', None)
         end_time = attrs.get('end_date_time', None)
-        time_unchanged = (office_hour and
-                        (office_hour.start_date_time == start_time and
-                         office_hour.end_date_time == end_time))
-        if (start_time or end_time) and not time_unchanged:
+        skip_check = (office_hour and
+                      (office_hour.start_date_time == start_time and
+                       office_hour.end_date_time == end_time))
+        if (start_time or end_time) and not skip_check:
             mentor = attrs.get('mentor', None) or office_hour.mentor
             start_conflict = (Q(start_date_time__gt=start_time) &
                               Q(start_date_time__lt=end_time))


### PR DESCRIPTION
## [AC-7888](https://masschallenge.atlassian.net/browse/AC-7888)

**Changes introduced**
- prevent experts from creating conflicting office hours

**Testing**
- As an office hour holder in an active program, go to http://localhost:8000/api/v1/office_hour/
- Creating and editing conflicting office hours should not be possible

Confirm that this PR meets the definition of done according to  [AC-7888](https://masschallenge.atlassian.net/browse/AC-7888)