### PR TITLE
[AC-7986] P1 - Handle timezones when no locations is associated to an office hour

### DIFF
--- a/web/impact/impact/tests/test_cancel_office_hour_session_view.py
+++ b/web/impact/impact/tests/test_cancel_office_hour_session_view.py
@@ -21,7 +21,7 @@ from ..v1.views.cancel_office_hour_session_view import (
     SESSION_SUCCESS_HEADER,
     CancelOfficeHourSessionView,
 )
-
+from ..v1.views.utils import get_timezone
 
 class TestCancelOfficeHourSession(APITestCase):
     fail_header = FAIL_HEADER
@@ -170,7 +170,7 @@ class TestCancelOfficeHourSession(APITestCase):
             response, True, STAFF_NOTIFICATION.format(**context))
 
     def _get_office_hour_context(self, office_hour):
-        tz = timezone(office_hour.location.timezone or DEFAULT_TIMEZONE)
+        tz = timezone(get_timezone(office_hour))
         start_date_time = office_hour.start_date_time
         date = start_date_time.astimezone(tz).strftime('%A, %d %B, %Y')
         start_time = start_date_time.astimezone(tz).strftime('%I:%M%p')

--- a/web/impact/impact/v1/views/cancel_office_hour_session_view.py
+++ b/web/impact/impact/v1/views/cancel_office_hour_session_view.py
@@ -32,7 +32,7 @@ def get_office_hours_url():
 
 
 def get_office_hour_shared_context(office_hour, message=None):
-    tz = timezone(office_hour.location.timezone or DEFAULT_TIMEZONE)
+    tz = timezone(get_timezone(office_hour))
     date = office_hour.start_date_time.astimezone(tz).strftime('%A, %d %B, %Y')
     start_time = office_hour.start_date_time.astimezone(tz).strftime('%I:%M%p')
     end_time = office_hour.end_date_time.astimezone(tz).strftime('%I:%M%p')

--- a/web/impact/impact/v1/views/cancel_office_hour_session_view.py
+++ b/web/impact/impact/v1/views/cancel_office_hour_session_view.py
@@ -10,6 +10,7 @@ from accelerator.models import MentorProgramOfficeHour
 from ...minimal_email_handler import MinimalEmailHandler
 from ...permissions.v1_api_permissions import OfficeHourMentorPermission
 from ...v1.views.impact_view import ImpactView
+from ...v1.views.utils import get_timezone
 
 User = get_user_model()
 

--- a/web/impact/impact/v1/views/utils.py
+++ b/web/impact/impact/v1/views/utils.py
@@ -46,14 +46,14 @@ def email_template_path(template_name):
 # Note: this function should be replaced with calls to
 # office_hour.local_start once the re-monolith is complete
 def localized_office_hour_start_time(office_hour):
-    tz = timezone(office_hour.location.timezone)
+    tz = timezone(get_timezone(office_hour))
     return office_hour.start_date_time.astimezone(tz)
 
 
 # Note: this function should be replaced with calls to
 # office_hour.local_end once the re-monolith is complete
 def localized_office_hour_end_time(office_hour):
-    tz = timezone(office_hour.location.timezone)
+    tz = timezone(get_timezone(office_hour))
     return office_hour.end_date_time.astimezone(tz)
 
 


### PR DESCRIPTION
### Changes Introduced in [AC-7986](https://masschallenge.atlassian.net/browse/AC-7986):
- Handle timezone failure for office hours with no locations
### Testing:
- Ensure that the tests are passing
- Ensure the are no remaining references to `office_hour.location.timezone`