### PR TITLE
[AC-8011]: Filter mentors by office hours availability

### DIFF
--- a/web/impact/impact/tests/test_algolia_api_key_view.py
+++ b/web/impact/impact/tests/test_algolia_api_key_view.py
@@ -126,7 +126,7 @@ class TestAlgoliaApiKeyView(APITestCase):
         user = self._create_user_with_role_grant(program, UserRole.FINALIST)
         response_data = self._get_response_data(
             user, self._mentor_directory_url())
-        self.assertIn(program.name, response_data["finalist_programs"])
+        self.assertIn(program.id, response_data["finalist_programs"])
 
     def test_non_finalists_have_no_finalist_programs(self):
         user = self.staff_user()

--- a/web/impact/impact/views/algolia_api_key_view.py
+++ b/web/impact/impact/views/algolia_api_key_view.py
@@ -63,7 +63,7 @@ class AlgoliaApiKeyView(APIView):
             'userToken': request.user.id,
         }
         finalist_programs = _get_finalist_program_role_grants(
-            request.user).values_list('program_role__program__name', flat=True)
+            request.user).values_list('program_role__program__id', flat=True)
         if filters:
             params['filters'] = filters
         public_key = _get_public_key(params, search_key)


### PR DESCRIPTION
## [AC-8011](https://masschallenge.atlassian.net/browse/AC-8011)

**Changes introduced**
- Filter mentors by office hours availability by program id instead of a program name

**Testing**
- Check out `AC-8011` on the `front end` and `accelerate` and `impact-api`
- on the `front end` repo, add the following env to your .env
```
BULLET_TRAIN_DEV='BULLET_TRAIN_DEV key here' reach out to @shanbady or @tg for access to bulletrain
NODE_ENV=development
```
- on accelerate: `$ make run-all-servers`
- on the front-end app: `$ yarn start`
- Using the staging_db(I've Indexed mentor profile on algolia using staging_db), visit http://localhost:1234/directory/ 
- Confirm that:
  - The mentor directory is filterable by mentors who have available office hours
  - Available office hours are defined as
     - Not reserved
     - Belonging to a mentor who is confirmed in the same program as the user who is querying the directory
     - Office hours are in the future
- Available office hours selection filter is hidden when there are no upcoming office hours available for the querying user 

[Front-end PR](https://github.com/masschallenge/front-end/pull/250)
[Accelerate PR](https://github.com/masschallenge/accelerate/pull/2718)