### PR TITLE
[AC-7971] improvements to Create/Edit Office Hours email notification

### DIFF
--- a/web/impact/impact/tests/test_cancel_office_hour_reservation.py
+++ b/web/impact/impact/tests/test_cancel_office_hour_reservation.py
@@ -1,3 +1,4 @@
+from django.core import mail
 from django.urls import reverse
 
 from accelerator.tests.factories import (
@@ -10,11 +11,11 @@ from ..v1.views import (
     NO_SUCH_RESERVATION,
     NO_SUCH_OFFICE_HOUR,
 )
-
 from ..v1.views.cancel_office_hour_reservation_view import (
     FAIL_HEADER,
     SUCCESS_HEADER,
 )
+from ..v1.views.utils import localized_office_hour_start_time
 
 
 class TestCancelOfficeHourReservationView(APITestCase):
@@ -126,6 +127,13 @@ class TestCancelOfficeHourReservationView(APITestCase):
         office_hour = MentorProgramOfficeHourFactory(finalist=None)
         self._submit_cancellation(office_hour, user=self.make_user())
         self.assert_not_notified(office_hour.mentor)
+
+    def test_correct_date_format_in_notification_email(self):
+        office_hour = MentorProgramOfficeHourFactory()
+        self._submit_cancellation(office_hour, user=office_hour.finalist)
+        email = mail.outbox[0]
+        localized_time = localized_office_hour_start_time(office_hour)
+        self.assertIn(localized_time.strftime("%I:%M"), email.body)
 
     def _submit_cancellation(self, office_hour, user, message=""):
         if office_hour is None:

--- a/web/impact/impact/tests/test_reserve_office_hour_view.py
+++ b/web/impact/impact/tests/test_reserve_office_hour_view.py
@@ -65,8 +65,8 @@ class TestReserveOfficeHourView(APITestCase):
             finalist=None,
             start_date_time=shared_midpoint,
             end_date_time=end_time)
-        response = self.post_response(new_office_hour.id,
-                                      request_user=finalist)
+        self.post_response(new_office_hour.id,
+                           request_user=finalist)
         self.assert_reserved_by(new_office_hour, finalist)
 
     def test_finalist_reserves_office_hour_with_conflict_reserve_fails(self):
@@ -166,20 +166,17 @@ class TestReserveOfficeHourView(APITestCase):
                            request_user=finalist)
         self.assert_notified(finalist)
 
-
     def test_correct_date_format_in_confirmation_email(self):
-        with self.settings(USE_L10N=False):
         # a finalist reserves and office hour, gets a confirmation email
-            office_hour = MentorProgramOfficeHourFactory(finalist=None)
-            finalist = _finalist()
-            self.post_response(office_hour.id,
-                               request_user=finalist)
-            email = mail.outbox[0]
-            localized_time = localized_office_hour_start_time(office_hour)
-            self.assertIn(localized_time.strftime("%I:%M"), email.body)
 
-        
- 
+        office_hour = MentorProgramOfficeHourFactory(finalist=None)
+        finalist = _finalist()
+        self.post_response(office_hour.id,
+                           request_user=finalist)
+        email = mail.outbox[0]
+        localized_time = localized_office_hour_start_time(office_hour)
+        self.assertIn(localized_time.strftime("%I:%M"), email.body)
+
     def test_previously_reserved_office_hour_gets_failure(self):
         # a finalist reserves a reserved office hour, gets failure response
         office_hour = MentorProgramOfficeHourFactory()

--- a/web/impact/impact/tests/test_reserve_office_hour_view.py
+++ b/web/impact/impact/tests/test_reserve_office_hour_view.py
@@ -1,7 +1,9 @@
+from django.core import mail
 from django.urls import reverse
 
 from .api_test_case import APITestCase
 from ..v1.views import ReserveOfficeHourView
