### PR TITLE
[AC-7896] Prevent finalists from reserving conflicting office hours

### DIFF
--- a/web/impact/impact/tests/test_reserve_office_hour_view.py
+++ b/web/impact/impact/tests/test_reserve_office_hour_view.py
@@ -48,6 +48,25 @@ class TestReserveOfficeHourView(APITestCase):
                                       request_user=finalist)
         self.assert_ui_notification(response, False, self.view.CONFLICT_EXISTS)
 
+    def test_finalist_can_reserve_adjacecent_office_hour_session(self):
+        start_time = minutes_from_now(30)
+        shared_midpoint = minutes_from_now(60)
+        end_time = minutes_from_now(90)
+        
+        finalist = _finalist()
+        MentorProgramOfficeHourFactory(
+            finalist=finalist,
+            start_date_time=start_time,
+            end_date_time=shared_midpoint)
+
+        new_office_hour = MentorProgramOfficeHourFactory(
+            finalist=None,
+            start_date_time=shared_midpoint,
+            end_date_time=end_time)
+        response = self.post_response(new_office_hour.id,
+                                      request_user=finalist)
+        self.assert_reserved_by(new_office_hour, finalist)
+        
     def test_finalist_reserves_office_hour_with_conflict_reserve_fails(self):
         start_time = minutes_from_now(60)
         end_time = minutes_from_now(90)

--- a/web/impact/impact/tests/test_reserve_office_hour_view.py
+++ b/web/impact/impact/tests/test_reserve_office_hour_view.py
@@ -62,6 +62,22 @@ class TestReserveOfficeHourView(APITestCase):
         self.post_response(new_office_hour.id, request_user=finalist)
         self.assert_not_reserved(new_office_hour)
 
+    def test_finalist_reserves_office_hour_with_enclosing_conflict(self):
+        # "enclosing conflict": existing hour starts before and ends after
+        # new hour
+        
+        finalist = _finalist()
+        MentorProgramOfficeHourFactory(
+            finalist=finalist,
+            start_date_time=minutes_from_now(30),
+            end_date_time=minutes_from_now(120))
+        new_office_hour = MentorProgramOfficeHourFactory(
+            finalist=None,
+            start_date_time=minutes_from_now(60),
+            end_date_time=minutes_from_now(90))
+        self.post_response(new_office_hour.id, request_user=finalist)
+        self.assert_not_reserved(new_office_hour)
+        
     def test_finalist_reserves_unspecified_office_hour(self):
         # a finalist reserves an office hour, gets success response
         finalist = _finalist()

--- a/web/impact/impact/tests/test_reserve_office_hour_view.py
+++ b/web/impact/impact/tests/test_reserve_office_hour_view.py
@@ -65,7 +65,7 @@ class TestReserveOfficeHourView(APITestCase):
     def test_finalist_reserves_office_hour_with_enclosing_conflict(self):
         # "enclosing conflict": existing hour starts before and ends after
         # new hour
-        
+
         finalist = _finalist()
         MentorProgramOfficeHourFactory(
             finalist=finalist,
@@ -77,7 +77,7 @@ class TestReserveOfficeHourView(APITestCase):
             end_date_time=minutes_from_now(90))
         self.post_response(new_office_hour.id, request_user=finalist)
         self.assert_not_reserved(new_office_hour)
-        
+
     def test_finalist_reserves_unspecified_office_hour(self):
         # a finalist reserves an office hour, gets success response
         finalist = _finalist()

--- a/web/impact/impact/tests/test_reserve_office_hour_view.py
+++ b/web/impact/impact/tests/test_reserve_office_hour_view.py
@@ -4,7 +4,10 @@ from .api_test_case import APITestCase
 from ..v1.views import ReserveOfficeHourView
 from ..permissions.v1_api_permissions import DEFAULT_PERMISSION_DENIED_DETAIL
 from .factories import UserFactory
