### PR TITLE
[AC-7914] - P1: Handle null location objects in the frontend

### DIFF
--- a/web/impact/impact/v1/views/office_hours_calendar_view.py
+++ b/web/impact/impact/v1/views/office_hours_calendar_view.py
@@ -215,6 +215,7 @@ class OfficeHoursCalendarView(ImpactView):
                                              "program",
                                              "program_family",
                                              "name"])
+        self.not_null_location = Q(**{self.location_path + '__isnull': False})
         return True
 
     def _get_office_hours_data(self):
@@ -253,7 +254,6 @@ class OfficeHoursCalendarView(ImpactView):
             finalist_email=F("finalist__email"),
             mentor_email=F("mentor__email"),
         )
-        self.response_elements['location_choices'] = self.location_choices()
         self.response_elements['timezones'] = office_hours.filter(
             location__isnull=False).order_by(
                 "location__timezone").values_list("location__timezone",
@@ -276,8 +276,9 @@ class OfficeHoursCalendarView(ImpactView):
             self.program_family, flat=True).distinct()
 
     def location_choices(self):
-        locations = self.user_query.values(
-            **_location_lookups(self.location_path)).distinct()
+        locations = self.user_query.filter(
+            self.not_null_location
+        ).values(**_location_lookups(self.location_path)).distinct()
         locations_list = list(locations)
         has_remote_location = _check_remote_location(locations_list)
 

--- a/web/impact/impact/v1/views/office_hours_calendar_view.py
+++ b/web/impact/impact/v1/views/office_hours_calendar_view.py
@@ -215,7 +215,6 @@ class OfficeHoursCalendarView(ImpactView):
                                              "program",
                                              "program_family",
                                              "name"])
-        self.not_null_location = Q(**{self.location_path + '__isnull': False})
         return True
 
     def _get_office_hours_data(self):
@@ -277,7 +276,7 @@ class OfficeHoursCalendarView(ImpactView):
 
     def location_choices(self):
         locations = self.user_query.filter(
-            self.not_null_location
+            Q(**{self.location_path + '__isnull': False})
         ).values(**_location_lookups(self.location_path)).distinct()
         locations_list = list(locations)
         has_remote_location = _check_remote_location(locations_list)


### PR DESCRIPTION
## [AC-7914](https://masschallenge.atlassian.net/browse/AC-7914)

**Changes Introduced**
- Ignore all null location objects in the location choices input

**Testing**
- login as an office hour holder
- As an admin user, delete some program family locations associated with the office hour holder's program families
    - go to http://localhost:8181/admin/mc/programfamily/{id}/change/ for each program family 
    - on the **PROGRAM FAMILY LOCATIONS** section, select the delete checkbox for each program family location and save
- as the office hour holder,  visit http://localhost:8000/api/v1/office_hours_calendar/
- Confirm that:
    - on this branch: no null location object is included in the `location_choices` list 
    - on development:  null location object is included in the `location_choices` list 


