### PR TITLE
[AC-7975] P0: Finalist topics saved on incorrect field

### DIFF
--- a/web/impact/impact/tests/test_reserve_office_hour_view.py
+++ b/web/impact/impact/tests/test_reserve_office_hour_view.py
@@ -238,7 +238,7 @@ class TestReserveOfficeHourView(APITestCase):
             startup_name = ""
         oh_details = {'finalist_first_name': office_hour.finalist.first_name,
                       'finalist_last_name': office_hour.finalist.last_name,
-                      'topics': office_hour.description,
+                      'topics': office_hour.topics,
                       'startup': startup_name}
         self.assertDictEqual(timecard, oh_details)
 

--- a/web/impact/impact/v1/views/reserve_office_hour_view.py
+++ b/web/impact/impact/v1/views/reserve_office_hour_view.py
@@ -149,7 +149,7 @@ class ReserveOfficeHourView(ImpactView):
 
     def _update_office_hour_data(self):
         self.office_hour.finalist = self.target_user
-        self.office_hour.description = self.message
+        self.office_hour.topics = self.message
         self.office_hour.startup = self.startup
         self.office_hour.save()
 


### PR DESCRIPTION
## [AC-7975](https://masschallenge.atlassian.net/browse/AC-7975)

**Changes introduced**
- Save message to an expert on the topics field

**Testing**
- As a finalist, reserve an office hour session with a message to expert
- Validate the message is saved on the office hour's topics field

[Sibling PR](https://github.com/masschallenge/accelerate/pull/2686)