### PR TITLE
AC-7994 P1 Add to calendar links displayed as plain urls

### DIFF
--- a/web/impact/impact/tests/test_reserve_office_hour_view.py
+++ b/web/impact/impact/tests/test_reserve_office_hour_view.py
@@ -175,7 +175,8 @@ class TestReserveOfficeHourView(APITestCase):
                            request_user=finalist)
         email = mail.outbox[0]
         localized_time = localized_office_hour_start_time(office_hour)
-        self.assertIn(localized_time.strftime("%I:%M"), email.body)
+        self.assertIn(localized_time.strftime(
+            "%I:%M"), email.alternatives[0][0])
 
     def test_previously_reserved_office_hour_gets_failure(self):
         # a finalist reserves a reserved office hour, gets failure response

--- a/web/impact/impact/v1/views/reserve_office_hour_view.py
+++ b/web/impact/impact/v1/views/reserve_office_hour_view.py
@@ -190,13 +190,15 @@ class ReserveOfficeHourView(ImpactView):
                    "calendar_data": calendar_data
                    }
         context.update(office_hour_time_info(self.office_hour))
-        body = loader.render_to_string(template_path, context)
+        html_email = loader.render_to_string(template_path, context)
         return {"to": [recipient.email],
                 "subject": self.SUBJECT,
-                "body": body,
+                "body": None,
                 "attachment": (ICS_FILENAME,
                                calendar_data['ical_content'],
-                               ICS_FILETYPE)}
+                               ICS_FILETYPE),
+                "attach_alternative": (html_email, 'text/html')
+                }
 
     def _succeed(self):
         if self.office_hour.startup:

--- a/web/impact/templates/emails/reserve_office_hour_email_to_finalist.html
+++ b/web/impact/templates/emails/reserve_office_hour_email_to_finalist.html
@@ -1,7 +1,15 @@
-Hi {{ recipient.first_name }},
+{% load static from staticfiles %}
+<html>
+<head>
 
-You have an office hour session at {{ start_time }} on
-{{ date }} ({{ timezone }}) with {{ counterpart.full_name }}
+</head>
+<body>
+<p>Hi {{ recipient.first_name }},</p>
+
+<p>
+  You have an office hour session at {{ start_time }} on
+  {{ date }} ({{ timezone }}) with {{ counterpart.full_name }}
+</p>
 
 <strong>Add a reminder</strong>
 <ul>
@@ -18,13 +26,19 @@ You have an office hour session at {{ start_time }} on
 </ul>
 
 {% if message %}
-{{ message }}
+<p>{{ message }}</p>
 {% endif %}
 
 
-To view and manage your office hour reservations, visit
-https://accelerate.masschallenge.org/newofficehours
+<p>
+  To view and manage your office hour reservations, visit
+  https://accelerate.masschallenge.org/newofficehours
+</p>
 
 
-Thanks,
-The MassChallenge Team
+<p>
+  Thanks,<br/>
+  The MassChallenge Team
+</p>
+</body>
+</html>

--- a/web/impact/templates/emails/reserve_office_hour_email_to_finalist.html
+++ b/web/impact/templates/emails/reserve_office_hour_email_to_finalist.html
@@ -1,13 +1,24 @@
 Hi {{ recipient.first_name }},
 
 You have an office hour session at {{ start_time }} on
-{{ date }} ({{ timezone }}) with {{ counterpart.full_name }} 
+{{ date }} ({{ timezone }}) with {{ counterpart.full_name }}
 
-Google Calendar: {{calendar_data.gcal_link}}
-Yahoo: {{calendar_data.yahoo_link}}
+<strong>Add a reminder</strong>
+<ul>
+  <li>
+    <a target="_blank" class="google" href="{{calendar_data.gcal_link}}">
+      Google Calendar
+    </a>
+  </li>
+  <li>
+    <a target="_blank" class="yahoo" href="{{calendar_data.yahoo_link}}">
+      Yahoo
+    </a>
+  </li>
+</ul>
 
 {% if message %}
-  {{ message }}
+{{ message }}
 {% endif %}
 
 

--- a/web/impact/templates/emails/reserve_office_hour_email_to_mentor.html
+++ b/web/impact/templates/emails/reserve_office_hour_email_to_mentor.html
@@ -1,8 +1,16 @@
-Hi {{ recipient.first_name }},
+{% load static from staticfiles %}
+<html>
+<head>
 
-Your office hour session at {{ start_time }} on {{ date }} ({{ timezone }})
-is reserved for {{ counterpart.full_name }}
-{% if startup %} of {{ startup }} {% endif %}
+</head>
+<body>
+<p>Hi {{ recipient.first_name }},</p>
+
+<p>
+  Your office hour session at {{ start_time }} on {{ date }} ({{ timezone }})
+  is reserved for {{ counterpart.full_name }}
+  {% if startup %} of {{ startup }} {% endif %}
+</p>
 
 <strong>Add a reminder</strong>
 <ul>
@@ -19,13 +27,19 @@ is reserved for {{ counterpart.full_name }}
 </ul>
 
 {% if message %}
-{{ message }}
+<p>{{ message }}</p>
 {% endif %}
 
 
-To view and manage your office hour reservations, visit
-https://accelerate.masschallenge.org/newofficehours
+<p>
+  To view and manage your office hour reservations, visit
+  https://accelerate.masschallenge.org/newofficehours
+</p>
 
 
-Thanks,
-The MassChallenge Team
+<p>
+  Thanks,<br/>
+  The MassChallenge Team
+</p>
+</body>
+</html>

--- a/web/impact/templates/emails/reserve_office_hour_email_to_mentor.html
+++ b/web/impact/templates/emails/reserve_office_hour_email_to_mentor.html
@@ -1,14 +1,25 @@
 Hi {{ recipient.first_name }},
 
 Your office hour session at {{ start_time }} on {{ date }} ({{ timezone }})
-is reserved for {{ counterpart.full_name }} 
+is reserved for {{ counterpart.full_name }}
 {% if startup %} of {{ startup }} {% endif %}
 
-Google Calendar: {{calendar_data.gcal_link}}
-Yahoo: {{calendar_data.yahoo_link}}
+<strong>Add a reminder</strong>
+<ul>
+  <li>
+    <a target="_blank" class="google" href="{{calendar_data.gcal_link}}">
+      Google Calendar
+    </a>
+  </li>
+  <li>
+    <a target="_blank" class="yahoo" href="{{calendar_data.yahoo_link}}">
+      Yahoo
+    </a>
+  </li>
+</ul>
 
 {% if message %}
-  {{ message }}
+{{ message }}
 {% endif %}
 
 


### PR DESCRIPTION
### Changes Introduced in [AC-7994](https://masschallenge.atlassian.net/browse/AC-7994):
- Format to template to html
### Testing:
- Check out this branch
- Masquerade as a mentor and a finalist
- Change their emails to your own before scheduling an office hour.
- Schedule an office hour and reserve it.
- Check the resulting email and notice the calendar links are no longer showing as plain URLs