### PR TITLE
[AC-7836] Integrate cancellation workflow

### DIFF
--- a/web/impact/impact/tests/test_cancel_office_hour_session_view.py
+++ b/web/impact/impact/tests/test_cancel_office_hour_session_view.py
@@ -3,29 +3,28 @@ from pytz import timezone
 from django.core import mail
 from django.urls import reverse
 
-from accelerator.models import UserRole
+from accelerator.models import MentorProgramOfficeHour, UserRole
 from accelerator.tests.contexts import UserRoleContext
 from accelerator.tests.utils import days_from_now
-from impact.permissions.v1_api_permissions import (
+from ..permissions.v1_api_permissions import (
     DEFAULT_PERMISSION_DENIED_DETAIL,
 )
-from impact.tests.api_test_case import APITestCase
-from impact.tests.factories import MentorProgramOfficeHourFactory
-from impact.v1.views.cancel_office_hour_session_view import (
+from ..tests.api_test_case import APITestCase
+from ..tests.factories import MentorProgramOfficeHourFactory
+from ..v1.views.cancel_office_hour_session_view import (
     DEFAULT_TIMEZONE,
     FAIL_HEADER,
     OFFICE_HOUR_SESSION_404,
     MENTOR_NOTIFICATION,
+    RESERVATION_SUCCESS_HEADER,
     STAFF_NOTIFICATION,
-    SUCCESS_HEADER,
+    SESSION_SUCCESS_HEADER,
     CancelOfficeHourSessionView,
-    MentorProgramOfficeHour,
 )
 
 
 class TestCancelOfficeHourSession(APITestCase):
     fail_header = FAIL_HEADER
-    success_header = SUCCESS_HEADER
     url = reverse(CancelOfficeHourSessionView.view_name)
 
     def test_mentor_can_cancel_their_own_unreserved_office_hour(self):
@@ -45,6 +44,7 @@ class TestCancelOfficeHourSession(APITestCase):
         self.assert_office_hour_session_was_cancelled(office_hour)
 
     def test_mentor_cancel_their_own_unreserved_session_ui_notification(self):
+        self.success_header = SESSION_SUCCESS_HEADER
         mentor = self._expert_user(UserRole.MENTOR)
         office_hour = MentorProgramOfficeHourFactory(
             mentor=mentor, finalist=None)
@@ -105,6 +105,7 @@ class TestCancelOfficeHourSession(APITestCase):
         self.assert_notified(mentor)
 
     def test_staff_cancel_office_hour_session_ui_notification(self):
+        self.success_header = RESERVATION_SUCCESS_HEADER
         office_hour = MentorProgramOfficeHourFactory()
         response = self._cancel_office_hour_session(office_hour.id,
                                                     self.staff_user())
@@ -123,6 +124,7 @@ class TestCancelOfficeHourSession(APITestCase):
         self.assert_office_hour_session_was_cancelled(office_hour)
 
     def test_mentor_cancel_own_reserved_office_hour_ui_notification(self):
+        self.success_header = RESERVATION_SUCCESS_HEADER
         mentor = self._expert_user(UserRole.MENTOR)
         office_hour = MentorProgramOfficeHourFactory(mentor=mentor)
         response = self._cancel_office_hour_session(office_hour.id, mentor)

--- a/web/impact/impact/v1/views/cancel_office_hour_session_view.py
+++ b/web/impact/impact/v1/views/cancel_office_hour_session_view.py
@@ -7,9 +7,9 @@ from django.template import loader
 from rest_framework.response import Response
 
 from accelerator.models import MentorProgramOfficeHour
-from impact.minimal_email_handler import MinimalEmailHandler
-from impact.permissions.v1_api_permissions import OfficeHourMentorPermission
-from impact.v1.views.impact_view import ImpactView
+from ...minimal_email_handler import MinimalEmailHandler
+from ...permissions.v1_api_permissions import OfficeHourMentorPermission
+from ...v1.views.impact_view import ImpactView
 
 User = get_user_model()
 
@@ -21,7 +21,8 @@ STAFF_NOTIFICATION = ('on behalf of {mentor_name} at {start_time} '
 MENTOR_NOTIFICATION = 'at {start_time} - {end_time} on {date}'
 OFFICE_HOUR_SESSION_404 = ("The office hour session you are trying to cancel "
                            "doesn't exist")
-SUCCESS_HEADER = 'Canceled office hour session'
+SESSION_SUCCESS_HEADER = 'Canceled office hour session'
+RESERVATION_SUCCESS_HEADER = 'Canceled office hour reservation'
 FAIL_HEADER = 'Office hour session could not be canceled'
 
 
@@ -55,14 +56,6 @@ def get_ui_notification(context, staff=False):
     return MENTOR_NOTIFICATION.format(**context)
 
 
-def get_response(success, detail):
-    return Response({
-        'success': success,
-        'header': SUCCESS_HEADER if success else FAIL_HEADER,
-        'detail': detail
-    })
-
-
 def get_cancelled_by(mentor_name=None, staff=False):
     to_finalist, to_mentor = mentor_name, 'You have'
     if staff:
@@ -79,6 +72,7 @@ class CancelOfficeHourSessionView(ImpactView):
 
     def cancel_office_hour_session(self, office_hour, user, message):
         shared_context = get_office_hour_shared_context(office_hour, message)
+        self._set_header(office_hour)
         if user == office_hour.mentor:
             cancelled_by = get_cancelled_by(shared_context['mentor_name'])
             self.handle_notification(office_hour, shared_context, cancelled_by)
@@ -98,11 +92,11 @@ class CancelOfficeHourSessionView(ImpactView):
         try:
             office_hour = MentorProgramOfficeHour.objects.get(pk=id)
         except MentorProgramOfficeHour.DoesNotExist:
-            return get_response(False, OFFICE_HOUR_SESSION_404)
+            return self.get_response(False, OFFICE_HOUR_SESSION_404)
         self.check_object_permissions(request, office_hour)
         response_detail, success = self.cancel_office_hour_session(
             office_hour, request.user, message)
-        return get_response(success, response_detail)
+        return self.get_response(success, response_detail)
 
     def get_addressee_info(self, office_hour, mentor_name):
         addressee_dict = {
@@ -143,3 +137,14 @@ class CancelOfficeHourSessionView(ImpactView):
             from_email=settings.NO_REPLY_EMAIL,
             attach_alternative=[html_email, 'text/html'],
         ).send()
+
+    def _set_header(self, office_hour):
+        self.header = (RESERVATION_SUCCESS_HEADER
+                       if office_hour.finalist else SESSION_SUCCESS_HEADER)
+
+    def get_response(self, success, detail):
+        return Response({
+            'success': success,
+            'header': self.header if success else FAIL_HEADER,
+            'detail': detail
+        })

--- a/web/impact/impact/v1/views/office_hours_calendar_view.py
+++ b/web/impact/impact/v1/views/office_hours_calendar_view.py
@@ -254,6 +254,8 @@ class OfficeHoursCalendarView(ImpactView):
             mentor_last_name=F("mentor__last_name"),
             mentor_primary_industry=F(primary_industry_key),
             startup_name=F("startup__organization__name"),
+            finalist_email=F("finalist__email"),
+            mentor_email=F("mentor__email"),
         )
         self.response_elements['location_choices'] = self.location_choices()
         self.response_elements['timezones'] = office_hours.filter(


### PR DESCRIPTION
## [AC-7836](https://masschallenge.atlassian.net/browse/AC-7836)

**Changes Introduced**
- add finalist/mentor email to response data

**Testing**
- As an office hour holder or finalist, go to http://localhost:8181/newofficehour or https://test4.masschallenge.org/newofficehours
- Confirm that the cancellation workflow works as expected
- Confirm this PR meets the definition of done according to [AC-7557](https://masschallenge.atlassian.net/browse/AC-7557)

[Sibling PR](https://github.com/masschallenge/accelerate/pull/2674)