+from ..v1.views.utils import localized_office_hour_start_time
 from ..permissions.v1_api_permissions import DEFAULT_PERMISSION_DENIED_DETAIL
 from .factories import UserFactory
 from .utils import (
@@ -52,7 +54,7 @@ class TestReserveOfficeHourView(APITestCase):
         start_time = minutes_from_now(30)
         shared_midpoint = minutes_from_now(60)
         end_time = minutes_from_now(90)
-        
+
         finalist = _finalist()
         MentorProgramOfficeHourFactory(
             finalist=finalist,
@@ -66,7 +68,7 @@ class TestReserveOfficeHourView(APITestCase):
         response = self.post_response(new_office_hour.id,
                                       request_user=finalist)
         self.assert_reserved_by(new_office_hour, finalist)
-        
+
     def test_finalist_reserves_office_hour_with_conflict_reserve_fails(self):
         start_time = minutes_from_now(60)
         end_time = minutes_from_now(90)
@@ -164,6 +166,20 @@ class TestReserveOfficeHourView(APITestCase):
                            request_user=finalist)
         self.assert_notified(finalist)
 
+
+    def test_correct_date_format_in_confirmation_email(self):
+        with self.settings(USE_L10N=False):
+        # a finalist reserves and office hour, gets a confirmation email
+            office_hour = MentorProgramOfficeHourFactory(finalist=None)
+            finalist = _finalist()
+            self.post_response(office_hour.id,
+                               request_user=finalist)
+            email = mail.outbox[0]
+            localized_time = localized_office_hour_start_time(office_hour)
+            self.assertIn(localized_time.strftime("%I:%M"), email.body)
+
+        
+ 
     def test_previously_reserved_office_hour_gets_failure(self):
         # a finalist reserves a reserved office hour, gets failure response
         office_hour = MentorProgramOfficeHourFactory()

--- a/web/impact/impact/v1/views/cancel_office_hour_reservation_view.py
+++ b/web/impact/impact/v1/views/cancel_office_hour_reservation_view.py
@@ -9,7 +9,10 @@ from impact.v1.views.impact_view import ImpactView
 from impact.permissions.v1_api_permissions import (
     OfficeHourFinalistPermission,
 )
-from .utils import email_template_path
+from .utils import (
+    email_template_path,
+    office_hour_time_info,
+)
 from ...minimal_email_handler import send_email
 from accelerator.models import MentorProgramOfficeHour
 from accelerator_abstract.models.base_user_utils import is_employee
@@ -84,12 +87,15 @@ class CancelOfficeHourReservationView(ImpactView):
         template_path = email_template_path(template_name)
         office_hour_date_time = _localize_start_time(self.office_hour)
         cancelling_party = self._cancelling_party_name()
+        start_time, date, _ = office_hour_time_info(
+            self.office_hour)
         template_context = {"recipient": recipient,
                             "counterpart": counterpart,
                             "office_hour_date_time": office_hour_date_time,
                             "cancelling_party": cancelling_party,
-                            "custom_message": self.message}
-
+                            "custom_message": self.message,
+                            "start_time": start_time,
+                            "date": date}
         subject = SUBJECT_LINE.format(counterpart.first_name,
                                       counterpart.last_name)
         body = loader.render_to_string(template_path, template_context)

--- a/web/impact/impact/v1/views/cancel_office_hour_reservation_view.py
+++ b/web/impact/impact/v1/views/cancel_office_hour_reservation_view.py
@@ -1,5 +1,3 @@
-from pytz import timezone
-
 from django.contrib.auth import get_user_model
 from django.template import loader
 
@@ -26,7 +24,7 @@ SUBJECT_LINE = "MassChallenge | Cancelled Office Hours with {} {}"
 NO_SUCH_RESERVATION = "That session is not reserved."
 NO_SUCH_OFFICE_HOUR = "The specified office hour was not found."
 SUCCESS_NOTIFICATION = ("Canceled reservation for {finalist_name} with "
-                        "{mentor_name} on {date}")
+                        "{mentor_name} on {date} at {time}")
 SUCCESS_HEADER = 'Canceled office hour reservation'
 FAIL_HEADER = 'Office hour reservation could not be canceled'
 
@@ -85,7 +83,6 @@ class CancelOfficeHourReservationView(ImpactView):
                                    counterpart,
                                    template_name):
         template_path = email_template_path(template_name)
