### PR TITLE
[AC-8498] User History API endpoint should not crash if user startup has no Organization

### DIFF
--- a/web/impact/impact/tests/test_user_history_view.py
+++ b/web/impact/impact/tests/test_user_history_view.py
@@ -71,11 +71,11 @@ class TestUserHistoryView(APITestCase):
                 name=startup.name,
                 id=startup.organization.id)
             self.assertEqual(startup_str, events[0]["description"])
-            
+
     def test_user_joined_startup_tolerates_null_organization(self):
         # Startup.organization should not be null, but if it is the
         # endpoint should not throw an error
-        
+
         startup = StartupFactory(organization=None)
         stm = StartupTeamMemberFactory(startup=startup)
         with self.login(email=self.basic_user().email):
@@ -86,7 +86,7 @@ class TestUserHistoryView(APITestCase):
             startup = stm.startup
             startup_str = UserJoinedStartupEvent.NO_ORGANIZATION_DESCRIPTION
             self.assertEqual(startup_str, events[0]["description"])
-            
+
     # signal muting is necessary when running impact tests in accelerate
     # since we ported this test from impact api where we dont expect
     # recievers in accelerate's receivers.py to run.
@@ -341,4 +341,3 @@ class TestUserHistoryView(APITestCase):
             schema = options_response.data["actions"]["GET"]
             validator = Draft4Validator(schema)
             assert validator.is_valid(json.loads(get_response.content))
-

--- a/web/impact/impact/tests/test_user_history_view.py
+++ b/web/impact/impact/tests/test_user_history_view.py
@@ -49,21 +49,43 @@ class TestUserHistoryView(APITestCase):
             self.assertEqual(1, len(events))
             self.assertEqual(user.date_joined, events[0]["datetime"])
 
-    def test_user_joined_startup(self):
+    def test_user_joined_startup_created_at(self):
         stm = StartupTeamMemberFactory()
         with self.login(email=self.basic_user().email):
             url = reverse(UserHistoryView.view_name, args=[stm.user.id])
             response = self.client.get(url)
             events = find_events(response.data["results"],
                                  UserJoinedStartupEvent.EVENT_TYPE)
-            self.assertEqual(1, len(events))
             self.assertEqual(stm.created_at, events[0]["datetime"])
+
+    def test_user_joined_startup_description(self):
+        stm = StartupTeamMemberFactory()
+        with self.login(email=self.basic_user().email):
+            url = reverse(UserHistoryView.view_name, args=[stm.user.id])
+            response = self.client.get(url)
+            events = find_events(response.data["results"],
+                                 UserJoinedStartupEvent.EVENT_TYPE)
             startup = stm.startup
             startup_str = UserJoinedStartupEvent.DESCRIPTION_FORMAT.format(
                 name=startup.name,
                 id=startup.organization.id)
             self.assertEqual(startup_str, events[0]["description"])
-
+            
+    def test_user_joined_startup_tolerates_null_organization(self):
+        # Startup.organization should not be null, but if it is the
+        # endpoint should not throw an error
+        
+        stm = StartupTeamMemberFactory()
+        stm.startup.organization.delete()
+        with self.login(email=self.basic_user().email):
+            url = reverse(UserHistoryView.view_name, args=[stm.user.id])
+            response = self.client.get(url)
+            events = find_events(response.data["results"],
+                                 UserJoinedStartupEvent.EVENT_TYPE)
+            startup = stm.startup
+            startup_str = UserJoinedStartupEvent.NO_ORGANIZATION_DESCRIPTION
+            self.assertEqual(startup_str, events[0]["description"])
+            
     # signal muting is necessary when running impact tests in accelerate
     # since we ported this test from impact api where we dont expect
     # recievers in accelerate's receivers.py to run.
@@ -318,3 +340,4 @@ class TestUserHistoryView(APITestCase):
             schema = options_response.data["actions"]["GET"]
             validator = Draft4Validator(schema)
             assert validator.is_valid(json.loads(get_response.content))
+

--- a/web/impact/impact/tests/test_user_history_view.py
+++ b/web/impact/impact/tests/test_user_history_view.py
@@ -15,6 +15,7 @@ from .factories import (
     NewsletterReceiptFactory,
     ProgramCycleFactory,
     ProgramRoleGrantFactory,
+    StartupFactory,
     StartupTeamMemberFactory,
     UserFactory,
 )
@@ -75,8 +76,8 @@ class TestUserHistoryView(APITestCase):
         # Startup.organization should not be null, but if it is the
         # endpoint should not throw an error
         
-        stm = StartupTeamMemberFactory()
-        stm.startup.organization.delete()
+        startup = StartupFactory(organization=None)
+        stm = StartupTeamMemberFactory(startup=startup)
         with self.login(email=self.basic_user().email):
             url = reverse(UserHistoryView.view_name, args=[stm.user.id])
             response = self.client.get(url)

--- a/web/impact/impact/v1/events/user_joined_startup_event.py
+++ b/web/impact/impact/v1/events/user_joined_startup_event.py
@@ -15,7 +15,7 @@ class UserJoinedStartupEvent(BaseHistoryEvent):
     DESCRIPTION_FORMAT = "Joined {name} ({id})"
     EVENT_TYPE = "joined startup"
     NO_ORGANIZATION_DESCRIPTION = "Joined startup (organization unknown)"
-    
+
     def __init__(self, member):
         super().__init__()
         self.member = member

--- a/web/impact/impact/v1/events/user_joined_startup_event.py
+++ b/web/impact/impact/v1/events/user_joined_startup_event.py
@@ -14,7 +14,8 @@ User = get_user_model()
 class UserJoinedStartupEvent(BaseHistoryEvent):
     DESCRIPTION_FORMAT = "Joined {name} ({id})"
     EVENT_TYPE = "joined startup"
-
+    NO_ORGANIZATION_DESCRIPTION = "Joined startup (organization unknown)"
+    
     def __init__(self, member):
         super().__init__()
         self.member = member

--- a/web/impact/impact/v1/events/user_joined_startup_event.py
+++ b/web/impact/impact/v1/events/user_joined_startup_event.py
@@ -21,9 +21,13 @@ class UserJoinedStartupEvent(BaseHistoryEvent):
         self.member = member
 
     def description(self):
-        return self.DESCRIPTION_FORMAT.format(
-            name=self.member.startup.name,
-            id=self.member.startup.organization.id)
+        startup = self.member.startup
+        if startup.organization is None:
+            return self.NO_ORGANIZATION_DESCRIPTION
+        else:
+            return self.DESCRIPTION_FORMAT.format(
+                name=startup.name,
+                id=startup.organization.id)
 
     @classmethod
     def events(cls, user):


### PR DESCRIPTION
https://masschallenge.atlassian.net/browse/AC-8498

To test: 
- verify that the user history endpoint (/api/v1/user/[user_id]/history/) does not throw an error if the user is associated with a startup whose organization is null. 