-from .utils import nonexistent_object_id
+from .utils import (
+    minutes_from_now,
+    nonexistent_object_id,
+)
 from accelerator.tests.factories import (
     MentorProgramOfficeHourFactory,
     StartupFactory,
@@ -28,24 +31,37 @@ class TestReserveOfficeHourView(APITestCase):
         self.assert_ui_notification(response, True, self.view.SUCCESS_DETAIL)
 
     def test_finalist_reserves_office_hour_with_conflict_fail_message(self):
+        start_time = minutes_from_now(60)
+        end_time = minutes_from_now(90)
+
         finalist = _finalist()
-        conflicting_office_hour = MentorProgramOfficeHourFactory(
-            finalist=finalist)
-        new_office_hour = MentorProgramOfficeHourFactory(finalist=None)
+        MentorProgramOfficeHourFactory(
+            finalist=finalist,
+            start_date_time=start_time,
+            end_date_time=end_time)
+
+        new_office_hour = MentorProgramOfficeHourFactory(
+            finalist=None,
+            start_date_time=start_time,
+            end_date_time=end_time)
         response = self.post_response(new_office_hour.id,
                                       request_user=finalist)
         self.assert_ui_notification(response, False, self.view.CONFLICT_EXISTS)
 
-
     def test_finalist_reserves_office_hour_with_conflict_reserve_fails(self):
+        start_time = minutes_from_now(60)
+        end_time = minutes_from_now(90)
         finalist = _finalist()
-        conflicting_office_hour = MentorProgramOfficeHourFactory(
-            finalist=finalist)
-        new_office_hour = MentorProgramOfficeHourFactory(finalist=None)
-        response = self.post_response(new_office_hour.id,
-                                      request_user=finalist)
+        MentorProgramOfficeHourFactory(finalist=finalist,
+                                       start_date_time=start_time,
+                                       end_date_time=end_time)
+        new_office_hour = MentorProgramOfficeHourFactory(
+            finalist=None,
+            start_date_time=start_time,
+            end_date_time=end_time)
+        self.post_response(new_office_hour.id, request_user=finalist)
         self.assert_not_reserved(new_office_hour)
-        
+
     def test_finalist_reserves_unspecified_office_hour(self):
         # a finalist reserves an office hour, gets success response
         finalist = _finalist()

--- a/web/impact/impact/tests/test_reserve_office_hour_view.py
+++ b/web/impact/impact/tests/test_reserve_office_hour_view.py
@@ -27,6 +27,25 @@ class TestReserveOfficeHourView(APITestCase):
                                       request_user=finalist)
         self.assert_ui_notification(response, True, self.view.SUCCESS_DETAIL)
 
+    def test_finalist_reserves_office_hour_with_conflict_fail_message(self):
+        finalist = _finalist()
+        conflicting_office_hour = MentorProgramOfficeHourFactory(
+            finalist=finalist)
+        new_office_hour = MentorProgramOfficeHourFactory(finalist=None)
+        response = self.post_response(new_office_hour.id,
+                                      request_user=finalist)
+        self.assert_ui_notification(response, False, self.view.CONFLICT_EXISTS)
+
+
+    def test_finalist_reserves_office_hour_with_conflict_reserve_fails(self):
+        finalist = _finalist()
+        conflicting_office_hour = MentorProgramOfficeHourFactory(
+            finalist=finalist)
+        new_office_hour = MentorProgramOfficeHourFactory(finalist=None)
+        response = self.post_response(new_office_hour.id,
+                                      request_user=finalist)
+        self.assert_not_reserved(new_office_hour)
+        
     def test_finalist_reserves_unspecified_office_hour(self):
         # a finalist reserves an office hour, gets success response
         finalist = _finalist()

--- a/web/impact/impact/tests/utils.py
+++ b/web/impact/impact/tests/utils.py
@@ -11,8 +11,12 @@ from io import StringIO
 from pytz import utc
 
 
+def minutes_from_now(minutes):
+    return utc.localize(datetime.utcnow() + timedelta(minutes=minutes))
+
+
 def days_from_now(days):
-    return utc.localize(datetime.now() + timedelta(days))
+    return utc.localize(datetime.utcnow() + timedelta(days))
 
 
 def months_from_now(months):

--- a/web/impact/impact/v1/views/reserve_office_hour_view.py
+++ b/web/impact/impact/v1/views/reserve_office_hour_view.py
@@ -137,8 +137,11 @@ class ReserveOfficeHourView(ImpactView):
 
         start_conflict = Q(start_date_time__range=(start, end))
         end_conflict = Q(end_date_time__range=(start, end))
+        enclosing_conflict = (Q(start_date_time__lte=start) &
+                              Q(end_date_time__gte=end))
+        
         if self.target_user.finalist_officehours.filter(
-                start_conflict | end_conflict).exists():
+                start_conflict | end_conflict | enclosing_conflict).exists():
             return True
         return False
 