-        office_hour_date_time = _localize_start_time(self.office_hour)
         cancelling_party = self._cancelling_party_name()
         template_context = office_hour_time_info(self.office_hour)
         template_context.update({"recipient": recipient,
@@ -106,15 +103,11 @@ class CancelOfficeHourReservationView(ImpactView):
             return self.user.full_name()
 
 
-def _localize_start_time(office_hour):
-    tz = timezone(office_hour.location.timezone)
-    return office_hour.start_date_time.astimezone(tz)
-
-
 def formatted_success_notification(office_hour):
     finalist_name = office_hour.finalist.full_name()
     mentor_name = office_hour.mentor.full_name()
-    date = _localize_start_time(office_hour).strftime("%b %d at %I:%M %p")
+    time_info = office_hour_time_info(office_hour)
     return SUCCESS_NOTIFICATION.format(finalist_name=finalist_name,
                                        mentor_name=mentor_name,
-                                       date=date)
+                                       date=time_info['date'],
+                                       time=time_info['start_time'])

--- a/web/impact/impact/v1/views/cancel_office_hour_reservation_view.py
+++ b/web/impact/impact/v1/views/cancel_office_hour_reservation_view.py
@@ -87,15 +87,11 @@ class CancelOfficeHourReservationView(ImpactView):
         template_path = email_template_path(template_name)
         office_hour_date_time = _localize_start_time(self.office_hour)
         cancelling_party = self._cancelling_party_name()
-        start_time, date, _ = office_hour_time_info(
-            self.office_hour)
-        template_context = {"recipient": recipient,
-                            "counterpart": counterpart,
-                            "office_hour_date_time": office_hour_date_time,
-                            "cancelling_party": cancelling_party,
-                            "custom_message": self.message,
-                            "start_time": start_time,
-                            "date": date}
+        template_context = office_hour_time_info(self.office_hour)
+        template_context.update({"recipient": recipient,
+                                 "counterpart": counterpart,
+                                 "cancelling_party": cancelling_party,
+                                 "custom_message": self.message})
         subject = SUBJECT_LINE.format(counterpart.first_name,
                                       counterpart.last_name)
         body = loader.render_to_string(template_path, template_context)

--- a/web/impact/impact/v1/views/office_hour_view.py
+++ b/web/impact/impact/v1/views/office_hour_view.py
@@ -1,8 +1,6 @@
 from datetime import timedelta
 from dateutil.parser import isoparse
 from django.conf import settings
-from itertools import chain
-from pytz import timezone
 from rest_framework import viewsets
 from rest_framework.response import Response
 

--- a/web/impact/impact/v1/views/office_hour_view.py
+++ b/web/impact/impact/v1/views/office_hour_view.py
@@ -30,14 +30,12 @@ CREATE_BODY = (
     "A notification email will be sent to you when a finalist "
     "reserves any of your office hours.\n\n"
     "You can also visit "
-    "<a href='https://accelerate.masschallenge.org/officehours'>"
-    "accelerate.masschallenge.org/officehours</a> at any time to view"
+    "accelerate.masschallenge.org/newofficehours at any time to view"
     " and manage your office hours\n\n"
     "Thank you for volunteering your time to meet with MassChallenge "
     "Finalists! If you have questions, reach out to your community "
     "manager or contact us at any time via "
-    "<a href='https://masschallenge.org/contact'>"
-    "https://masschallenge.org/contact</a>\n\n"
+    "https://masschallenge.org/contact\n\n"
     "- The MassChallenge Team\n"
 )
 EDIT_BODY = (
@@ -49,14 +47,12 @@ EDIT_BODY = (
     "A notification email will be sent to you when a finalist "
     "reserves any of your office hours.\n\n"
     "You can also visit "
-    "<a href='https://accelerate.masschallenge.org/officehours'>"
-    "accelerate.masschallenge.org/officehours</a> at any time to view"
+    "accelerate.masschallenge.org/newofficehours at any time to view"
     " and manage your office hours\n\n"
     "Thank you for volunteering your time to meet with MassChallenge "
     "Finalists! If you have questions, reach out to your community "
     "manager or contact us at any time via "
-    "<a href='https://masschallenge.org/contact'>"
-    "https://masschallenge.org/contact</a>\n\n"
+    "https://masschallenge.org/contact\n\n"
     "- The MassChallenge Team\n"
 )
 

--- a/web/impact/impact/v1/views/reserve_office_hour_view.py
+++ b/web/impact/impact/v1/views/reserve_office_hour_view.py
@@ -18,15 +18,11 @@ from .impact_view import ImpactView
 from .utils import (
     email_template_path,
     is_office_hour_reserver,
-    localized_office_hour_start_time,
+    office_hour_time_info,
 )
 from ...minimal_email_handler import send_email
 User = get_user_model()
 
-
-HOUR_MINUTE_FORMAT = "%I:%M"
-MONTH_DAY_FORMAT = "%m:%d"
-DEFAULT_TIMEZONE = "UTC"
 
 mentor_template_name = "reserve_office_hour_email_to_mentor.html"
 finalist_template_name = "reserve_office_hour_email_to_finalist.html"
@@ -177,7 +173,8 @@ class ReserveOfficeHourView(ImpactView):
         else:
             startup_name = ""
 
-        start_time, date, timezone = self.oh_time_info()
+        start_time, date, timezone = office_hour_time_info(
+            self.office_hour)
         context = {"recipient": recipient,
                    "counterpart": counterpart,
                    "start_time": start_time,
@@ -189,13 +186,6 @@ class ReserveOfficeHourView(ImpactView):
         return {"to": [recipient.email],
                 "subject": self.SUBJECT,
                 "body": body}
-
-    def oh_time_info(self):
-        start_time = localized_office_hour_start_time(self.office_hour)
-
-        return (start_time.strftime(HOUR_MINUTE_FORMAT),
-                start_time.strftime(MONTH_DAY_FORMAT),
-                get_timezone(self.office_hour))
 
     def _succeed(self):
         if self.office_hour.startup:
@@ -223,9 +213,3 @@ class ReserveOfficeHourView(ImpactView):
             'header': self.header,
             'detail': self.detail,
             'timecard_info': self.timecard_info})
-
-
-def get_timezone(office_hour):
-    if office_hour.location and office_hour.location.timezone:
-        return office_hour.location.timezone
-    return DEFAULT_TIMEZONE

--- a/web/impact/impact/v1/views/reserve_office_hour_view.py
+++ b/web/impact/impact/v1/views/reserve_office_hour_view.py
@@ -173,15 +173,11 @@ class ReserveOfficeHourView(ImpactView):
         else:
             startup_name = ""
 
-        start_time, date, timezone = office_hour_time_info(
-            self.office_hour)
         context = {"recipient": recipient,
                    "counterpart": counterpart,
-                   "start_time": start_time,
-                   "date": date,
-                   "timezone": timezone,
                    "startup": startup_name,
                    "message": self.message}
+        context.update(office_hour_time_info(self.office_hour))
         body = loader.render_to_string(template_path, context)
         return {"to": [recipient.email],
                 "subject": self.SUBJECT,

--- a/web/impact/impact/v1/views/reserve_office_hour_view.py
+++ b/web/impact/impact/v1/views/reserve_office_hour_view.py
@@ -24,7 +24,6 @@ from ...minimal_email_handler import send_email
 User = get_user_model()
 
 
-
 HOUR_MINUTE_FORMAT = "%I:%M"
 MONTH_DAY_FORMAT = "%m:%d"
 DEFAULT_TIMEZONE = "UTC"
@@ -143,10 +142,10 @@ class ReserveOfficeHourView(ImpactView):
         start_conflict = (Q(start_date_time__gt=start) &
                           Q(start_date_time__lt=end))
         end_conflict = (Q(end_date_time__gt=start) &
-                        Q(end_date_time__lt=end))        
+                        Q(end_date_time__lt=end))
         enclosing_conflict = (Q(start_date_time__lte=start) &
                               Q(end_date_time__gte=end))
-        
+
         if self.target_user.finalist_officehours.filter(
                 start_conflict | end_conflict | enclosing_conflict).exists():
             return True
@@ -197,7 +196,7 @@ class ReserveOfficeHourView(ImpactView):
         return (start_time.strftime(HOUR_MINUTE_FORMAT),
                 start_time.strftime(MONTH_DAY_FORMAT),
                 get_timezone(self.office_hour))
-    
+
     def _succeed(self):
         if self.office_hour.startup:
             startup_name = self.office_hour.startup.organization.name
@@ -225,7 +224,8 @@ class ReserveOfficeHourView(ImpactView):
             'detail': self.detail,
             'timecard_info': self.timecard_info})
 
