### PR TITLE
[AC-7898] Add two fields to office_hours_calendar output

### DIFF
--- a/web/impact/impact/tests/test_office_hours_calendar_view.py
+++ b/web/impact/impact/tests/test_office_hours_calendar_view.py
@@ -328,6 +328,29 @@ class TestOfficeHoursCalendarView(APITestCase):
         location_choices = response.data['location_choices']
         self.assertEqual([], location_choices)
 
+    def test_calendar_data_includes_startup_industry(self):
+        startup_team_member = StartupTeamMemberFactory()
+        startup = startup_team_member.startup
+        finalist = startup_team_member.user
+        office_hour = self.create_office_hour(finalist=finalist,
+                                              startup=startup)
+        response = self.get_response(user=office_hour.mentor)
+        self.assertEqual(
+            startup_team_member.startup.primary_industry.name,
+            response.data['calendar_data'][0]['startup_primary_industry'])
+
+    def test_calendar_data_includes_startup_short_pitch(self):
+        startup_team_member = StartupTeamMemberFactory()
+        startup = startup_team_member.startup
+        finalist = startup_team_member.user
+        office_hour = self.create_office_hour(finalist=finalist,
+                                              startup=startup)
+        response = self.get_response(user=office_hour.mentor)
+        self.assertEqual(
+            startup_team_member.startup.short_pitch,
+            response.data['calendar_data'][0]['startup_short_pitch'])
+
+
     def create_office_hour(self,
                            mentor=None,
                            finalist=None,
@@ -335,7 +358,8 @@ class TestOfficeHoursCalendarView(APITestCase):
                            duration_minutes=30,
                            timezone="America/New_York",
                            program=None,
-                           location=None):
+                           location=None,
+                           startup=None):
         create_params = {}
         mentor = mentor or _mentor(program)
         create_params['mentor'] = mentor
@@ -347,6 +371,8 @@ class TestOfficeHoursCalendarView(APITestCase):
         create_params['location__timezone'] = timezone
         create_params['finalist'] = finalist
         create_params['program'] = program
+        if startup:
+            create_params['startup'] = startup
         if not timezone:
             create_params['location'] = location
         return MentorProgramOfficeHourFactory(**create_params)

--- a/web/impact/impact/v1/views/office_hours_calendar_view.py
+++ b/web/impact/impact/v1/views/office_hours_calendar_view.py
@@ -252,6 +252,8 @@ class OfficeHoursCalendarView(ImpactView):
             startup_name=F("startup__organization__name"),
             finalist_email=F("finalist__email"),
             mentor_email=F("mentor__email"),
+            startup_primary_industry=F("startup__primary_industry__name"),
+            startup_short_pitch=F("startup__short_pitch")
         )
         self.response_elements['timezones'] = office_hours.filter(
             location__isnull=False).order_by(

--- a/web/impact/templates/emails/reserve_office_hour_email_to_finalist.html
+++ b/web/impact/templates/emails/reserve_office_hour_email_to_finalist.html
@@ -22,7 +22,7 @@
     <a target="_blank" class="yahoo" href="{{calendar_data.yahoo_link}}">
       Yahoo
     </a>
-  </li>  
+  </li>
 </ul>
 
 {% if message %}

--- a/web/impact/templates/emails/reserve_office_hour_email_to_finalist.html
+++ b/web/impact/templates/emails/reserve_office_hour_email_to_finalist.html
@@ -23,6 +23,12 @@
       Yahoo
     </a>
   </li>
+  <li>
+    <a target="_blank" class="outlook" href="{{calendar_data.outlook_link}}">
+      Outlook
+    </a>
+  </li>
+  
 </ul>
 
 {% if message %}

--- a/web/impact/templates/emails/reserve_office_hour_email_to_finalist.html
+++ b/web/impact/templates/emails/reserve_office_hour_email_to_finalist.html
@@ -22,13 +22,7 @@
     <a target="_blank" class="yahoo" href="{{calendar_data.yahoo_link}}">
       Yahoo
     </a>
-  </li>
-  <li>
-    <a target="_blank" class="outlook" href="{{calendar_data.outlook_link}}">
-      Outlook
-    </a>
-  </li>
-  
+  </li>  
 </ul>
 
 {% if message %}


### PR DESCRIPTION
https://masschallenge.atlassian.net/browse/AC-7898

To test: create an office hour slot for some mentor and reserve it for some finalist, selecting a startup. Check the office_hours_calendar api endpoint for the mentor. startup's short_pitch and primary industry should be included in the output. 