### PR TITLE
[AC-8037] Update directory office hours calendar picker

### DIFF
--- a/web/impact/impact/tests/test_office_hours_calendar_view.py
+++ b/web/impact/impact/tests/test_office_hours_calendar_view.py
@@ -46,18 +46,18 @@ from .utils import nonexistent_object_id
 class TestOfficeHoursCalendarView(APITestCase):
     view = OfficeHoursCalendarView
 
-    def test_no_focal_dateified_sees_current_week(self):
+    def test_no_focal_date_specified_sees_current_week(self):
         office_hour = self.create_office_hour()
         response = self.get_response(user=office_hour.mentor)
         self.assert_hour_in_response(response, office_hour)
 
-    def test_no_focal_dateified_does_not_see_last_week(self):
+    def test_no_focal_date_specified_does_not_see_last_week(self):
         office_hour = self.create_office_hour(
             start_date_time=days_from_now(-9))
         response = self.get_response(user=office_hour.mentor)
         self.assert_hour_not_in_response(response, office_hour)
 
-    def test_focal_dateified_sees_sessions_in_range(self):
+    def test_focal_date_specified_sees_sessions_in_range(self):
         two_weeks_ago = days_from_now(-14)
         focal_date = two_weeks_ago.strftime(ISO_8601_DATE_FORMAT)
         office_hour = self.create_office_hour(
@@ -67,30 +67,16 @@ class TestOfficeHoursCalendarView(APITestCase):
         self.assert_hour_in_response(response, office_hour)
 
     def test_calendar_data_for_month_span_last_day_of_the_month(self):
-        today = datetime.now()
-        days_in_month = calendar.monthrange(today.year, today.month)[1]
-        days_to_month_end = days_in_month - int(today.strftime("%d"))
-        month_end = days_from_now(days_to_month_end)
-        office_hour = self.create_office_hour(start_date_time=month_end)
-        focal_date = today.strftime(ISO_8601_DATE_FORMAT)
+        last_month = days_from_now(-40)
+        last_month_end = days_from_now(-31)
+        office_hour = self.create_office_hour(start_date_time=last_month_end)
+        focal_date = last_month.strftime(ISO_8601_DATE_FORMAT)
         response = self.get_response(user=office_hour.mentor,
                                      focal_date=focal_date,
                                      calendar_span="month")
         self.assert_hour_in_response(response, office_hour)
 
-    def test_calendar_data_for_month_span_mid_month(self):
-        today = datetime.now()
-        days_in_month = calendar.monthrange(today.year, today.month)[1]
-        days_to_mid_month = (days_in_month - int(today.strftime("%d"))) / 2
-        mid_month = days_from_now(days_to_mid_month)
-        office_hour = self.create_office_hour(start_date_time=mid_month)
-        focal_date = today.strftime(ISO_8601_DATE_FORMAT)
-        response = self.get_response(user=office_hour.mentor,
-                                     focal_date=focal_date,
-                                     calendar_span="month")
-        self.assert_hour_in_response(response, office_hour)
-
-    def test_focal_dateified_does_not_see_sessions_not_in_range(self):
+    def test_focal_date_specified_does_not_see_sessions_not_in_range(self):
         two_weeks_ago = days_from_now(-14)
         focal_date = two_weeks_ago.strftime(ISO_8601_DATE_FORMAT)
         office_hour = self.create_office_hour()

--- a/web/impact/impact/tests/test_office_hours_calendar_view.py
+++ b/web/impact/impact/tests/test_office_hours_calendar_view.py
@@ -65,7 +65,7 @@ class TestOfficeHoursCalendarView(APITestCase):
                                      focal_date=focal_date)
         self.assert_hour_in_response(response, office_hour)
 
-    def test_calendar_data_for_monthly_span_last_day_of_the_month(self):
+    def test_calendar_data_for_month_span_last_day_of_the_month(self):
         today = datetime.now()
         days_in_month = calendar.monthrange(today.year, today.month)[1]
         days_to_month_end = days_in_month - int(today.strftime("%d"))
@@ -74,10 +74,10 @@ class TestOfficeHoursCalendarView(APITestCase):
         focal_date = today.strftime(ISO_8601_DATE_FORMAT)
         response = self.get_response(user=office_hour.mentor,
                                      focal_date=focal_date,
-                                     calendar_span="monthly")
+                                     calendar_span="month")
         self.assert_hour_in_response(response, office_hour)
 
