### PR TITLE
[AC-8072] Finalists and staff should see staff-created office hour sessions

### DIFF
--- a/web/impact/impact/tests/test_office_hours_calendar_view.py
+++ b/web/impact/impact/tests/test_office_hours_calendar_view.py
@@ -134,7 +134,7 @@ class TestOfficeHoursCalendarView(APITestCase):
         office_hour = self.create_office_hour(mentor=staff_mentor)
         response = self.get_response(user=staff_user)
         self.assert_hour_in_response(response, office_hour)
-        
+
     def test_staff_sees_current_open_hours_for_their_program(self):
         program = ProgramFactory()
         staff_user = self.staff_user(program_family=program.program_family)
@@ -365,7 +365,6 @@ class TestOfficeHoursCalendarView(APITestCase):
         self.assertEqual(
             startup_team_member.startup.short_pitch,
             response.data['calendar_data'][0]['startup_short_pitch'])
-
 
     def create_office_hour(self,
                            mentor=None,

--- a/web/impact/impact/tests/test_office_hours_calendar_view.py
+++ b/web/impact/impact/tests/test_office_hours_calendar_view.py
@@ -119,6 +119,14 @@ class TestOfficeHoursCalendarView(APITestCase):
         response = self.get_response(user=finalist)
         self.assert_hour_not_in_response(response, office_hour)
 
+    def test_current_finalist_sees_staff_hours(self):
+        program = ProgramFactory()
+        finalist = _finalist(program=program)
+        staff_user = self.staff_user(program_family=program.program_family)
+        office_hour = self.create_office_hour(mentor=staff_user)
+        response = self.get_response(user=finalist)
+        self.assert_hour_in_response(response, office_hour)
+        
     def test_staff_sees_current_open_hours_for_their_program(self):
         program = ProgramFactory()
         staff_user = self.staff_user(program_family=program.program_family)

--- a/web/impact/impact/tests/test_office_hours_calendar_view.py
+++ b/web/impact/impact/tests/test_office_hours_calendar_view.py
@@ -126,6 +126,14 @@ class TestOfficeHoursCalendarView(APITestCase):
         office_hour = self.create_office_hour(mentor=staff_user)
         response = self.get_response(user=finalist)
         self.assert_hour_in_response(response, office_hour)
+
+    def test_staff_user_sees_staff_hours(self):
+        program = ProgramFactory()
+        staff_user = self.staff_user(program_family=program.program_family)
+        staff_mentor = self.staff_user(program_family=program.program_family)
+        office_hour = self.create_office_hour(mentor=staff_mentor)
+        response = self.get_response(user=staff_user)
+        self.assert_hour_in_response(response, office_hour)
         
     def test_staff_sees_current_open_hours_for_their_program(self):
         program = ProgramFactory()

--- a/web/impact/impact/v1/views/office_hours_calendar_view.py
+++ b/web/impact/impact/v1/views/office_hours_calendar_view.py
@@ -361,8 +361,8 @@ def _relevant_staff(user_programs):
     program_families = ProgramFamily.objects.filter(programs__in=user_programs)
     staff_ids = Clearance.objects.filter(
         program_family_id__in=program_families).values_list(
-            "user_id", flat=True)
-    return Q(**compose_filter(("mentor",
-                               "id",
-                               "in"),
+            'user_id', flat=True)
+    return Q(**compose_filter(('mentor',
+                               'id',
+                               'in'),
                               staff_ids))

--- a/web/impact/impact/v1/views/office_hours_calendar_view.py
+++ b/web/impact/impact/v1/views/office_hours_calendar_view.py
@@ -185,7 +185,8 @@ class OfficeHoursCalendarView(ImpactView):
                                                "in"),
                                               user_programs))
         return MentorProgramOfficeHour.objects.filter(
-            reserved_by_user | unreserved & (relevant_mentors|relevant_staff),
+            (reserved_by_user |
+             unreserved & (relevant_mentors | relevant_staff)),
             start_date_time__range=[self.start_date, self.end_date]).annotate(
                 own_office_hour=Case(
                     default=Value(False),
@@ -355,13 +356,13 @@ def _is_finalist(user):
     return user.programrolegrant_set.filter(
         ACTIVE_PROGRAM & OFFICE_HOURS_RESERVER).exists()
 
+
 def _relevant_staff(user_programs):
     program_families = ProgramFamily.objects.filter(programs__in=user_programs)
-
-    staff_ids = Clearance.objects.filter(program_family_id__in=program_families).values_list(
-        "user_id", flat=True)
+    staff_ids = Clearance.objects.filter(
+        program_family_id__in=program_families).values_list(
+            "user_id", flat=True)
     return Q(**compose_filter(("mentor",
                                "id",
                                "in"),
                               staff_ids))
-


### PR DESCRIPTION
https://masschallenge.atlassian.net/browse/AC-8072

Definition of fixed: office hour sessions created by staff (without mentor role grants) should be visible to finalists and staff when viewing /newofficehours