### PR TITLE
AC-8187 - Fix failing Office Hours test on AC-7469

### DIFF
--- a/web/impact/impact/tests/test_office_hours_calendar_view.py
+++ b/web/impact/impact/tests/test_office_hours_calendar_view.py
@@ -129,7 +129,7 @@ class TestOfficeHoursCalendarView(APITestCase):
     def test_staff_user_sees_staff_hours(self):
         program = ProgramFactory()
         staff_user = self.staff_user(program_family=program.program_family)
-        staff_mentor = self.staff_user(program_family=program.program_family)
+        staff_mentor = _mentor(user=self.staff_user(), program=program)
         office_hour = self.create_office_hour(mentor=staff_mentor)
         response = self.get_response(user=staff_user)
         self.assert_hour_in_response(response, office_hour)


### PR DESCRIPTION
## [AC-8187](https://masschallenge.atlassian.net/browse/AC-8187)

**Review suggestions:**
* Confirm that the test named in the ticket (`test_staff_user_sees_staff_hours`) now passes
* Check that the logic of the changed test still upholds the intended purpose of the test