-    def test_calendar_data_for_monthly_span_mid_month(self):
+    def test_calendar_data_for_month_span_mid_month(self):
         today = datetime.now()
         days_in_month = calendar.monthrange(today.year, today.month)[1]
         days_to_mid_month = (days_in_month - int(today.strftime("%d"))) / 2
@@ -86,7 +86,7 @@ class TestOfficeHoursCalendarView(APITestCase):
         focal_date = today.strftime(ISO_8601_DATE_FORMAT)
         response = self.get_response(user=office_hour.mentor,
                                      focal_date=focal_date,
-                                     calendar_span="monthly")
+                                     calendar_span="month")
         self.assert_hour_in_response(response, office_hour)
 
     def test_focal_dateified_does_not_see_sessions_not_in_range(self):

--- a/web/impact/impact/tests/test_office_hours_calendar_view.py
+++ b/web/impact/impact/tests/test_office_hours_calendar_view.py
@@ -202,14 +202,6 @@ class TestOfficeHoursCalendarView(APITestCase):
         response = self.get_response(staff_user)
         self.assert_hour_not_in_response(response, office_hour)
 
-    def test_non_staff_cannot_view_on_behalf_of(self):
-        user = self.basic_user()
-        finalist = _finalist()
-        response = self.get_response(user=user,
-                                     target_user_id=finalist.id)
-        self.assert_failure(response,
-                            DEFAULT_PERMISSION_DENIED_DETAIL)
-
     def test_mentor_with_no_hours_in_range_sees_empty_response(self):
         two_weeks_ago = days_from_now(-14)
         session = self.create_office_hour(start_date_time=two_weeks_ago)

--- a/web/impact/impact/tests/test_office_hours_calendar_view.py
+++ b/web/impact/impact/tests/test_office_hours_calendar_view.py
@@ -91,16 +91,20 @@ class TestOfficeHoursCalendarView(APITestCase):
         self.assert_hour_in_response(response, office_hour)
 
     def test_return_upcoming_calendar_data(self):
-        two_weeks_ago = days_from_now(-14)
-        focal_date = two_weeks_ago.strftime(ISO_8601_DATE_FORMAT)
-        office_hour = self.create_office_hour(
-            start_date_time=two_weeks_ago,
-            finalist=UserFactory())
-        office_hour1 = self.create_office_hour(start_date_time=two_weeks_ago)
-        response = self.get_response(user=office_hour1.mentor,
-                                     focal_date=focal_date,
+        today = datetime.now()
+        days_in_month = calendar.monthrange(today.year, today.month)[1]
+        days_to_mid_month = (days_in_month - int(today.strftime("%d"))) / 2
+        mid_month = days_from_now(days_to_mid_month)
+        office_hour = self.create_office_hour(start_date_time=mid_month,
+                                              finalist=UserFactory())
+        office_hour1 = self.create_office_hour(start_date_time=mid_month)
+        response = self.get_response(calendar_span="month",
+                                     user=office_hour1.mentor,
                                      upcoming=True)
-        self.assert_hour_not_in_response(response, office_hour)
+        response1 = self.get_response(calendar_span="month",
+                                     user=office_hour.mentor,
+                                     upcoming=True)
+        self.assert_hour_not_in_response(response1, office_hour)
         self.assert_hour_in_response(response, office_hour1)
 
     def test_focal_dateified_does_not_see_sessions_not_in_range(self):

--- a/web/impact/impact/tests/test_office_hours_calendar_view.py
+++ b/web/impact/impact/tests/test_office_hours_calendar_view.py
@@ -67,10 +67,20 @@ class TestOfficeHoursCalendarView(APITestCase):
         self.assert_hour_in_response(response, office_hour)
 
     def test_calendar_data_for_month_span_last_day_of_the_month(self):
-        last_month = days_from_now(-40)
-        last_month_end = days_from_now(-31)
-        office_hour = self.create_office_hour(start_date_time=last_month_end)
-        focal_date = last_month.strftime(ISO_8601_DATE_FORMAT)
+        end_of_month = datetime(2020,1,31,5,0,0)
+        focal_day  = datetime(2020,1,3,5,0,0)
+        office_hour = self.create_office_hour(start_date_time=end_of_month)
+        focal_date = focal_day.strftime(ISO_8601_DATE_FORMAT)
+        response = self.get_response(user=office_hour.mentor,
+                                     focal_date=focal_date,
+                                     calendar_span="month")
+        self.assert_hour_in_response(response, office_hour)
+
+    def test_calendar_data_for_month_span_mid_month(self):
+        end_of_month = datetime(2020,1,31,5,0,0)
+        mid_month = datetime(2020,1,15,5,0,0)
+        office_hour = self.create_office_hour(start_date_time=mid_month)
+        focal_date = end_of_month.strftime(ISO_8601_DATE_FORMAT)
         response = self.get_response(user=office_hour.mentor,
                                      focal_date=focal_date,
                                      calendar_span="month")

--- a/web/impact/impact/tests/test_office_hours_calendar_view.py
+++ b/web/impact/impact/tests/test_office_hours_calendar_view.py
@@ -90,23 +90,6 @@ class TestOfficeHoursCalendarView(APITestCase):
                                      calendar_span="month")
         self.assert_hour_in_response(response, office_hour)
 