+
 def get_timezone(office_hour):
-    if  office_hour.location and office_hour.location.timezone:
+    if office_hour.location and office_hour.location.timezone:
         return office_hour.location.timezone
     return DEFAULT_TIMEZONE

--- a/web/impact/impact/v1/views/utils.py
+++ b/web/impact/impact/v1/views/utils.py
@@ -50,6 +50,13 @@ def localized_office_hour_start_time(office_hour):
     return office_hour.start_date_time.astimezone(tz)
 
 
+# Note: this function should be replaced with calls to
+# office_hour.local_end once the re-monolith is complete
+def localized_office_hour_end_time(office_hour):
+    tz = timezone(office_hour.location.timezone)
+    return office_hour.end_date_time.astimezone(tz)
+
+
 def is_office_hour_reserver(user):
     """Returns True iff user has an office-hour reserver user role
     with respect to an active program
@@ -63,10 +70,11 @@ def is_office_hour_reserver(user):
 
 def office_hour_time_info(office_hour):
     start_time = localized_office_hour_start_time(office_hour)
-
-    return (start_time.strftime(HOUR_MINUTE_FORMAT),
-            start_time.strftime(MONTH_DAY_FORMAT),
-            get_timezone(office_hour))
+    end_time = localized_office_hour_end_time(office_hour)
+    return {"start_time": start_time.strftime(HOUR_MINUTE_FORMAT),
+            "end_time": end_time.strftime(HOUR_MINUTE_FORMAT),            
+            "date": start_time.strftime(MONTH_DAY_FORMAT),
+            "timezone": get_timezone(office_hour)}
 
 
 def get_timezone(office_hour):

--- a/web/impact/impact/v1/views/utils.py
+++ b/web/impact/impact/v1/views/utils.py
@@ -54,3 +54,4 @@ def is_office_hour_reserver(user):
     return user.programrolegrant_set.filter(
         program_role__user_role__name__in=reserver_roles,
         program_role__program__program_status=ACTIVE_PROGRAM_STATUS).exists()
+

--- a/web/impact/impact/v1/views/utils.py
+++ b/web/impact/impact/v1/views/utils.py
@@ -8,6 +8,11 @@ from accelerator.models import (
     UserRole,
 )
 
+HOUR_MINUTE_FORMAT = "%I:%M"
+MONTH_DAY_FORMAT = "%m:%d"
+DEFAULT_TIMEZONE = "UTC"
+
+
 VALID_KEYS_NOTE = "Valid keys are: {}"
 
 
@@ -54,3 +59,17 @@ def is_office_hour_reserver(user):
     return user.programrolegrant_set.filter(
         program_role__user_role__name__in=reserver_roles,
         program_role__program__program_status=ACTIVE_PROGRAM_STATUS).exists()
+
+
+def office_hour_time_info(office_hour):
+    start_time = localized_office_hour_start_time(office_hour)
+
+    return (start_time.strftime(HOUR_MINUTE_FORMAT),
+            start_time.strftime(MONTH_DAY_FORMAT),
+            get_timezone(office_hour))
+
+
+def get_timezone(office_hour):
+    if office_hour.location and office_hour.location.timezone:
+        return office_hour.location.timezone
+    return DEFAULT_TIMEZONE

--- a/web/impact/impact/v1/views/utils.py
+++ b/web/impact/impact/v1/views/utils.py
@@ -72,7 +72,7 @@ def office_hour_time_info(office_hour):
     start_time = localized_office_hour_start_time(office_hour)
     end_time = localized_office_hour_end_time(office_hour)
     return {"start_time": start_time.strftime(HOUR_MINUTE_FORMAT),
-            "end_time": end_time.strftime(HOUR_MINUTE_FORMAT),            
+            "end_time": end_time.strftime(HOUR_MINUTE_FORMAT),
             "date": start_time.strftime(MONTH_DAY_FORMAT),
             "timezone": get_timezone(office_hour)}
 

--- a/web/impact/impact/v1/views/utils.py
+++ b/web/impact/impact/v1/views/utils.py
@@ -54,4 +54,3 @@ def is_office_hour_reserver(user):
     return user.programrolegrant_set.filter(
         program_role__user_role__name__in=reserver_roles,
         program_role__program__program_status=ACTIVE_PROGRAM_STATUS).exists()
-

--- a/web/impact/templates/emails/cancel_office_hour_reservation_email_to_finalist.html
+++ b/web/impact/templates/emails/cancel_office_hour_reservation_email_to_finalist.html
@@ -1,8 +1,7 @@
 Hi {{ recipient.first_name }},
 
-Your upcoming office hour session at {{ office_hour_date_time | date:"h:m" }} on
-{{ office_hour_date_time | date }} with {{ counterpart.full_name }} was cancelled by
-{{ cancelling_party }}.
+Your upcoming office hour session at {{ start_time }} on {{ date }} with
+{{ counterpart.full_name }} was cancelled by {{ cancelling_party }}.
 To schedule a new time with this or any available mentor, visit
 https://accelerate.masschallenge.org/newofficehours
 

--- a/web/impact/templates/emails/cancel_office_hour_reservation_email_to_mentor.html
+++ b/web/impact/templates/emails/cancel_office_hour_reservation_email_to_mentor.html
@@ -1,9 +1,8 @@
 Hi {{ recipient.first_name }},
 
-Your upcoming office hour session at {{ office_hour_date_time|date:"h:m" }} on
-{{ office_hour_date_time | date }} with {{ counterpart.full_name }} was cancelled
-by {{ cancelling_party }}. This office hour session is now available for another
-startup to reserve.
+Your upcoming office hour session at {{ start_time }} on {{ date }} with
+{{ counterpart.full_name }} was cancelled by {{ cancelling_party }}.
+This office hour session is now available for another startup to reserve.
 You may make changes to your upcoming office hours here:
 https://accelerate.masschallenge.org/newofficehours
 

--- a/web/impact/templates/emails/reserve_office_hour_email_to_finalist.html
+++ b/web/impact/templates/emails/reserve_office_hour_email_to_finalist.html
@@ -1,8 +1,7 @@
 Hi {{ recipient.first_name }},
 
-You have an office hour session at {{ office_hour_date_time | date:"h:i" }} on
-{{ office_hour_date_time | date }} ({{ office_hour_date_time | date:"e" }})
-with {{ counterpart.full_name }} 
+You have an office hour session at {{ start_time }} on
+{{ date }} ({{ timezone }}) with {{ counterpart.full_name }} 
 
 
 {% if message %}

--- a/web/impact/templates/emails/reserve_office_hour_email_to_finalist.html
+++ b/web/impact/templates/emails/reserve_office_hour_email_to_finalist.html
@@ -1,6 +1,6 @@
 Hi {{ recipient.first_name }},
 
-You have an office hour session at {{ office_hour_date_time | date:"h:m" }} on
+You have an office hour session at {{ office_hour_date_time | date:"h:i" }} on
 {{ office_hour_date_time | date }} ({{ office_hour_date_time | date:"e" }})
 with {{ counterpart.full_name }} 
 

--- a/web/impact/templates/emails/reserve_office_hour_email_to_mentor.html
+++ b/web/impact/templates/emails/reserve_office_hour_email_to_mentor.html
@@ -1,7 +1,6 @@
 Hi {{ recipient.first_name }},
 
-Your office hour session at {{ office_hour_date_time | date:"h:i" }} on
-{{ office_hour_date_time | date }} ({{ office_hour_date_time | date:"e" }})
+Your office hour session at {{ start_time }} on {{ date }} ({{ timezone }})
 is reserved for {{ counterpart.full_name }} 
 {% if startup %} of {{ startup }} {% endif %}
 

--- a/web/impact/templates/emails/reserve_office_hour_email_to_mentor.html
+++ b/web/impact/templates/emails/reserve_office_hour_email_to_mentor.html
@@ -1,6 +1,6 @@
 Hi {{ recipient.first_name }},
 
-Your office hour session at {{ office_hour_date_time | date:"h:m" }} on
+Your office hour session at {{ office_hour_date_time | date:"h:i" }} on
 {{ office_hour_date_time | date }} ({{ office_hour_date_time | date:"e" }})
 is reserved for {{ counterpart.full_name }} 
 {% if startup %} of {{ startup }} {% endif %}


### PR DESCRIPTION
https://masschallenge.atlassian.net/browse/AC-7971

Verify that the following have been done:
- Remove the <a> tags around the contact url 
- update urls to point to newofficehours rather than officehours
- Display the timezone:
  - Time: 04:30AM-05:00AM (America/New_York) / Location: MassChallenge Boston

Note: some refactoring came along with this work. 