### PR TITLE
AC-8246 re-ordering url includes

### DIFF
--- a/web/impact/impact/urls.py
+++ b/web/impact/impact/urls.py
@@ -66,10 +66,25 @@ urlpatterns = [
     url(r'^$', IndexView.as_view()),
     url(r'^v0/', include(v0_urlpatterns)),
     url(r'^v1/', include(v1_urlpatterns)),
+    url(r'^oauth/', include('oauth2_provider.urls',
+        namespace='oauth2_provider')),
     url(r'^(?P<app>\w+)/(?P<model>[a-z_]+)/'
         r'(?P<related_model>[a-z_]+)/$',
         GeneralViewSet.as_view({'get': 'list', 'post': 'create'}),
         name='related-object-list'),
+    url(r'^graphql/$',
+        csrf_exempt(SafeGraphQLView.as_view(
+            graphiql=settings.DEBUG,
+            schema=schema,
+            middleware=[
+                IsAuthenticatedMiddleware])),
+        name="graphql"),
+    url(r'^graphql/auth/$',
+        csrf_exempt(SafeGraphQLView.as_view(
+            graphiql=settings.DEBUG,
+            schema=auth_schema)),
+        name="graphql-auth"),
+    url(r'^sso/', include(sso_urlpatterns)),
     url(r'^(?P<app>\w+)/(?P<model>[a-z_]+)/'
         r'(?P<related_model>[a-z_]+)/'
         r'(?P<pk>[0-9]+)/$',
@@ -94,20 +109,5 @@ urlpatterns = [
     url(r'^simpleuser/', include(simpleuser_router.urls)),
     url(r'^mc/', include(schema_router.urls),
         name='api-root'),
-    url(r'^sso/', include(sso_urlpatterns)),
-    url(r'^graphql/$',
-        csrf_exempt(SafeGraphQLView.as_view(
-            graphiql=settings.DEBUG,
-            schema=schema,
-            middleware=[
-                IsAuthenticatedMiddleware])),
-        name="graphql"),
-    url(r'^graphql/auth/$',
-        csrf_exempt(SafeGraphQLView.as_view(
-            graphiql=settings.DEBUG,
-            schema=auth_schema)),
-        name="graphql-auth"),
-    url(r'^oauth/', include('oauth2_provider.urls',
-        namespace='oauth2_provider')),
     url(r'^schema/$', schema_view, name='schema'),
 ]


### PR DESCRIPTION
This PR fixes a url resolution error in the monolith api.

To test:

1- visit the endpoint on the latest release with monolith code (https://staging.masschallenge.org/api/oauth/token/) - note that it fails with a 500
2 - I have this deployed to test3 currently. visit the test3 version (https://test3.masschallenge.org/api/oauth/token/) and note that it responds with a 405 (expected response for that route) which indicates the url is resolving properly. 
3 - similarly the graphql endpoint gives a 404 on staging (https://staging.masschallenge.org/api/graphql/) but will give an appropriate response on test3 (https://test3.masschallenge.org/api/graphql/)