### PR TITLE
[AC-7965] Fix display of time in Office Hour reservation emails

### DIFF
--- a/web/impact/impact/v1/views/utils.py
+++ b/web/impact/impact/v1/views/utils.py
@@ -9,7 +9,7 @@ from accelerator.models import (
 )
 
 HOUR_MINUTE_FORMAT = "%I:%M %p"
-MONTH_DAY_FORMAT = "%m:%d"
+MONTH_DAY_FORMAT = "%B %d"
 DEFAULT_TIMEZONE = "UTC"
 
 

--- a/web/impact/impact/v1/views/utils.py
+++ b/web/impact/impact/v1/views/utils.py
@@ -8,7 +8,7 @@ from accelerator.models import (
     UserRole,
 )
 
-HOUR_MINUTE_FORMAT = "%I:%M"
+HOUR_MINUTE_FORMAT = "%I:%M %p"
 MONTH_DAY_FORMAT = "%m:%d"
 DEFAULT_TIMEZONE = "UTC"
 


### PR DESCRIPTION
https://masschallenge.atlassian.net/browse/AC-7965

To verify locally:
Create an office hour, ideally with a Location not in your local timezone
Use the reserve_office_hour endpoint localhost:8000/api/v1/reserve_office_hour  to reserve that office hour
Check the output in your terminal: should see two emails displayed, both of them having the correct start time for the office hour, displayed in the timezone set on that office hour. 
