### PR TITLE
[AC-7820]:Directory contact privacy

### DIFF
--- a/web/impact/impact/graphql/auth/utils.py
+++ b/web/impact/impact/graphql/auth/utils.py
@@ -1,4 +1,10 @@
 from django.conf import settings
+from accelerator.models import UserRole
+from accelerator_abstract.models.base_user_utils import is_employee
+
+PUBLIC = 'public'
+STAFF = 'staff'
+FINALISTS_AND_STAFF = 'finalists and staff'
 
 
 def get_jwt_cookie(request):
@@ -6,3 +12,22 @@ def get_jwt_cookie(request):
     if cookie_name:
         return request.COOKIES.get(cookie_name)
     return None
+
+
+def get_user_privacy_type(user):
+    if is_employee(user):
+        return STAFF
+    if user.programrolegrant_set.filter(
+            program_role__user_role__name=UserRole.FINALIST
+    ).exists():
+        return FINALISTS_AND_STAFF
+    return PUBLIC
+
+
+def can_view_private_data(user, type_requirement):
+    user_privacy_type = get_user_privacy_type(user)
+    if user_privacy_type == STAFF:
+        return True
+    if type_requirement == PUBLIC:
+        return True
+    return type_requirement == user_privacy_type

--- a/web/impact/impact/graphql/types/user_type.py
+++ b/web/impact/impact/graphql/types/user_type.py
@@ -1,6 +1,8 @@
+from accelerator.models import ExpertProfile
+from django.contrib.auth import get_user_model
 from graphene_django import DjangoObjectType
 
-from django.contrib.auth import get_user_model
+from ...graphql.auth.utils import can_view_private_data
 
 User = get_user_model()
 
@@ -9,3 +11,11 @@ class UserType(DjangoObjectType):
     class Meta:
         model = User
         only_fields = ('id', 'first_name', 'last_name', 'email')
+
+    def resolve_email(self, info, **kwargs):
+        profile = self.get_profile()
+        email = self.email
+        if type(profile) is ExpertProfile:
+            if not can_view_private_data(info.context.user, profile.privacy_email):
+                email = ""
+        return email

--- a/web/impact/impact/graphql/types/user_type.py
+++ b/web/impact/impact/graphql/types/user_type.py
@@ -15,7 +15,8 @@ class UserType(DjangoObjectType):
     def resolve_email(self, info, **kwargs):
         profile = self.get_profile()
         email = self.email
+        request_user = info.context.user
         if type(profile) is ExpertProfile:
-            if not can_view_private_data(info.context.user, profile.privacy_email):
+            if not can_view_private_data(request_user, profile.privacy_email):
                 email = ""
         return email


### PR DESCRIPTION
## [AC-7820](https://masschallenge.atlassian.net/browse/AC-7820)

**Changes introduced**
- add directory contact privacy

**Testing**
- checkout to `AC-7820` on `front-end` and `impact-api` branch
- On the front-end: `yarn start`
- Visit `http://localhost:1234/directory/people/<user_id>`
- Confirm that:
    - Staff users can view all contact information
    - **public** contact information is visible to all users
    - **finalists and staff** contact information is only visible to staff users and finalists

[Sibling PR](https://github.com/masschallenge/front-end/pull/244)