--- a/web/impact/impact/v1/views/reserve_office_hour_view.py
+++ b/web/impact/impact/v1/views/reserve_office_hour_view.py
@@ -134,14 +134,14 @@ class ReserveOfficeHourView(ImpactView):
     def _conflict_exists(self):
         start = self.office_hour.start_date_time
         end = self.office_hour.end_date_time
-        
+
         start_conflict = Q(start_date_time__range=(start, end))
         end_conflict = Q(end_date_time__range=(start, end))
         if self.target_user.finalist_officehours.filter(
                 start_conflict | end_conflict).exists():
             return True
         return False
-    
+
     def _update_office_hour_data(self):
         self.office_hour.finalist = self.target_user
         self.office_hour.description = self.message

--- a/web/impact/impact/v1/views/reserve_office_hour_view.py
+++ b/web/impact/impact/v1/views/reserve_office_hour_view.py
@@ -1,5 +1,7 @@
-from django.template import loader
 from django.contrib.auth import get_user_model
+from django.db.models import Q
+from django.template import loader
+
 from rest_framework.response import Response
 
 from accelerator_abstract.models.base_user_utils import is_employee
@@ -43,6 +45,8 @@ class ReserveOfficeHourView(ImpactView):
                                         "choice for {}")
     USER_CANNOT_RESERVE_OFFICE_HOURS = ("The selected user is not allowed to "
                                         "reserve office hour sessions.")
+    CONFLICT_EXISTS = ("There is a conflict with an existing office hour "
+                       "reservation")
 
     def post(self, request):
         '''
@@ -119,11 +123,25 @@ class ReserveOfficeHourView(ImpactView):
         if self.office_hour.finalist is not None:
             self.fail(self.OFFICE_HOUR_ALREADY_RESERVED)
             return False
+        if self._conflict_exists():
+            self.fail(self.CONFLICT_EXISTS)
+            return False
         self._update_office_hour_data()
         self._send_confirmation_emails()
         self._succeed()
         return True
 
+    def _conflict_exists(self):
+        start = self.office_hour.start_date_time
+        end = self.office_hour.end_date_time
+        
+        start_conflict = Q(start_date_time__range=(start, end))
+        end_conflict = Q(end_date_time__range=(start, end))
+        if self.target_user.finalist_officehours.filter(
+                start_conflict | end_conflict).exists():
+            return True
+        return False
+    
     def _update_office_hour_data(self):
         self.office_hour.finalist = self.target_user
         self.office_hour.description = self.message

--- a/web/impact/impact/v1/views/reserve_office_hour_view.py
+++ b/web/impact/impact/v1/views/reserve_office_hour_view.py
@@ -139,7 +139,7 @@ class ReserveOfficeHourView(ImpactView):
         end_conflict = Q(end_date_time__range=(start, end))
         enclosing_conflict = (Q(start_date_time__lte=start) &
                               Q(end_date_time__gte=end))
-        
+
         if self.target_user.finalist_officehours.filter(
                 start_conflict | end_conflict | enclosing_conflict).exists():
             return True

--- a/web/impact/impact/v1/views/reserve_office_hour_view.py
+++ b/web/impact/impact/v1/views/reserve_office_hour_view.py
@@ -135,11 +135,13 @@ class ReserveOfficeHourView(ImpactView):
         start = self.office_hour.start_date_time
         end = self.office_hour.end_date_time
 
-        start_conflict = Q(start_date_time__range=(start, end))
-        end_conflict = Q(end_date_time__range=(start, end))
+        start_conflict = (Q(start_date_time__gt=start) &
+                          Q(start_date_time__lt=end))
+        end_conflict = (Q(end_date_time__gt=start) &
+                        Q(end_date_time__lt=end))        
         enclosing_conflict = (Q(start_date_time__lte=start) &
                               Q(end_date_time__gte=end))
-
+        
         if self.target_user.finalist_officehours.filter(
                 start_conflict | end_conflict | enclosing_conflict).exists():
             return True


### PR DESCRIPTION
https://masschallenge.atlassian.net/browse/AC-7896

To test: 
Set up two office hours whose times conflict. Attempt to reserve both of them. 

If ui is not easy to work with locally, use localhost api directly - post response with data =` {'office_hour_id': OFFICE_HOUR_ID}` to http://localhost:8000/api/v1/reserve_office_hour/

Note, two hours h1 and h2 can conflict in three ways: h1 starts during h2, h1 ends during h2, or h1 starts before and ends after h2. 