-    def test_return_upcoming_calendar_data(self):
-        today = datetime.now()
-        days_in_month = calendar.monthrange(today.year, today.month)[1]
-        days_to_mid_month = (days_in_month - int(today.strftime("%d"))) / 2
-        mid_month = days_from_now(days_to_mid_month)
-        office_hour = self.create_office_hour(start_date_time=mid_month,
-                                              finalist=UserFactory())
-        office_hour1 = self.create_office_hour(start_date_time=mid_month)
-        response = self.get_response(calendar_span="month",
-                                     user=office_hour1.mentor,
-                                     upcoming=True)
-        response1 = self.get_response(calendar_span="month",
-                                     user=office_hour.mentor,
-                                     upcoming=True)
-        self.assert_hour_not_in_response(response1, office_hour)
-        self.assert_hour_in_response(response, office_hour1)
-
     def test_focal_dateified_does_not_see_sessions_not_in_range(self):
         two_weeks_ago = days_from_now(-14)
         focal_date = two_weeks_ago.strftime(ISO_8601_DATE_FORMAT)

--- a/web/impact/impact/v1/views/office_hours_calendar_view.py
+++ b/web/impact/impact/v1/views/office_hours_calendar_view.py
@@ -35,12 +35,11 @@ from accelerator.models import (
 from accelerator_abstract.models.base_user_utils import is_employee
 User = get_user_model()
 
-today = datetime.today()
-DAYS_IN_MONTH = calendar.monthrange(today.year, today.month)[1]
+
 ISO_8601_DATE_FORMAT = "%Y-%m-%d"
 ONE_DAY = timedelta(1)
 ONE_WEEK = timedelta(8)
-ONE_MONTH = timedelta(DAYS_IN_MONTH)
+
 
 
 STAFF = "staff"
@@ -120,7 +119,7 @@ class OfficeHoursCalendarView(ImpactView):
 
     def _get_date_range(self, request):
         focal_date = request.query_params.get("focal_date", None)
-        calendar_span = request.query_params.get("calendar_span", "weekly")
+        calendar_span = request.query_params.get("calendar_span", "week")
 
         try:
             self.start_date, self.end_date = _date_range(calendar_span, focal_date)
@@ -343,12 +342,14 @@ def _date_range(calendar_span, focal_date=None):
     else:
         initial_date = datetime.now()
     initial_date = utc.localize(initial_date)
-    # This calculation depends on the fact that monday == 0 in python
-    if calendar_span == "monthly":
+    if calendar_span == "month":
         start_date = initial_date - timedelta(int(initial_date.strftime("%d")))
-        end_date = start_date + ONE_MONTH + ONE_DAY
+        days_in_month = calendar.monthrange(start_date.year, start_date.month)[1]
+        one_month = timedelta(days_in_month)
+        end_date = start_date + one_month + ONE_DAY
         adjusted_start_date = start_date + ONE_DAY
     else:
+        # This calculation depends on the fact that monday == 0 in python
         start_date = initial_date - timedelta(initial_date.weekday())
         end_date = start_date + ONE_WEEK + ONE_DAY
         adjusted_start_date = start_date - ONE_DAY

--- a/web/impact/impact/v1/views/office_hours_calendar_view.py
+++ b/web/impact/impact/v1/views/office_hours_calendar_view.py
@@ -22,7 +22,6 @@ from django.db.models import (
 from . import ImpactView
 from ...utils import compose_filter
 from ...permissions.v1_api_permissions import (
-    DEFAULT_PERMISSION_DENIED_DETAIL,
     IsAuthenticated,
 )
 from accelerator.models import (
@@ -95,12 +94,6 @@ class OfficeHoursCalendarView(ImpactView):
             except User.DoesNotExist:
                 self.fail(self.NO_SUCH_USER)
                 return False
-
-            if not is_employee(request.user):
-                if self.target_user != request.user:
-                    # non-staff may not view on behalf of another user
-                    self.fail(DEFAULT_PERMISSION_DENIED_DETAIL)
-                    return False
         return True
 
     def _check_request_user_type(self):

--- a/web/impact/impact/v1/views/office_hours_calendar_view.py
+++ b/web/impact/impact/v1/views/office_hours_calendar_view.py
@@ -328,16 +328,13 @@ def _make_f_expression(field, location_path):
 
 def _date_range(calendar_span, focal_date=None):
     # returns (start_date, end_date)
-    # When calendar_span == week and upcoming == False
+    # When calendar_span == week
     # start_date is the latest monday that is less than or equal to today,
     # end_date is start_date + seven days
-    # When calendar_span == month and upcoming == False
+    # When calendar_span == month 
     # start_date is the first day of the new month
     # end_date is start_date + length of the current month
     # both values are then padded by 24 hours to allow for TZ differences
-    # when upcoming == True
-    # start_date is the current date period
-
     # throws ValueError if focal_date is not in ISO-8601 format
 
     if focal_date:
@@ -347,15 +344,15 @@ def _date_range(calendar_span, focal_date=None):
 
     initial_date = utc.localize(initial_date)
     if calendar_span == "month":
-        start_date = initial_date - timedelta(int(initial_date.strftime("%d")))
-        days_in_month = calendar.monthrange(start_date.year, start_date.month)[1]
-        one_month = timedelta(days_in_month + 1)
-        end_date = start_date + one_month + ONE_DAY
+        reducer = timedelta(int(initial_date.strftime("%d")))
+        span = timedelta(31)
     else:
         # This calculation depends on the fact that monday == 0 in python
-        start_date = initial_date - timedelta(initial_date.weekday())
-        end_date = start_date + ONE_WEEK + ONE_DAY
-  
+        reducer = timedelta(initial_date.weekday())
+        span = ONE_WEEK
+
+    start_date = initial_date - reducer
+    end_date = start_date + span + ONE_DAY
     adjusted_start_date = start_date - ONE_DAY
     return adjusted_start_date, end_date
 

--- a/web/impact/impact/v1/views/office_hours_calendar_view.py
+++ b/web/impact/impact/v1/views/office_hours_calendar_view.py
@@ -351,12 +351,11 @@ def _date_range(calendar_span, focal_date=None):
         days_in_month = calendar.monthrange(start_date.year, start_date.month)[1]
         one_month = timedelta(days_in_month)
         end_date = start_date + one_month + ONE_DAY
-        adjusted_start_date = start_date + ONE_DAY
     else:
         # This calculation depends on the fact that monday == 0 in python
         start_date = initial_date - timedelta(initial_date.weekday())
         end_date = start_date + ONE_WEEK + ONE_DAY
-        adjusted_start_date = start_date - ONE_DAY
+    adjusted_start_date = start_date - ONE_DAY
     return adjusted_start_date, end_date
 
 


### PR DESCRIPTION
## [AC-8037](https://masschallenge.atlassian.net/browse/AC-8037)

**Changes introduced**
- allow consumers of `/api/v1/office_hours_calendar/` to pass `calendar_span` argument that specify the length of data to return
- change the request argument `date_spec` to `focal_date`

**Testing**
- See sibling PRs

### [Sibling 1](https://github.com/masschallenge/front-end/pull/253)
### [Sibling 2](https://github.com/masschallenge/accelerate/pull/2742)