### PR TITLE
[AC-7923] P0: [New office hours] Some staff unable to create and view office hours

### DIFF
--- a/web/impact/impact/tests/api_test_case.py
+++ b/web/impact/impact/tests/api_test_case.py
@@ -48,10 +48,10 @@ class APITestCase(TestCase):
         user.save()
         return user
 
-    def staff_user(self, program_family=None):
+    def staff_user(self, program_family=None, level=CLEARANCE_LEVEL_STAFF):
         user = self.make_user('basic_user{}@test.com'.format(self._user_count))
         self._user_count += 1
-        kwargs = {"level": CLEARANCE_LEVEL_STAFF,
+        kwargs = {"level": level,
                   "user": user}
         if program_family:
             kwargs['program_family'] = program_family

--- a/web/impact/impact/tests/test_create_edit_office_hours_view.py
+++ b/web/impact/impact/tests/test_create_edit_office_hours_view.py
@@ -7,6 +7,11 @@ from pytz import utc
 
 from django.urls import reverse
 
+from accelerator_abstract.models.base_clearance import (
+    CLEARANCE_LEVEL_EXEC_MD,
+    CLEARANCE_LEVEL_GLOBAL_MANAGER,
+    CLEARANCE_LEVEL_POM,
+)
 from accelerator.models import MentorProgramOfficeHour, UserRole
 from accelerator.tests.contexts import UserRoleContext
 from accelerator.tests.factories import (
@@ -312,9 +317,33 @@ class TestCreateEditOfficeHourView(APITestCase):
         self._edit_office_hour_session(mentor, office_hour, data)
         self._assert_office_hour_not_updated(office_hour)
 
-    def test_staff_with_clearance_can_create_office_hours(self):
+    def test_user_with_staff_clearance_can_create_office_hours(self):
         program_family = ProgramFactory().program_family
         staff_user = self.staff_user(program_family=program_family)
+        data = self._get_post_request_data(staff_user)
+        with self._assert_office_hour_created():
+            self._create_office_hour_session(staff_user, data)
+
+    def test_user_with_pom_clearance_can_create_office_hours(self):
+        program_family = ProgramFactory().program_family
+        staff_user = self.staff_user(program_family=program_family,
+                                     level=CLEARANCE_LEVEL_POM)
+        data = self._get_post_request_data(staff_user)
+        with self._assert_office_hour_created():
+            self._create_office_hour_session(staff_user, data)
+
+    def test_user_with_exec_md_clearance_can_create_office_hours(self):
+        program_family = ProgramFactory().program_family
+        staff_user = self.staff_user(program_family=program_family,
+                                     level=CLEARANCE_LEVEL_EXEC_MD)
+        data = self._get_post_request_data(staff_user)
+        with self._assert_office_hour_created():
+            self._create_office_hour_session(staff_user, data)
+
+    def test_global_manager_can_create_office_hours(self):
+        program_family = ProgramFactory().program_family
+        staff_user = self.staff_user(program_family=program_family,
+                                     level=CLEARANCE_LEVEL_GLOBAL_MANAGER)
         data = self._get_post_request_data(staff_user)
         with self._assert_office_hour_created():
             self._create_office_hour_session(staff_user, data)

--- a/web/impact/impact/tests/test_create_edit_office_hours_view.py
+++ b/web/impact/impact/tests/test_create_edit_office_hours_view.py
@@ -11,6 +11,7 @@ from accelerator_abstract.models.base_clearance import (
     CLEARANCE_LEVEL_EXEC_MD,
     CLEARANCE_LEVEL_GLOBAL_MANAGER,
     CLEARANCE_LEVEL_POM,
+    CLEARANCE_LEVEL_STAFF
 )
 from accelerator.models import MentorProgramOfficeHour, UserRole
 from accelerator.tests.contexts import UserRoleContext
@@ -318,35 +319,20 @@ class TestCreateEditOfficeHourView(APITestCase):
         self._assert_office_hour_not_updated(office_hour)
 
     def test_user_with_staff_clearance_can_create_office_hours(self):
-        program_family = ProgramFactory().program_family
-        staff_user = self.staff_user(program_family=program_family)
-        data = self._get_post_request_data(staff_user)
-        with self._assert_office_hour_created():
-            self._create_office_hour_session(staff_user, data)
+        self.assert_user_with_clearance_can_create_office_hours(
+            CLEARANCE_LEVEL_STAFF)
 
     def test_user_with_pom_clearance_can_create_office_hours(self):
-        program_family = ProgramFactory().program_family
-        staff_user = self.staff_user(program_family=program_family,
-                                     level=CLEARANCE_LEVEL_POM)
-        data = self._get_post_request_data(staff_user)
-        with self._assert_office_hour_created():
-            self._create_office_hour_session(staff_user, data)
+        self.assert_user_with_clearance_can_create_office_hours(
+            CLEARANCE_LEVEL_POM)
 
     def test_user_with_exec_md_clearance_can_create_office_hours(self):
-        program_family = ProgramFactory().program_family
-        staff_user = self.staff_user(program_family=program_family,
-                                     level=CLEARANCE_LEVEL_EXEC_MD)
-        data = self._get_post_request_data(staff_user)
-        with self._assert_office_hour_created():
-            self._create_office_hour_session(staff_user, data)
+        self.assert_user_with_clearance_can_create_office_hours(
+            CLEARANCE_LEVEL_EXEC_MD)
 
     def test_global_manager_can_create_office_hours(self):
-        program_family = ProgramFactory().program_family
-        staff_user = self.staff_user(program_family=program_family,
-                                     level=CLEARANCE_LEVEL_GLOBAL_MANAGER)
-        data = self._get_post_request_data(staff_user)
-        with self._assert_office_hour_created():
-            self._create_office_hour_session(staff_user, data)
+        self.assert_user_with_clearance_can_create_office_hours(
+            CLEARANCE_LEVEL_GLOBAL_MANAGER)
 
     def _expert_with_inactive_program(self, role):
         program = ProgramFactory(program_status='ended')
@@ -369,6 +355,15 @@ class TestCreateEditOfficeHourView(APITestCase):
         if get_data:
             data.update(get_data)
         return data
+
+    def assert_user_with_clearance_can_create_office_hours(
+            self, clearance_level):
+        program_family = ProgramFactory().program_family
+        staff_user = self.staff_user(program_family=program_family,
+                                     level=clearance_level)
+        data = self._get_post_request_data(staff_user)
+        with self._assert_office_hour_created():
+            self._create_office_hour_session(staff_user, data)
 
     def _assert_success_response(self, response, edit=False):
         header = SUCCESS_EDIT_HEADER if edit else SUCCESS_CREATE_HEADER

--- a/web/impact/impact/tests/test_office_hours_calendar_view.py
+++ b/web/impact/impact/tests/test_office_hours_calendar_view.py
@@ -301,7 +301,6 @@ class TestOfficeHoursCalendarView(APITestCase):
     def test_location_always_include_remote_location(self):
         program_family_location = ProgramFamilyLocationFactory()
         program_family = program_family_location.program_family
-        location = program_family_location.location
         remote_location = LocationFactory(name="Remote")
         ProgramFactory(program_family=program_family)
         staff_user = self.staff_user(program_family=program_family)

--- a/web/impact/impact/tests/test_office_hours_calendar_view.py
+++ b/web/impact/impact/tests/test_office_hours_calendar_view.py
@@ -12,6 +12,7 @@ from accelerator_abstract.models.base_clearance import (
     CLEARANCE_LEVEL_EXEC_MD,
     CLEARANCE_LEVEL_GLOBAL_MANAGER,
     CLEARANCE_LEVEL_POM,
+    CLEARANCE_LEVEL_STAFF
 )
 
 from accelerator.models import UserRole
@@ -253,11 +254,8 @@ class TestOfficeHoursCalendarView(APITestCase):
         self.assertIn("meeting_info", calendar_data)
 
     def test_user_with_staff_clearance_sees_own_office_hour(self):
-        program = ProgramFactory()
-        staff_user = self.staff_user(program_family=program.program_family)
-        office_hour = self.create_office_hour(mentor=staff_user)
-        response = self.get_response(user=staff_user)
-        self.assert_hour_in_response(response, office_hour)
+        self.assert_user_with_clearance_sees_own_office_hour(
+            CLEARANCE_LEVEL_STAFF)
 
     def test_location_choices_for_staff_with_clearance_in_response(self):
         program_family_location = ProgramFamilyLocationFactory()
@@ -312,28 +310,16 @@ class TestOfficeHoursCalendarView(APITestCase):
         self.assertTrue(remote_location.name in response_location_names)
 
     def test_user_with_pom_clearance_sees_own_office_hour(self):
-        program = ProgramFactory()
-        staff_user = self.staff_user(program_family=program.program_family,
-                                     level=CLEARANCE_LEVEL_POM)
-        office_hour = self.create_office_hour(mentor=staff_user)
-        response = self.get_response(user=staff_user)
-        self.assert_hour_in_response(response, office_hour)
+        self.assert_user_with_clearance_sees_own_office_hour(
+            CLEARANCE_LEVEL_POM)
 
     def test_user_with_exec_md_clearance_sees_own_office_hour(self):
-        program = ProgramFactory()
-        staff_user = self.staff_user(program_family=program.program_family,
-                                     level=CLEARANCE_LEVEL_EXEC_MD)
-        office_hour = self.create_office_hour(mentor=staff_user)
-        response = self.get_response(user=staff_user)
-        self.assert_hour_in_response(response, office_hour)
+        self.assert_user_with_clearance_sees_own_office_hour(
+            CLEARANCE_LEVEL_EXEC_MD)
 
     def test_global_manager_sees_own_office_hour(self):
-        program = ProgramFactory()
-        staff_user = self.staff_user(program_family=program.program_family,
-                                     level=CLEARANCE_LEVEL_GLOBAL_MANAGER)
-        office_hour = self.create_office_hour(mentor=staff_user)
-        response = self.get_response(user=staff_user)
-        self.assert_hour_in_response(response, office_hour)
+        self.assert_user_with_clearance_sees_own_office_hour(
+            CLEARANCE_LEVEL_GLOBAL_MANAGER)
 
     def create_office_hour(self,
                            mentor=None,
@@ -382,6 +368,14 @@ class TestOfficeHoursCalendarView(APITestCase):
 
     def assert_correct_user_type(self, response, user_type):
         self.assertEqual(response.data['user_type'], user_type)
+
+    def assert_user_with_clearance_sees_own_office_hour(self, clearance_level):
+        program = ProgramFactory()
+        staff_user = self.staff_user(program_family=program.program_family,
+                                     level=clearance_level)
+        office_hour = self.create_office_hour(mentor=staff_user)
+        response = self.get_response(user=staff_user)
+        self.assert_hour_in_response(response, office_hour)
 
     def get_response(self,
                      user=None,

--- a/web/impact/impact/v1/serializers/office_hours_serializer.py
+++ b/web/impact/impact/v1/serializers/office_hours_serializer.py
@@ -5,11 +5,9 @@ from rest_framework.serializers import (
     ModelSerializer,
     ValidationError,
 )
-from accelerator_abstract.models.base_clearance import (
-    CLEARANCE_LEVEL_STAFF
-)
 from accelerator_abstract.models.base_user_utils import is_employee
 from accelerator.models import (
+    Clearance,
     MentorProgramOfficeHour,
     UserRole
 )
@@ -89,10 +87,8 @@ class OfficeHourSerializer(ModelSerializer):
         user = self.context['request'].user
         roles = [UserRole.MENTOR, UserRole.AIR]
         if user == mentor:
-            return user.clearances.filter(
-                level=CLEARANCE_LEVEL_STAFF,
-                program_family__programs__program_status='active'
-            ).exists()
+            return Clearance.objects.clearances_for_user(user).filter(
+                program_family__programs__program_status='active').exists()
         return mentor.programrolegrant_set.filter(
             program_role__user_role__name__in=roles,
             program_role__program__program_status='active',

--- a/web/impact/impact/v1/views/office_hours_calendar_view.py
+++ b/web/impact/impact/v1/views/office_hours_calendar_view.py
@@ -30,9 +30,6 @@ from accelerator.models import (
     UserRole,
     Location,
 )
-from accelerator_abstract.models.base_clearance import (
-    CLEARANCE_LEVEL_STAFF
-)
 from accelerator_abstract.models.base_user_utils import is_employee
 User = get_user_model()
 
@@ -199,10 +196,9 @@ class OfficeHoursCalendarView(ImpactView):
 
     def _set_user_query(self):
         if self.request_user_type == STAFF:
-            self.user_query = self.target_user.clearances.filter(
-                level=CLEARANCE_LEVEL_STAFF,
-                program_family__programs__program_status='active'
-            )
+            self.user_query = Clearance.objects.clearances_for_user(
+                self.target_user).filter(
+                program_family__programs__program_status='active')
             self.location_path = "__".join(["program_family",
                                             "programfamilylocation",
                                             "location"])


### PR DESCRIPTION
## [AC-7923](https://masschallenge.atlassian.net/browse/AC-7923)

**Changes introduced**
- Allow all users with clearances in an active program to create and view office hours

**Testing**
- As a user with any staff clearance in an active program
- go to http://localhost:8000/api/v1/office_hours_calendar/, confirm that the response data has the correct user `location_choices` and `mentor_program_families`
- go to http://localhost:8000/api/v1/office_hour/, confirm that the staff user is able to create an office hour session