### PR TITLE
[AC-8010]: Remove legacy program picker code

### DIFF
--- a/web/impact/impact/tests/test_cancel_office_hour_session_view.py
+++ b/web/impact/impact/tests/test_cancel_office_hour_session_view.py
@@ -12,7 +12,6 @@ from ..permissions.v1_api_permissions import (
 from ..tests.api_test_case import APITestCase
 from ..tests.factories import MentorProgramOfficeHourFactory
 from ..v1.views.cancel_office_hour_session_view import (
-    DEFAULT_TIMEZONE,
     FAIL_HEADER,
     OFFICE_HOUR_SESSION_404,
     MENTOR_NOTIFICATION,
@@ -22,6 +21,7 @@ from ..v1.views.cancel_office_hour_session_view import (
     CancelOfficeHourSessionView,
 )
 from ..v1.views.utils import get_timezone
+
 
 class TestCancelOfficeHourSession(APITestCase):
     fail_header = FAIL_HEADER

--- a/web/impact/impact/tests/test_office_hours_calendar_view.py
+++ b/web/impact/impact/tests/test_office_hours_calendar_view.py
@@ -350,7 +350,6 @@ class TestOfficeHoursCalendarView(APITestCase):
             startup_team_member.startup.short_pitch,
             response.data['calendar_data'][0]['startup_short_pitch'])
 
-
     def create_office_hour(self,
                            mentor=None,
                            finalist=None,

--- a/web/impact/impact/v1/helpers/mentor_program_office_hour_helper.py
+++ b/web/impact/impact/v1/helpers/mentor_program_office_hour_helper.py
@@ -29,7 +29,6 @@ OFFFICE_HOUR_FIELDS = {
     "street_address": OPTIONAL_STRING_FIELD,
     "city": OPTIONAL_STRING_FIELD,
     "state": OPTIONAL_STRING_FIELD,
-    "program_family": OPTIONAL_STRING_FIELD,
 }
 
 
@@ -43,11 +42,6 @@ class MentorProgramOfficeHourHelper(ModelHelper):
     @property
     def title(self):
         return str(self.subject)
-
-    @property
-    def program_family(self):
-        program = self.subject.program
-        return program.program_family.name if program else ''
 
     @property
     def location(self):


### PR DESCRIPTION
**Changes introduced in [AC-8010](https://masschallenge.atlassian.net/browse/AC-8010)**
Removed the program_family attribute from office hours

Test instructions found in the [sibling PR](https://github.com/masschallenge/front-end/pull/251) in the frontend